### PR TITLE
Fix slot issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,18 @@ FORMAT_FILES := $(shell find OpenPuck ReversePuckFirmware puck_sniffer pairtui \
 
 # --- firmware build ---------------------------------------------------------
 # The OpenPuck firmware needs two TinyUSB config values that differ from the Adafruit nRF52 core defaults:
-#   CFG_TUD_HID=4            -- four HID interfaces (Steam mode exposes four puck slots); core default is 2.
+#   CFG_TUD_HID=6            -- four HID interfaces (Steam mode exposes four puck slots) plus one for mouse 
+#								and one for WebUSB; core default is 2.
 #   CFG_TUD_TASK_QUEUE_SZ=64 -- deeper usbd event queue; the default 16 deadlocks the loop task under comms
 #                               load -> watchdog reset (see OpenPuck.ino + docs/BUILD_AND_DEPLOY.md).
 #   CFG_TUD_VENDOR_TX_BUFSIZE=256 -- the WebUSB status blob is ~118 B; the core default 64 can't hold it whole,
 #                               so the panel send (which drops rather than blocks when the FIFO is full) could
 #                               never fit a frame -> blank panel. Sized to hold a full blob with headroom.
 # They're baked in here so a normal build is just `make build` -- no need to remember the flags. Override any
-# on the command line, e.g.   make build CFG_TUD_HID=6 CFG_TUD_TASK_QUEUE_SZ=128
+# on the command line, e.g.   make build CFG_TUD_HID=8 CFG_TUD_TASK_QUEUE_SZ=128
 # or add your own defines:     make build EXTRA_FLAGS="-DOPK_LOG=1"
 FQBN ?= adafruit:nrf52:feather52840
-CFG_TUD_HID ?= 4
+CFG_TUD_HID ?= 6
 # Deep so a loop()-context sendReport never blocks on a full usbd event queue (the watchdog path). Sends run
 # from loop() now (usbTxPump) for stable RF timing, so this depth is what keeps that block from happening.
 CFG_TUD_TASK_QUEUE_SZ ?= 512

--- a/ReversePuck/scpair.py
+++ b/ReversePuck/scpair.py
@@ -25,6 +25,7 @@ import os
 import struct
 import sys
 import time
+from pathlib import Path
 
 # ---- Linux ioctl numbers for hidraw (asm-generic _IOC) ----
 _IOC_NONE, _IOC_WRITE, _IOC_READ = 0, 1, 2
@@ -163,6 +164,21 @@ def enumerate_devices():
         vid, pid, serial = _sysfs_ids(node)
         if vid != VALVE_VID:
             continue
+
+        # Check if this hidraw object is actually a puck slot, or if it's a OpenPuck Wake mouse or similar
+        dxi = node.replace('/dev/', '')
+        base = Path(f"/sys/class/hidraw/{dxi}/device")
+        iface_dir = base.resolve().parent
+
+        bInterfaceClass = int((iface_dir / "bInterfaceClass").read_text().strip(), 16)
+        bInterfaceSubClass = int((iface_dir / "bInterfaceSubClass").read_text().strip(), 16)
+        bInterfaceProtocol = int((iface_dir / "bInterfaceProtocol").read_text().strip(), 16)
+
+        # A real puck slot has these values:
+        if (bInterfaceClass != 3 or bInterfaceSubClass != 0 or bInterfaceProtocol != 0):
+            # If these don't match, this is not a Puck slot, but some other random HID interface.
+            continue
+
         try:
             dev = HidDev(node, vid, pid, serial)
         except PermissionError:


### PR DESCRIPTION
This seems to fix #126. 

The issue is that by default, the OpenPuck Wake mouse is enabled in Steam mode. This mouse uses a HID slot, but the Makefile was configured to only allow 4 HID slots. One was used by the mouse, leaving only three for Puck pairing slots, causing writes to one of the slots to fail. 

Steam knew the 1st slot was a mouse, not a puck slot, and didn't display it / refuse to write to it. 

scpair.py didn't know that, so it tried to write to the mouse's record, which obviously failed.
Increasing the allowed slot count to 6 fixes the issue, Steam now displays all four slots correctly.

scpair.py, however, did now start displaying 5 slots - one for the mouse, four for the puck slots. So I added some code to skip interfaces that aren't puck bonding slots.