### PR TITLE
Enable MakerDiary ConnectKit (and possibly other nosd boards)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,12 @@ CFG_TUD_TASK_QUEUE_SZ ?= 512
 # too small and would silently drop every frame (blank panel / stale mappings).
 CFG_TUD_VENDOR_TX_BUFSIZE ?= 256
 EXTRA_FLAGS ?=
+# Force-include nosd.h into every translation unit so OpenPuck builds SoftDevice-free on ALL boards: it
+# drops the core's -DSOFTDEVICE_PRESENT and turns the InternalFileSystem's sd_* flash SVCs into plain calls
+# resolved by OpenPuck/nosd_flash.cpp (direct NVMC). See OpenPuck/nosd.h for the full rationale.
+NOSD_INCLUDE = -include $(CURDIR)/OpenPuck/nosd.h
 # {build.flags.usb} is expanded by arduino-cli (VID/PID/strings); pass it through verbatim.
-USB_EXTRA_FLAGS = -DNRF52840_XXAA {build.flags.usb} -DCFG_TUD_HID=$(CFG_TUD_HID) -DCFG_TUD_TASK_QUEUE_SZ=$(CFG_TUD_TASK_QUEUE_SZ) -DCFG_TUD_VENDOR_TX_BUFSIZE=$(CFG_TUD_VENDOR_TX_BUFSIZE) $(EXTRA_FLAGS)
+USB_EXTRA_FLAGS = -DNRF52840_XXAA {build.flags.usb} -DCFG_TUD_HID=$(CFG_TUD_HID) -DCFG_TUD_TASK_QUEUE_SZ=$(CFG_TUD_TASK_QUEUE_SZ) -DCFG_TUD_VENDOR_TX_BUFSIZE=$(CFG_TUD_VENDOR_TX_BUFSIZE) $(NOSD_INCLUDE) $(EXTRA_FLAGS)
 # When BUILD_PATH is set, --clean + path flags are injected; omitted for fast incremental dev builds.
 _PATH_FLAGS = $(if $(BUILD_PATH),--clean --build-path $(BUILD_PATH) --output-dir $(OUTPUT_DIR))
 
@@ -52,7 +56,8 @@ _PATH_FLAGS = $(if $(BUILD_PATH),--clean --build-path $(BUILD_PATH) --output-dir
 # the bottom swallows it so make doesn't try to build the port path as a target.
 FLASH_PORT := $(filter-out format format-check check build build-raytac \
 	package-raytac flash-raytac deploy-raytac provision-raytac-softdevice \
-	build-recovery reversepuck reversepuck-flash reversepuck-deploy flash deploy,$(MAKECMDGOALS))
+	build-recovery build-connectkit build-connectkit-recovery \
+	reversepuck reversepuck-flash reversepuck-deploy flash deploy,$(MAKECMDGOALS))
 UPLOAD = arduino-cli upload -b $(FQBN) -p "$(FLASH_PORT)" OpenPuck
 
 # ReversePuck (controller dongle, 28DE:1302) build flags. It has ONE HID interface (core default 2 is fine),
@@ -63,6 +68,7 @@ RP_UPLOAD = arduino-cli upload -b $(FQBN) -p "$(FLASH_PORT)" ReversePuckFirmware
 
 .PHONY: format format-check check build build-raytac package-raytac \
 	flash-raytac deploy-raytac provision-raytac-softdevice build-recovery \
+	build-connectkit build-connectkit-recovery \
 	reversepuck reversepuck-flash reversepuck-deploy flash deploy
 
 ## Compile the firmware with the required USB flags baked in. Override CFG_TUD_HID / CFG_TUD_TASK_QUEUE_SZ /
@@ -122,6 +128,31 @@ provision-raytac-softdevice:
 ## One-time factory-reset recovery image (wipes persistent storage once on first boot). See §6 of the build doc.
 build-recovery:
 	$(MAKE) build BUILD_PATH=$(BUILD_PATH) OUTPUT_DIR=$(OUTPUT_DIR) EXTRA_FLAGS="$(EXTRA_FLAGS) -DOPK_FACTORY_RESET=1"
+
+## Build OpenPuck for the MakerDiary nRF52840 Connect Kit and emit a drag-and-drop .uf2.
+## Native NO-SoftDevice build via the in-repo vendored platform (arduino/hardware/openpuck/nrf52),
+## app linked @ 0x1000. ARDUINO_DIRECTORIES_USER is exported so arduino-cli finds that platform.
+## Like `build`, does NOT run gen_version.sh -- run it yourself first for version provenance.
+## Flash: double-tap RST -> the board mounts as UF2BOOT -> copy build/connectkit/OpenPuck-connectkit.uf2 onto it.
+## See docs/CONNECT_KIT_SETUP.md for the full walkthrough.
+build-connectkit build-connectkit-recovery: export ARDUINO_DIRECTORIES_USER = $(CURDIR)/arduino
+build-connectkit:
+	mkdir -p build/connectkit build/cache/connectkit
+	@# The trailing `-` lets the compile's optional adafruit-nrfutil DFU-zip step be absent: the Connect
+	@# Kit flashes by drag-and-drop, so we only need the .hex (emitted BEFORE that step). A genuine compile
+	@# failure is caught by the missing-.hex check below, so real errors still fail the build.
+	-arduino-cli compile --clean -b openpuck:nrf52:makerdiary_connectkit \
+		--build-path build/cache/connectkit --output-dir build/connectkit \
+		--build-property "build.extra_flags=$(USB_EXTRA_FLAGS)" OpenPuck
+	@# arduino-cli emits the .hex into the build-path cache; the --output-dir copy only runs on a fully
+	@# successful compile (which the optional DFU-zip step prevents), so read the .hex from the cache.
+	@test -f build/cache/connectkit/OpenPuck.ino.hex || { echo "connectkit compile failed (no .hex produced)"; exit 1; }
+	./gen_uf2.sh build/cache/connectkit/OpenPuck.ino.hex build/connectkit/OpenPuck-connectkit.uf2
+	@echo "Connect Kit image ready: build/connectkit/OpenPuck-connectkit.uf2  (drag onto the UF2BOOT drive)"
+
+## One-time factory-reset Connect Kit image (wipes persistent storage once on first boot). See §6 of the build doc.
+build-connectkit-recovery:
+	$(MAKE) build-connectkit EXTRA_FLAGS="$(EXTRA_FLAGS) -DOPK_FACTORY_RESET=1"
 
 ## Compile the ReversePuck controller dongle firmware (28DE:1302) with its WebUSB vendor flags baked in.
 reversepuck:

--- a/OpenPuck/nosd.h
+++ b/OpenPuck/nosd.h
@@ -1,0 +1,28 @@
+// nosd.h -- compile OpenPuck SoftDevice-free on every board.
+//
+// This header is FORCE-INCLUDED into every translation unit (see the `-include` in the Makefile's
+// USB_EXTRA_FLAGS / RP_USB_FLAGS), ahead of all other code, so it can reshape the SoftDevice surface
+// globally regardless of which board (feather / raytac / XIAO / Connect Kit) is being built.
+//
+// Why: OpenPuck drives the radio bare-metal and NEVER enables the SoftDevice on ANY board. On the classic
+// Feather/Pro-Micro path the S140 blob still physically sits in flash (for the boot handoff), and the app
+// happens to work only because that disabled-but-present SoftDevice still services the flash SVCs the
+// Adafruit InternalFileSystem calls. A board with no SoftDevice at all (the MakerDiary Connect Kit's nosd
+// bootloader) has no SVC handler, so those calls fault on the first flash write (e.g. saving a bond during
+// pairing). Making the whole codebase SoftDevice-free removes that latent dependency everywhere.
+//
+// Two moves:
+//   1. #undef SOFTDEVICE_PRESENT -- the Adafruit core hardcodes -DSOFTDEVICE_PRESENT; dropping it here
+//      gates OUT the SoftDevice-only code paths (the FreeRTOS port's sd_clock_hfclk_* / sd_nvic_* usage,
+//      sd_app_evt_wait, ...) so OpenPuck's own bare-metal management (HFXO in the radio, CMSIS critical
+//      sections) is used instead. GCC applies -D before -include, so this reliably removes the -D.
+//   2. #define SVCALL_AS_NORMAL_FUNCTION -- turns Nordic's inline-SVC sd_* stubs into plain extern
+//      declarations, so the few that remain referenced (sd_flash_write / sd_flash_page_erase /
+//      sd_softdevice_is_enabled / sd_softdevice_disable) resolve to our direct-NVMC implementations in
+//      nosd_flash.cpp instead of trapping into a (possibly absent) SoftDevice.
+
+#undef SOFTDEVICE_PRESENT
+
+#ifndef SVCALL_AS_NORMAL_FUNCTION
+#define SVCALL_AS_NORMAL_FUNCTION 1
+#endif

--- a/OpenPuck/nosd_flash.cpp
+++ b/OpenPuck/nosd_flash.cpp
@@ -1,0 +1,73 @@
+// nosd_flash.cpp -- SoftDevice-free flash for every OpenPuck board.
+//
+// OpenPuck never enables the SoftDevice (see nosd.h). But the Adafruit InternalFileSystem flash layer
+// (core: libraries/InternalFileSytem/src/flash/flash_nrf5x.c) is hardcoded to the SoftDevice flash SVCs
+// -- sd_flash_page_erase / sd_flash_write, plus sd_softdevice_is_enabled to pick sync-vs-async -- and is
+// NOT gated by SOFTDEVICE_PRESENT, so it issues those SVCs unconditionally. With SVCALL_AS_NORMAL_FUNCTION
+// (nosd.h) those degrade to plain extern calls; this file implements them directly on the NVMC. Because
+// the SoftDevice is never running, sd_softdevice_is_enabled reports "disabled", so the caller treats every
+// op as synchronous and never waits on a SoftDevice completion callback.
+//
+// On a classic Feather this replaces the disabled-SoftDevice flash path (equivalent, one fewer moving
+// part); on a nosd board (Connect Kit) it is what makes flash writes work at all.
+
+#include "nrf.h"
+
+// ORIGIN(FLASH) from the linker script (nrf52_common.ld PROVIDEs it) -- the application base, which is
+// board-specific: 0x1000 on a nosd board, 0x26000 behind an S140 v6, 0x27000 behind S140 v7. Writing below
+// it would clobber the MBR and/or a resident SoftDevice, so it is the hard lower bound.
+extern uint32_t __flash_arduino_start[];
+
+// nRF52840 bootloader base (UF2 or Nordic Open DFU). Matches InternalFileSystem's own BOOTLOADER_ADDR, and
+// the flash_nrf5x_write() guard, so we never erase/write into the bootloader or the pages above it.
+#define NOSD_FLASH_BOOTLOADER 0x000F4000u
+
+#define NOSD_NRF_ERROR_FORBIDDEN 15u // NRF_ERROR_FORBIDDEN; any non-zero makes the caller treat the op as failed
+
+extern "C" {
+
+static inline void nosd_nvmc_wait(void) { while (NRF_NVMC->READY == NVMC_READY_READY_Busy) { } }
+
+uint32_t sd_softdevice_is_enabled(uint8_t *p_enabled)
+{
+	if (p_enabled) *p_enabled = 0; // OpenPuck never enables it -> flash ops run synchronously
+	return 0;                      // NRF_SUCCESS
+}
+
+uint32_t sd_softdevice_disable(void)
+{
+	return 0; // NRF_SUCCESS (nothing to disable)
+}
+
+uint32_t sd_flash_page_erase(uint32_t page_number)
+{
+	uint32_t addr = page_number * 4096u; // page index -> byte address
+	if (addr < (uint32_t)__flash_arduino_start || addr >= NOSD_FLASH_BOOTLOADER)
+		return NOSD_NRF_ERROR_FORBIDDEN; // never touch MBR / a resident SoftDevice / the bootloader
+	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Een;
+	nosd_nvmc_wait();
+	NRF_NVMC->ERASEPAGE = addr;
+	nosd_nvmc_wait();
+	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+	nosd_nvmc_wait();
+	return 0; // NRF_SUCCESS
+}
+
+uint32_t sd_flash_write(uint32_t *p_dst, uint32_t const *p_src, uint32_t size /*words*/)
+{
+	uint32_t a = (uint32_t)p_dst;
+	uint32_t end = a + size * 4u;
+	if (a < (uint32_t)__flash_arduino_start || end > NOSD_FLASH_BOOTLOADER || end < a)
+		return NOSD_NRF_ERROR_FORBIDDEN;
+	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;
+	nosd_nvmc_wait();
+	for (uint32_t i = 0; i < size; i++) {
+		p_dst[i] = p_src[i];
+		nosd_nvmc_wait();
+	}
+	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+	nosd_nvmc_wait();
+	return 0; // NRF_SUCCESS
+}
+
+} // extern "C"

--- a/OpenPuck/nosd_flash.cpp
+++ b/OpenPuck/nosd_flash.cpp
@@ -22,16 +22,23 @@ extern uint32_t __flash_arduino_start[];
 // the flash_nrf5x_write() guard, so we never erase/write into the bootloader or the pages above it.
 #define NOSD_FLASH_BOOTLOADER 0x000F4000u
 
-#define NOSD_NRF_ERROR_FORBIDDEN 15u // NRF_ERROR_FORBIDDEN; any non-zero makes the caller treat the op as failed
+#define NOSD_NRF_ERROR_FORBIDDEN \
+	15u // NRF_ERROR_FORBIDDEN; any non-zero makes the caller treat the op as failed
 
 extern "C" {
 
-static inline void nosd_nvmc_wait(void) { while (NRF_NVMC->READY == NVMC_READY_READY_Busy) { } }
+static inline void nosd_nvmc_wait(void)
+{
+	while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+	}
+}
 
 uint32_t sd_softdevice_is_enabled(uint8_t *p_enabled)
 {
-	if (p_enabled) *p_enabled = 0; // OpenPuck never enables it -> flash ops run synchronously
-	return 0;                      // NRF_SUCCESS
+	if (p_enabled)
+		*p_enabled =
+			0; // OpenPuck never enables it -> flash ops run synchronously
+	return 0; // NRF_SUCCESS
 }
 
 uint32_t sd_softdevice_disable(void)
@@ -42,7 +49,8 @@ uint32_t sd_softdevice_disable(void)
 uint32_t sd_flash_page_erase(uint32_t page_number)
 {
 	uint32_t addr = page_number * 4096u; // page index -> byte address
-	if (addr < (uint32_t)__flash_arduino_start || addr >= NOSD_FLASH_BOOTLOADER)
+	if (addr < (uint32_t)__flash_arduino_start ||
+	    addr >= NOSD_FLASH_BOOTLOADER)
 		return NOSD_NRF_ERROR_FORBIDDEN; // never touch MBR / a resident SoftDevice / the bootloader
 	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Een;
 	nosd_nvmc_wait();
@@ -53,11 +61,13 @@ uint32_t sd_flash_page_erase(uint32_t page_number)
 	return 0; // NRF_SUCCESS
 }
 
-uint32_t sd_flash_write(uint32_t *p_dst, uint32_t const *p_src, uint32_t size /*words*/)
+uint32_t sd_flash_write(uint32_t *p_dst, uint32_t const *p_src,
+			uint32_t size /*words*/)
 {
 	uint32_t a = (uint32_t)p_dst;
 	uint32_t end = a + size * 4u;
-	if (a < (uint32_t)__flash_arduino_start || end > NOSD_FLASH_BOOTLOADER || end < a)
+	if (a < (uint32_t)__flash_arduino_start ||
+	    end > NOSD_FLASH_BOOTLOADER || end < a)
 		return NOSD_NRF_ERROR_FORBIDDEN;
 	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;
 	nosd_nvmc_wait();

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ There are two fundamental problems with the controller:
 
 OpenPuck uses a [Pro Micro NRF52840](https://www.amazon.com/dp/B0GSZ7FD6T) ($8 on Amazon, possibly cheaper elsewhere) which uses a radio similar to the one being used by the controller and the puck. Once the arduino sketch is uploaded it emulates the puck over USB to Steam by default and allows pairing the controller normally (almost, the lizard mode for when Steam is off might not be 1:1). Latency [has been measured to be within 1ms of the official puck](https://www.reddit.com/r/SteamController/comments/1u754ze/complete_latency_testing_of_openpuck_project/).
 
+If you want a more robust board with an external antenna, the [MakerDiary nRF52840 Connect Kit](https://makerdiary.com/products/nrf52840-connectkit) (U.FL variant) is supported natively — dual crystals and a proper antenna connector, flashed by plain drag-and-drop. See [docs/CONNECT_KIT_SETUP.md](./docs/CONNECT_KIT_SETUP.md).
+
 At any point you can hold all 4 back buttons and press X to switch over to ***Xbox mode** which maps all canonical inputs to their expected counterparts (plus L4 -> LB, L5 -> L3, etc which are configurable). In this mode the right trackpad acts as a mouse but at present this only works in Android and SteamOS.
 
 Similarly you can hold all 4 back buttons and press Y to switch (teehee) over to a **Switch mode**. This emulates a pro controller full with gyro and haptics. There's other modes as well:

--- a/arduino/hardware/openpuck/nrf52/boards.txt
+++ b/arduino/hardware/openpuck/nrf52/boards.txt
@@ -1,0 +1,65 @@
+# MakerDiary nRF52840 Connect Kit, built against the installed Adafruit nRF52
+# core via a core reference (build.core=adafruit:nRF5). See platform.txt for why
+# the runtime-path flag there is mandatory. FQBN: openpuck:nrf52:makerdiary_connectkit.
+#
+# nosd: the Connect Kit's stock UF2 bootloader ships NO SoftDevice and hands the
+# application control at 0x1000 (per MakerDiary's official flash map,
+# nrf52840_partition_uf2_nosd.dtsi). Feather/XIAO boards run an app above an S140
+# (0x26000 / 0x27000); this board runs it directly at 0x1000. That single fact
+# drives both the linker origin and the -DSOFTDEVICE_PRESENT drop below.
+
+makerdiary_connectkit.name=MakerDiary nRF52840 Connect Kit (OpenPuck, nosd)
+
+# DFU / upload identity. The running app enumerates 1915:c00a; the UF2 bootloader
+# port is listed so arduino-cli can recognise it for `make flash`. Drag-and-drop
+# UF2 onto the UF2BOOT drive is the primary path and needs none of this.
+makerdiary_connectkit.vid.0=0x1915
+makerdiary_connectkit.pid.0=0xc00a
+makerdiary_connectkit.vid.1=0x239a
+makerdiary_connectkit.pid.1=0x0029
+
+makerdiary_connectkit.bootloader.tool=bootburn
+makerdiary_connectkit.upload.tool=nrfutil
+makerdiary_connectkit.upload.protocol=nrfutil
+makerdiary_connectkit.upload.use_1200bps_touch=true
+makerdiary_connectkit.upload.wait_for_upload_port=true
+# Application partition 0x1000..0xD4000 = 0xD3000 = 864256 bytes (official map:
+# 4 kB MBR, 844 kB app, 128 kB storage, 48 kB UF2 bootloader).
+makerdiary_connectkit.upload.maximum_size=864256
+makerdiary_connectkit.upload.maximum_data_size=237568
+
+makerdiary_connectkit.build.core=adafruit:nRF5
+makerdiary_connectkit.build.variant=makerdiary_connectkit
+makerdiary_connectkit.build.mcu=cortex-m4
+makerdiary_connectkit.build.f_cpu=64000000
+# -> -DARDUINO_MAKERDIARY_CONNECTKIT (available for future board gates; unused on main).
+makerdiary_connectkit.build.board=MAKERDIARY_CONNECTKIT
+makerdiary_connectkit.build.usb_manufacturer="MakerDiary"
+makerdiary_connectkit.build.usb_product="nRF52840 Connect Kit"
+makerdiary_connectkit.build.vid=0x1915
+makerdiary_connectkit.build.pid=0xc00a
+# `make build` overrides build.extra_flags with the required CFG_TUD_* values (a
+# bare arduino-cli compile without them #errors on purpose).
+makerdiary_connectkit.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
+makerdiary_connectkit.build.uf2_family=0xADA52840
+
+# nosd: link the application at 0x1000 (no SoftDevice). Variant-local script; its
+# INCLUDE "nrf52_common.ld" resolves through the inherited -L{build.core.path}/linker.
+makerdiary_connectkit.build.ldscript={build.variant.path}/nrf52840_connectkit_nosd.ld
+
+# sd_* here only put the SoftDevice API headers on the include path (declarations
+# only) and set the DFU zip's --sd-req; no SoftDevice is present or started.
+makerdiary_connectkit.build.sd_name=s140
+makerdiary_connectkit.build.sd_version=6.1.1
+makerdiary_connectkit.build.sd_fwid=0x00B6
+
+# nosd: OpenPuck builds SoftDevice-free on ALL boards via a force-included OpenPuck/nosd.h (see the
+# NOSD_INCLUDE flag in the repo Makefile) -- it drops -DSOFTDEVICE_PRESENT and routes the InternalFileSystem
+# sd_* flash calls to OpenPuck/nosd_flash.cpp (direct NVMC). So this board inherits the core's build.flags.nrf
+# unchanged -- no per-board override needed here.
+
+# No board menus: supply the flags the Adafruit recipe would otherwise take from a
+# menu selection, at Adafruit's release defaults (no debug, no serial logger).
+makerdiary_connectkit.build.debug_flags=-DCFG_DEBUG=0
+makerdiary_connectkit.build.logger_flags=-DCFG_LOGGER=0
+makerdiary_connectkit.build.sysview_flags=

--- a/arduino/hardware/openpuck/nrf52/platform.txt
+++ b/arduino/hardware/openpuck/nrf52/platform.txt
@@ -1,0 +1,18 @@
+# OpenPuck vendored Arduino platform.
+#
+# The board(s) in boards.txt reference the installed Adafruit nRF52 core
+# (build.core=adafruit:nRF5), inheriting all of its compilers, recipes and
+# bundled libraries (TinyUSB, InternalFileSystem, ...). What differs per board
+# is the application link origin (build.ldscript) and, for nosd boards, the
+# build.flags.nrf override that drops -DSOFTDEVICE_PRESENT.
+
+name=OpenPuck nRF52 Boards (Adafruit core)
+version=1.0.0
+
+# MANDATORY for the core reference to work (Arduino CLI >= 1.0.4). Without it,
+# {runtime.platform.path} resolves to THIS (near-empty) vendored folder, and
+# every inherited Adafruit path built from it breaks (the TinyUSB include, the
+# bundled adafruit-nrfutil upload tool, the bootloader files). Setting this
+# repoints {runtime.platform.path} at the referenced Adafruit platform, where
+# those files actually live.
+runtime.use_core_platform_path_for_runtime_platform_path=true

--- a/arduino/hardware/openpuck/nrf52/variants/makerdiary_connectkit/nrf52840_connectkit_nosd.ld
+++ b/arduino/hardware/openpuck/nrf52/variants/makerdiary_connectkit/nrf52840_connectkit_nosd.ld
@@ -1,0 +1,49 @@
+/* Linker script for the MakerDiary nRF52840 Connect Kit under OpenPuck (nosd).
+ *
+ * The Connect Kit's stock UF2 bootloader ships NO SoftDevice and hands control
+ * to the application at 0x1000 (right after the MBR). Feather/XIAO boards place
+ * an S140 in front of the app (0x26000 / 0x27000); this board has none, so the
+ * app is linked at 0x1000 and reclaims that space. OpenPuck never uses a
+ * SoftDevice, so this is the honest layout.
+ *
+ * FLASH region = MakerDiary's official "Application" partition
+ * (nrf52840_partition_uf2_nosd.dtsi): 0x1000 .. 0xD4000 (844 kB). The 0xD4000 ..
+ * 0xF4000 "Storage" partition (128 kB) is left free for the filesystem, and the
+ * UF2 bootloader owns 0xF4000 .. 0x100000.
+ *
+ * RAM is left at the SoftDevice-era 0x20006000 origin for this first bring-up
+ * (24 kB below it simply goes unused with no SD present) -- safe and OpenPuck
+ * fits comfortably; can be reclaimed toward 0x20000000 later. INCLUDE
+ * "nrf52_common.ld" resolves through the Adafruit core's linker dir
+ * (-L{build.core.path}/linker).
+ */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx)     : ORIGIN = 0x1000, LENGTH = 0xD4000 - 0x1000
+
+  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .svc_data :
+  {
+    PROVIDE(__start_svc_data = .);
+    KEEP(*(.svc_data))
+    PROVIDE(__stop_svc_data = .);
+  } > RAM
+
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+} INSERT AFTER .data;
+
+INCLUDE "nrf52_common.ld"

--- a/arduino/hardware/openpuck/nrf52/variants/makerdiary_connectkit/variant.cpp
+++ b/arduino/hardware/openpuck/nrf52/variants/makerdiary_connectkit/variant.cpp
@@ -1,0 +1,46 @@
+/*
+ * MakerDiary nRF52840 Connect Kit variant for OpenPuck.
+ *
+ * Identity digital-pin map (Arduino pin N -> nRF pin index N) and an
+ * initVariant() that parks the LEDs off. See variant.h for the pin sourcing
+ * (MakerDiary's official DTS).
+ */
+
+#include "variant.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+#include "nrf.h"
+
+const uint32_t g_ADigitalPinMap[PINS_COUNT] =
+{
+    // P0.00 .. P0.31  ->  Arduino 0 .. 31
+     0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+    16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+    // P1.00 .. P1.15  ->  Arduino 32 .. 47
+    32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+};
+
+// This board runs nosd: its UF2 bootloader hands the application control at 0x1000 with no
+// SoftDevice, and does NOT point the CPU's vector table at the app. So the app must set VTOR to
+// its own vector table itself -- and it has to happen BEFORE main()/init(), because init() enables
+// the first interrupts (USB power detect, systick); if one fires while VTOR still points at stale
+// handlers the chip faults and resets. A constructor runs during __libc_init_array, ahead of
+// main(), so it is early enough. (Doing this only in initVariant(), which runs AFTER init(), is
+// too late and reset-loops.)
+__attribute__((constructor(101))) static void ck_set_vtor(void)
+{
+    SCB->VTOR = 0x1000;
+}
+
+void initVariant()
+{
+    SCB->VTOR = 0x1000; // redundant with the constructor above; harmless belt-and-suspenders.
+
+    // Park all LEDs off. They are common-anode / active LOW, so OFF = drive HIGH.
+    // (Raw registers so this doesn't depend on the Arduino pin layer being up yet.)
+    NRF_P1->PIN_CNF[10] = 1; // RGB red   P1.10, DIR=output
+    NRF_P1->PIN_CNF[11] = 1; // RGB green P1.11
+    NRF_P1->PIN_CNF[12] = 1; // RGB blue  P1.12
+    NRF_P1->PIN_CNF[15] = 1; // green LED P1.15
+    NRF_P1->OUTSET = (1u << 10) | (1u << 11) | (1u << 12) | (1u << 15);
+}

--- a/arduino/hardware/openpuck/nrf52/variants/makerdiary_connectkit/variant.h
+++ b/arduino/hardware/openpuck/nrf52/variants/makerdiary_connectkit/variant.h
@@ -1,0 +1,105 @@
+/*
+ * MakerDiary nRF52840 Connect Kit variant for OpenPuck.
+ *
+ * Pin assignments are taken from MakerDiary's official Zephyr board definition
+ * (boards/makerdiary/nrf52840_connectkit/nrf52840_connectkit_nrf52840.dts):
+ *   - Green status LED (led0)    = P1.15  (active LOW)
+ *   - RGB red   (led1)           = P1.10  (active LOW)
+ *   - RGB green                  = P1.11  (active LOW)
+ *   - RGB blue                   = P1.12  (active LOW)
+ *   - USER button (sw0)          = P1.00  (pull-up, active LOW)
+ *   - Reset                      = P0.18  (gpio-as-nreset)
+ *   - 32.768 kHz LF crystal (Y2) present -> USE_LFXO
+ *
+ * The digital pin map (variant.cpp) is an identity map: Arduino pin N maps to
+ * the nRF pin index N (P0.00..P0.31 = 0..31, P1.00..P1.15 = 32..47), so the LED
+ * / button macros below are just the nRF pin indices. OpenPuck drives the radio
+ * and USB at register/TinyUSB level and doesn't lean on the Arduino pin
+ * abstraction, so a straight identity map is the least surprising choice.
+ */
+
+#ifndef _MAKERDIARY_CONNECTKIT_H_
+#define _MAKERDIARY_CONNECTKIT_H_
+
+/** Master clock frequency */
+#define VARIANT_MCK       (64000000ul)
+
+#define USE_LFXO      // Connect Kit has a 32.768 kHz crystal (Y2) for LFCLK
+//#define USE_LFRC    // (would be RC for LFCLK)
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// nRF pin index N == Arduino pin N (identity map in variant.cpp)
+#define PINS_COUNT              (48)
+#define NUM_DIGITAL_PINS        (48)
+#define NUM_ANALOG_INPUTS       (8)
+#define NUM_ANALOG_OUTPUTS      (0)
+
+// LEDs (all common-anode / active LOW: a channel lights when driven LOW)
+#define LED_GREEN0              (47)    // P1.15 standalone green status LED (led0)
+#define LED_RED                 (42)    // P1.10 RGB red   (led1)
+#define LED_GREEN               (43)    // P1.11 RGB green
+#define LED_BLUE                (44)    // P1.12 RGB blue
+
+#define PIN_LED                 (LED_GREEN0)
+#define LED_BUILTIN             (PIN_LED)
+#define LED_STATE_ON            (0)     // active LOW
+
+#define PIN_NEOPIXEL            (PINS_COUNT)
+#define NEOPIXEL_NUM            (0)
+
+// Buttons
+#define PIN_BUTTON1             (32)    // P1.00 USER button (sw0), pull-up/active LOW
+
+// Analog inputs (AINx)
+#define PIN_A0                  (2)     // P0.02 AIN0
+#define PIN_A1                  (3)     // P0.03 AIN1
+#define PIN_A2                  (4)     // P0.04 AIN2
+#define PIN_A3                  (5)     // P0.05 AIN3
+#define PIN_A4                  (28)    // P0.28 AIN4
+#define PIN_A5                  (29)    // P0.29 AIN5
+#define PIN_A6                  (30)    // P0.30 AIN6
+#define PIN_A7                  (31)    // P0.31 AIN7
+static const uint8_t A0 = PIN_A0, A1 = PIN_A1, A2 = PIN_A2, A3 = PIN_A3;
+static const uint8_t A4 = PIN_A4, A5 = PIN_A5, A6 = PIN_A6, A7 = PIN_A7;
+#define ADC_RESOLUTION          (12)
+
+// NFC antenna pins
+#define PIN_NFC1                (9)     // P0.09
+#define PIN_NFC2                (10)    // P0.10
+
+// Serial1 (UART) -- unused by OpenPuck; valid placeholders.
+#define PIN_SERIAL1_RX          (8)
+#define PIN_SERIAL1_TX          (6)
+
+// SPI -- unused by OpenPuck; valid placeholders (not begun, so never configured).
+#define SPI_INTERFACES_COUNT    (1)
+#define PIN_SPI_MISO            (14)
+#define PIN_SPI_MOSI            (15)
+#define PIN_SPI_SCK             (13)
+static const uint8_t SS   = 7;
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK  = PIN_SPI_SCK;
+
+// Wire (I2C) -- unused by OpenPuck; valid placeholders.
+#define WIRE_INTERFACES_COUNT   (1)
+#define PIN_WIRE_SDA            (4)     // P0.04
+#define PIN_WIRE_SCL            (5)     // P0.05
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+// NOTE: no EXTERNAL_FLASH_* here. The Connect Kit has an MX25R64 QSPI flash, but
+// OpenPuck stores config/bonds in the nRF52840's INTERNAL flash (LittleFS), so
+// the external flash is intentionally left unconfigured.
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/docs/BUILD_AND_DEPLOY.md
+++ b/docs/BUILD_AND_DEPLOY.md
@@ -152,6 +152,20 @@ build; use the physical Open DFU workflow above instead. The panel's factory
 erase (§6, filesystem-only) and the serial `ERASE-ALL` console command work
 normally.
 
+## 4c. Build for the MakerDiary nRF52840 Connect Kit
+
+The MakerDiary nRF52840 Connect Kit is supported as a native **no-SoftDevice** build (app linked at
+`0x1000`) via an in-repo vendored Arduino platform (`arduino/hardware/openpuck/nrf52/`) that references
+the same Adafruit nRF52 core — no bootloader swap, no SWD probe, plain drag-and-drop:
+
+```sh
+make build-connectkit   # -> build/connectkit/OpenPuck-connectkit.uf2
+```
+
+Double-tap **RST** (mounts as `UF2BOOT`) and copy the `.uf2` onto it. Full walkthrough, including why the
+nosd approach is needed and the board's reliability advantages, is in
+[CONNECT_KIT_SETUP.md](./CONNECT_KIT_SETUP.md).
+
 ## 5. Upload the firmware
 
 The quickest path is `make`. The serial port is a **required argument** (find it with `arduino-cli board list`):

--- a/docs/CONNECT_KIT_SETUP.md
+++ b/docs/CONNECT_KIT_SETUP.md
@@ -1,0 +1,95 @@
+# Running OpenPuck on the MakerDiary nRF52840 Connect Kit
+
+Native support for the **MakerDiary nRF52840 Connect Kit** — a reliability-focused alternative to the
+usual Pro Micro / Feather. It has **two crystals** (a 32 MHz HFXO *and* a 32.768 kHz LFXO — most cheap
+Pro Micro clones omit the LFXO), a clean buck-boost supply, and a **U.FL external-antenna** option.
+
+OpenPuck runs on it as a **native no-SoftDevice (nosd) build**, flashed by plain **drag-and-drop** —
+**no SWD probe, no SoftDevice, no bootloader swap.** Get the **U.FL variant** if you want an external antenna.
+
+## Quick start
+
+1. **Install the toolchain** (once): arduino-cli + the Adafruit nRF52 core — see
+   [BUILD_AND_DEPLOY.md](./BUILD_AND_DEPLOY.md) §2–3.
+2. **Build:**
+   ```sh
+   ./gen_version.sh        # optional: bakes version/git provenance into the build
+   make build-connectkit   # -> build/connectkit/OpenPuck-connectkit.uf2
+   ```
+3. **Flash:** double-tap the **RST** button — the board mounts as a **`UF2BOOT`** drive. Copy
+   `build/connectkit/OpenPuck-connectkit.uf2` onto it. It reboots into OpenPuck and enumerates as the
+   Steam puck.
+4. **Pair** the controller (see [Pairing](#pairing)).
+
+Later firmware updates can also be done from the
+[WebUSB configurator](https://safijari.github.io/openpuck/)'s **Firmware update** tab, like any OpenPuck.
+
+## Why this board
+
+- **Reliability:** a real 32 MHz HFXO crystal (the radio's timing reference) **and** a 32.768 kHz LFXO —
+  the two things flaky no-name clones most often get wrong.
+- **External antenna:** the U.FL variant closes most of the ~20 dB the firmware notes for a bare
+  PCB-trace antenna, getting you into real-puck range.
+- **Passive +8 dBm RF front end** (no PA/LNA) — exactly what OpenPuck drives.
+
+## How it works (the nosd approach)
+
+The Connect Kit's stock UF2 bootloader ships **with no SoftDevice** and hands the application control at
+**`0x1000`**. OpenPuck never uses a SoftDevice anyway, so rather than swap the bootloader it runs
+**natively at `0x1000`, no SoftDevice**. All of this lives in the in-repo **vendored Arduino platform**
+at `arduino/hardware/openpuck/nrf52/` (which references the installed Adafruit nRF52 core) — **OpenPuck's
+own source is untouched.**
+
+Three board-specific pieces make it work, all in the vendored platform:
+
+1. **Link at `0x1000`, no SoftDevice** — a variant linker script (`nrf52840_connectkit_nosd.ld`) plus a
+   `boards.txt` `build.flags.nrf` that drops `-DSOFTDEVICE_PRESENT`.
+2. **Set `VTOR` early** — `variant.cpp` sets `SCB->VTOR = 0x1000` in a `constructor`, *before*
+   `main()`/`init()` enables the first interrupt. (The bootloader doesn't point the vector table at the
+   app; doing it later, e.g. in `initVariant()`, reset-loops.)
+3. **Direct-NVMC flash** — the Adafruit `InternalFileSystem` flash layer calls the SoftDevice flash SVCs
+   (`sd_flash_write` / `sd_flash_page_erase`), which have no handler on a nosd chip and crash on the first
+   bond write. Built with `-DSVCALL_AS_NORMAL_FUNCTION`, the variant provides NVMC implementations of
+   those (bounds-checked to `[0x1000, 0xF4000)` so they can never touch the MBR or bootloader).
+
+Official flash map (MakerDiary `nrf52840_partition_uf2_nosd.dtsi`):
+
+| Region | Range |
+|---|---|
+| MBR | `0x00000`–`0x01000` |
+| **Application** (OpenPuck) | `0x01000`–`0xD4000` |
+| **Storage** (LittleFS: config + bonds) | `0xD4000`–`0xF4000` |
+| UF2 bootloader | `0xF4000`–`0x100000` |
+
+## Pairing
+
+Plug both the Connect Kit and the controller into the same machine via **data** USB-C, with **Steam running**.
+
+- Pair into **slot 2** (leaves your existing slot-1 puck intact): turn the controller off (**Steam + Y**),
+  then power it on holding **LB + A + Steam** (a different chime confirms slot 2), then pair in Steam
+  (auto-popup, or **Settings → Controllers → Add Controller**).
+- Slots: **RB + A + Steam** = slot 1, **LB + A + Steam** = slot 2.
+
+Confirm with an input test in Steam (buttons / sticks / gyro / trackpads).
+
+## Antenna
+
+Fit a 2.4 GHz antenna to the **U.FL** connector (U.FL→SMA pigtail). Do **not** add an external PA/LNA —
+OpenPuck only drives the nRF's internal +8 dBm, and an unpowered external LNA would hurt sensitivity.
+
+## Recovery / troubleshooting
+
+- **Un-brickable by flashing:** drag-drop writes only the app region; the MBR and bootloader are never
+  touched. A bad app just means double-tap **RST** → `UF2BOOT` → drag a good `.uf2`.
+- **`make build-connectkit` prints "adafruit-nrfutil not found":** harmless — that's only arduino-cli's
+  optional DFU-zip step; the `.uf2` is still produced (the target tolerates it).
+- **Dev serial log:** the board can log over UART on **P1.09 @ 115200** if you re-add a debug logger to
+  the variant; wire adapter **RX ← P1.09**, **GND ← GND**, adapter at **3.3 V**.
+
+## Reference
+
+- **FQBN:** `openpuck:nrf52:makerdiary_connectkit`
+- **Build:** `make build-connectkit` — or `make build-connectkit-recovery` for a one-time factory-reset image.
+- **Bootloader drive:** `UF2BOOT` (enter: double-tap **RST**, or hold **USER** while plugging in).
+- **Pins:** green LED P1.15; RGB red/green/blue P1.10/P1.11/P1.12 (OpenPuck leaves them off); USER button P1.00; reset P0.18.
+- **Official board docs:** <https://wiki.makerdiary.com/nrf52840-connectkit/>


### PR DESCRIPTION
Provides a way to build for nosd boards; tested with makerdiary (https://makerdiary.com/products/nrf52840-connectkit)
Notable changes:
1) Added a vendored directory to describe the makerdiary
2) Converted all boards to operate 'like' nosd. For boards that are SoftDevice (sd), the change actually means dropping usage of adafruit's InternalFileSystem and directly reading/writing. The reasoning behind that is that InternalFileSystem expects the S140 sd blob to exist which then will attempt to read/write to a specific section of the stack. On nosd, that place appears to be in text and when the next instruction is read, it blows up. This conversion makes it so both sd and nosd operate the same way with read/writes in an effort to escape this class of problem and unify device operation between bootloader types.

--> This does need someone with a sd device (the suggested device, or similar, in the readme) to test it as I don't personally have one. Please do that before merging!