### PR TITLE
fix: correct typo 'Swith Pro' to 'Switch Pro' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Similarly you can hold all 4 back buttons and press Y to switch (teehee) over to
 | back-4 + A | Steam | Steam Controller Mode |
 | back-4 + B | Lizard | Lizard mode, even if Steam is open |
 | back-4 + X | Xbox | Xbox 360 Controller |
-| back-4 + Y | Swith Pro | Switch Controller + Gyro + Haptics |
+| back-4 + Y | Switch Pro | Switch Controller + Gyro + Haptics |
 | WebUSB panel → mode 4 | Hori Pad | Switch mode with no gyro or haptics |
 | WebUSB panel → mode 5 | DualSense + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 6 | DS4/HIDGYRO + Gyro + Trackpad | PC only |


### PR DESCRIPTION
Fixes a typo in the mode-switching button combo table where 'Swith Pro' was incorrectly spelled instead of 'Switch Pro'. Closes #103.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._