### PR TITLE
Add documentation for WebUSB on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Switching slots requires turning the controller off (Steam + Y if steam is runni
 # Configuration
 A webusb based configuration UI is available [here](https://safijari.github.io/openpuck/). It allows Switching the mode manually and changing the back button mapping for other modes among other things. This will likely only work in Chrome and Edge and needs the pro micro to be connected via USB to the same computer for it to function. Note that it might not work in all modes on all machines but should always work in the Steam Controller mode (which you can revert to with back-4 + A).
 
+If you're running Linux and your browser still shows "disconnected" after selecting the OpenPuck in the device selector, it's probably a permissions issue. Check [this document](./docs/WEBUSB_LINUX.md) for more details. 
+
 # 3D Printed Cases
 - [jaki-gh](https://github.com/jaki-gh) has contributed a 3D printable housing with OpenPuck written on it alongside a Steam logo. You can find that [here](https://www.thingiverse.com/thing:7371668).
 - [StonnedModder](https://www.printables.com/model/1760684-openpuck-promicro-nrf52840-case) built a case meant to accomodate a USB C to USB A adapter which you can find [here](https://www.printables.com/model/1760684-openpuck-promicro-nrf52840-case).

--- a/docs/WEBUSB_LINUX.md
+++ b/docs/WEBUSB_LINUX.md
@@ -1,0 +1,25 @@
+# WebUSB on Linux
+
+By default, not every user is allowed to access raw USB devices like the OpenPuck. This can result in the configuration webpage showing "disconnected" after selecting the correct device. 
+
+You can check the error log by going to `chrome://device-log/`. (or `chromium://device-log`, `edge://device-log`, ... depending on your browser.)
+
+If it shows "Failed to open /dev/bus/usb/xxx/xxx: Operation not permitted", you need to follow these instructions to give the current user raw access to Valve hardware (vendor ID 28de).
+
+
+
+## Instructions
+
+As root, create the file `/etc/udev/rules.d/50-openpuck.rules` with the following content: 
+
+```
+SUBSYSTEM=="usb", ATTR{idVendor}=="28de", MODE="0664", GROUP="plugdev"
+```
+
+This ensures that all members of the `plugdev` group can access all Valve hardware directly. 
+
+Then, run `sudo usermod -a -G plugdev $USER` to make sure your user is a member of that group, and then run `sudo udevadm control --reload-rules` (or reboot your machine) to enable the new rule. 
+
+Only if you have chromium installed through Snap, you may also need to run `snap connect chromium:raw-usb` to give it direct USB access.
+
+Then just unplug and re-plug the OpenPuck and your browser should be able to connect to the OpenPuck while it's in Steam Controller mode.


### PR DESCRIPTION
As reported in #23 , I ran into the issue with the WebUSB config webpage not working. I was able to select the device and pair it, but the page always showed "disconnected". 

I finally figured out that it's a permissions issue related to which users and software can directly access USB devices. 

I added the steps necessary to fix the issue to a new document under docs/ in case anyone else also runs into this issue.