### PR TITLE
chore(ci): bump actions to latest recommend - remove node v20 warnings in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -31,7 +31,7 @@ jobs:
         uses: arduino/setup-arduino-cli@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
 
@@ -110,7 +110,7 @@ jobs:
           find build/openpuck build/reversepuck -maxdepth 1 -type f -print | sort
 
       - name: Upload OpenPuck UF2 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OpenPuck-${{ steps.build_version.outputs.artifact_version }}-standard.uf2
           retention-days: 7
@@ -118,7 +118,7 @@ jobs:
           path: build/openpuck/OpenPuck.ino.uf2
 
       - name: Upload OpenPuck HEX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OpenPuck-${{ steps.build_version.outputs.artifact_version }}-standard.hex
           retention-days: 7
@@ -126,7 +126,7 @@ jobs:
           path: build/openpuck/OpenPuck.ino.hex
 
       - name: Upload ReversePuckFirmware UF2 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ReversePuckFirmware-${{ steps.build_version.outputs.artifact_version }}.uf2
           retention-days: 7
@@ -134,7 +134,7 @@ jobs:
           path: build/reversepuck/ReversePuckFirmware.ino.uf2
 
       - name: Upload ReversePuckFirmware HEX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ReversePuckFirmware-${{ steps.build_version.outputs.artifact_version }}.hex
           retention-days: 7

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install clang-format
         # Pinned to 18 so CI matches the version contributors run locally;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
         uses: arduino/setup-arduino-cli@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
 
@@ -164,7 +164,7 @@ jobs:
           ls -la release_assets
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.release_version.outputs.version }}
           name: ${{ format('OpenPuck {0}', steps.release_version.outputs.version) }}


### PR DESCRIPTION
While looking though the workflows, I notice alot of
```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4, arduino/setup-arduino-cli@v2.
```
This PR improves on this.