### PR TITLE
Fix gyro of SC in switch mode being to sensitive

### DIFF
--- a/OpenPuck/mode_switch_pro.cpp
+++ b/OpenPuck/mode_switch_pro.cpp
@@ -531,6 +531,11 @@ static void switchProBuild(uint8_t slot, uint8_t out[63])
 	int16_t groll = gscale((int16_t)g_in[bond].gy);
 	int16_t gpitch = gscale((int16_t)(-(int16_t)g_in[bond].gx));
 	int16_t gyaw = gscale((int16_t)g_in[bond].gz);
+
+	// The physical yaw of the SC is making the roll (or yaw if facing to wall like on switch) move to fast in switch mode.
+	// Reducing it to 80% sensitivity. Using int32 to fix a possible overflow during the multiplication.
+	groll = (int16_t)(((int32_t)groll * 4) / 5);
+	
 	for (int k = 0; k < 3; k++) {
 		int o = 12 + k * 12;
 		out[o + 0] = aX & 0xFF;

--- a/OpenPuck/mode_switch_pro.cpp
+++ b/OpenPuck/mode_switch_pro.cpp
@@ -535,7 +535,11 @@ static void switchProBuild(uint8_t slot, uint8_t out[63])
 	// The physical yaw of the SC is making the roll (or yaw if facing to wall like on switch) move to fast in switch mode.
 	// Reducing it to 80% sensitivity. Using int32 to fix a possible overflow during the multiplication.
 	groll = (int16_t)(((int32_t)groll * 4) / 5);
-	
+
+	// Other sensors were also a little off. Reducing to 90% sensitivity matches Switch Pro Controller and Steam mode.
+	gpitch = (int16_t)(((int32_t)gpitch * 9) / 10);
+	gyaw = (int16_t)(((int32_t)gyaw * 9) / 10);
+
 	for (int k = 0; k < 3; k++) {
 		int o = 12 + k * 12;
 		out[o + 0] = aX & 0xFF;


### PR DESCRIPTION
The gyro axis' of the SC (Steam Controller) seem to be a little more sensitive as needed for the switch, making gyro movement faster than it should be.

Reduced the roll-sensor to 80%, yaw and pitch to 90% (not that much different)

I tested it first on switch in Splatoon 3 by switching around an original Switch Pro Controller and SC and later using the motion section on Dolphin Emulator on PC to compare the raw motion visualization.

Now the motion is the same as the Switch Pro Controller and the SC in Steam mode (at least to my eye).