### PR TITLE
Add Seeed XIAO nRF52840 board target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ FORMAT_FILES := $(shell find OpenPuck ReversePuckFirmware puck_sniffer pairtui \
 # on the command line, e.g.   make build CFG_TUD_HID=8 CFG_TUD_TASK_QUEUE_SZ=128
 # or add your own defines:     make build EXTRA_FLAGS="-DOPK_LOG=1"
 FQBN ?= adafruit:nrf52:feather52840
+# Seeed XIAO nRF52840 target (see build-xiao). Use xiaonRF52840Sense for the Sense variant.
+XIAO_FQBN ?= Seeeduino:nrf52:xiaonRF52840
 CFG_TUD_HID ?= 6
 # Optional output paths; when set, --clean is implied and build artifacts land in OUTPUT_DIR.
 # Used by CI: make build BUILD_PATH=build/cache/openpuck OUTPUT_DIR=build/openpuck
@@ -50,7 +52,7 @@ _PATH_FLAGS = $(if $(BUILD_PATH),--clean --build-path $(BUILD_PATH) --output-dir
 # (No auto-detect -- uploading to a guessed serial port risks writing to the wrong device. List with
 # `arduino-cli board list`.) FLASH_PORT = whatever goal isn't one of our real targets; the catch-all rule at
 # the bottom swallows it so make doesn't try to build the port path as a target.
-FLASH_PORT := $(filter-out format format-check check build build-raytac \
+FLASH_PORT := $(filter-out format format-check check build build-raytac build-xiao deploy-xiao \
 	package-raytac flash-raytac deploy-raytac provision-raytac-softdevice \
 	build-recovery reversepuck reversepuck-flash reversepuck-deploy flash deploy,$(MAKECMDGOALS))
 UPLOAD = arduino-cli upload -b $(FQBN) -p "$(FLASH_PORT)" OpenPuck
@@ -61,7 +63,7 @@ UPLOAD = arduino-cli upload -b $(FQBN) -p "$(FLASH_PORT)" OpenPuck
 RP_USB_FLAGS = -DNRF52840_XXAA {build.flags.usb} -DCFG_TUD_TASK_QUEUE_SZ=$(CFG_TUD_TASK_QUEUE_SZ) -DCFG_TUD_VENDOR_TX_BUFSIZE=$(CFG_TUD_VENDOR_TX_BUFSIZE) $(EXTRA_FLAGS)
 RP_UPLOAD = arduino-cli upload -b $(FQBN) -p "$(FLASH_PORT)" ReversePuckFirmware
 
-.PHONY: format format-check check build build-raytac package-raytac \
+.PHONY: format format-check check build build-raytac build-xiao deploy-xiao package-raytac \
 	flash-raytac deploy-raytac provision-raytac-softdevice build-recovery \
 	reversepuck reversepuck-flash reversepuck-deploy flash deploy
 
@@ -80,6 +82,25 @@ build-raytac:
 		--build-path build/cache/raytac \
 		--output-dir build/raytac \
 		--build-property "build.extra_flags=$(USB_EXTRA_FLAGS) -DOPK_BOARD_MDBT50Q_CX_40=1" OpenPuck
+
+## Build for the Seeed XIAO nRF52840 (Seeed nRF52 Boards core -- the Adafruit fork, NOT the mbed one).
+## Same UF2 bootloader story as the SuperMini, but Seeed's core ships S140 7.3.0, so the app base moves to
+## 0x27000 (handled by OPK_BOARD_XIAO_NRF52840 in board_config.h). Add the Seeed index first:
+##   arduino-cli config add board_manager.additional_urls \
+##       https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
+##   arduino-cli core update-index && arduino-cli core install Seeeduino:nrf52
+build-xiao:
+	mkdir -p build/xiao build/cache/xiao
+	arduino-cli compile --clean -b $(XIAO_FQBN) \
+		--build-path build/cache/xiao \
+		--output-dir build/xiao \
+		--build-property "build.extra_flags=$(USB_EXTRA_FLAGS) -DOPK_BOARD_XIAO_NRF52840=1" OpenPuck
+
+## Build then upload to a XIAO. Usage: make deploy-xiao <port>   (double-tap RST first if it is in puck mode)
+deploy-xiao:
+	@[ -n "$(FLASH_PORT)" ] || { echo "usage: make deploy-xiao <port>   e.g. make deploy-xiao /dev/ttyACM0"; exit 1; }
+	$(MAKE) build-xiao
+	arduino-cli upload -b $(XIAO_FQBN) -p "$(FLASH_PORT)" OpenPuck
 
 ## Package an existing Raytac build for its factory Nordic Open DFU bootloader.
 package-raytac:

--- a/OpenPuck/board_config.h
+++ b/OpenPuck/board_config.h
@@ -6,3 +6,13 @@
 #else
 #define OPK_HAS_ADAFRUIT_DFU 1
 #endif
+
+// Start of the application region in flash. The Feather/SuperMini builds run under the Adafruit core's
+// S140 6.1.1 (app at 0x26000); Seeed's XIAO core ships S140 7.3.0, whose one-page-larger SoftDevice moves
+// the app to 0x27000 (see nrf52840_s140_v7.ld). Everything above is unchanged: LittleFS still starts at
+// 0xED000, bootloader at 0xF4000, its settings page at 0xFF000.
+#if defined(OPK_BOARD_XIAO_NRF52840)
+#define OPK_APP_BASE 0x27000UL
+#else
+#define OPK_APP_BASE 0x26000UL
+#endif

--- a/OpenPuck/fw_update.cpp
+++ b/OpenPuck/fw_update.cpp
@@ -2,15 +2,17 @@
 // meta-page commit arms it; the next boot applies it from RAM. See fw_update.h for the protocol and the
 // corruption-safety invariant every step here preserves.
 #include "fw_update.h"
+#include "board_config.h"
 #include "fault_diag.h"
 #include <Arduino.h>
 #include <string.h>
 
-// nRF52840 flash map (Adafruit UF2 bootloader layout): MBR 0x0-0x1000, SoftDevice to 0x26000, app region
-// 0x26000-0xED000, internal LittleFS 0xED000-0xF4000, bootloader 0xF4000+, its settings page at 0xFF000.
+// nRF52840 flash map (Adafruit UF2 bootloader layout): MBR 0x0-0x1000, SoftDevice to OPK_APP_BASE, app
+// region OPK_APP_BASE-0xED000 (0x26000 under S140 6.1.1, 0x27000 under the S140 7.3.0 the Seeed XIAO core
+// ships), internal LittleFS 0xED000-0xF4000, bootloader 0xF4000+, its settings page at 0xFF000.
 // We manage the TOP of the app region: the meta/commit page at 0xEC000 and the staged image right below it,
 // growing downward. Nothing outside [APP_BASE, 0xED000) is ever written except FWUP_BL_SETTINGS (see apply).
-#define FWUP_APP_BASE 0x26000UL
+#define FWUP_APP_BASE OPK_APP_BASE
 #define FWUP_APP_END 0xED000UL
 #define FWUP_META 0xEC000UL
 // internal LittleFS (cfg.bin + bonds.bin) sits between the app region and the bootloader; wiped whole by the
@@ -19,8 +21,9 @@
 #define FWUP_FS_END 0xF4000UL
 #define FWUP_BL_SETTINGS 0xFF000UL
 #define FWUP_PAGE 4096UL
-// Image cap. Also what makes the apply copy safe from self-overlap: dst ends at most at 0x26000+0x60000 =
-// 0x86000, while the staged source starts at (0xEC000-size)&~0xFFF >= 0x8C000 -- disjoint by >=24 KiB.
+// Image cap. Also what makes the apply copy safe from self-overlap: dst ends at most at APP_BASE+0x60000 =
+// 0x86000 (0x87000 on a 0x27000 app base), while the staged source starts at (0xEC000-size)&~0xFFF >=
+// 0x8C000 -- disjoint by >=20 KiB on either layout.
 #define FWUP_MAX_IMG 0x60000UL
 
 // Capability tag, searched for BY THE PANEL inside any .uf2 it is about to flash: an image without this

--- a/OpenPuck/status_led.h
+++ b/OpenPuck/status_led.h
@@ -11,6 +11,16 @@
 // Override the pins/polarity below if your board differs.
 #pragma once
 
+// Seeed XIAO nRF52840: the RGB LEDs are active-LOW (variant.cpp parks them HIGH at boot, despite variant.h
+// advertising LED_STATE_ON as 1). LED_BUILTIN is the red one (P0.26). Pin B MUST be overridden here: 24 in
+// the Feather map is P0.15, but on the XIAO map D24 is P0.21 = QSPI_SCK, and driving that fights the
+// on-board 2 MB QSPI flash.
+#if defined(OPK_BOARD_XIAO_NRF52840)
+#define WAKE_LED_PIN_A LED_BUILTIN
+#define WAKE_LED_PIN_B LED_BUILTIN
+#define WAKE_LED_ON LOW
+#endif
+
 #ifndef WAKE_LED_PIN_A
 
 // Feather: P1.15 user LED (harmless unconnected pad on SuperMini clones)

--- a/docs/BUILD_AND_DEPLOY.md
+++ b/docs/BUILD_AND_DEPLOY.md
@@ -152,6 +152,92 @@ build; use the physical Open DFU workflow above instead. The panel's factory
 erase (§6, filesystem-only) and the serial `ERASE-ALL` console command work
 normally.
 
+### 4b. Seeed XIAO nRF52840 (Sense)
+
+Both XIAO nRF52840 variants build from the same source; the Sense only adds a
+microphone and IMU, which OpenPuck does not use. Use `xiaonRF52840Sense` in
+place of `xiaonRF52840` below if you have that board.
+
+#### Prerequisites
+
+The XIAO needs Seeed's own core, which is a fork of the Adafruit one:
+
+```bash
+arduino-cli config add board_manager.additional_urls \
+    https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
+arduino-cli core update-index
+arduino-cli core install Seeeduino:nrf52
+```
+
+It also needs a newer TinyUSB than the core bundles. Seeed's core ships
+Adafruit TinyUSB 1.7.0, which hardcodes `#define CFG_TUD_HID 1` with no
+`#ifndef` guard (so the build flag is silently overridden) and predates
+`setConfigurationAttribute()`, `allocEndpoint()`, and
+`setSerialDescriptor()`. Install a user-library copy, which outranks the
+core-bundled one in arduino-cli's resolver:
+
+```bash
+arduino-cli lib install "Adafruit TinyUSB Library@3.7.0"
+```
+
+Pin the version: 3.7.5 added an `is_isr` parameter to `usbd_edpt_xfer()`,
+which does not compile against `mode_xinput.cpp`. Anything from 3.7.0 through
+3.7.4 works. (The Adafruit core pins 3.7.0, so this matches what the standard
+build uses.)
+
+#### Build and flash
+
+```bash
+make build-xiao
+make deploy-xiao COM5     # or /dev/ttyACM0
+```
+
+Double-tap RST before flashing: like every other target, puck mode drops the
+CDC port, so the board cannot auto-reset into its bootloader.
+
+#### Flash layout
+
+Seeed's core ships **S140 7.3.0** rather than the 6.1.1 the Feather profile
+uses, which moves the application up one page. Everything above it is
+unchanged:
+
+- OpenPuck starts at `0x27000` (not `0x26000`) and must end before `0xED000`.
+- InternalFS occupies `0xED000` through `0xF3FFF`.
+- The Adafruit-format UF2 bootloader occupies `0xF4000` through `0xFFFFF`.
+
+`OPK_APP_BASE` in `board_config.h` carries this difference; the staged updater
+derives `FWUP_APP_BASE` from it.
+
+The XIAO's RGB LEDs are active-low, and `LED_BUILTIN` is the red one. Pin 24 —
+the SuperMini's blue user LED in the Feather pin map — is **P0.21 (QSPI_SCK)**
+on the XIAO, so the dual-pin remote-wake indicator is overridden to
+`LED_BUILTIN` on both pins rather than driving the on-board QSPI flash's clock
+line.
+
+#### Staged WebUSB updates are not supported on this board
+
+Use serial or UF2 DFU (§5, §5b) to update a XIAO. The panel's firmware-update
+tab hardcodes the app base:
+
+```js
+const APP_BASE=0x26000, ...
+if(lo!==APP_BASE) throw new Error("image base 0x"+lo.toString(16)+" ...")
+```
+
+so it rejects a XIAO-built `.uf2` (base `0x27000`), while an official release
+image passes that check but cannot run at `0x27000` — applying one leaves the
+board app-less. `fwupBegin` carries no target address, so the firmware cannot
+reject the mismatch either; `vectorsPlausible()` passes because a Feather
+image's reset vector still falls inside the XIAO's app region. Recovery is the
+normal one: double-tap RST and reflash over serial DFU; the bootloader is
+untouched.
+
+#### Tested
+
+Board enumerates as the puck, controller pairs and reconnects wirelessly,
+bonds survive reboot, the WebUSB panel connects, and Xbox/Switch/Steam mode
+switching re-enumerates correctly.
+
 ## 5. Upload the firmware
 
 The quickest path is `make`. The serial port is a **required argument** (find it with `arduino-cli board list`):

--- a/gen_uf2.sh
+++ b/gen_uf2.sh
@@ -34,7 +34,11 @@ if [ -z "$DATA_DIR" ]; then
 	fi
 fi
 
-UF2CONV="$(find "$DATA_DIR/packages/adafruit/hardware/nrf52" -name uf2conv.py 2>/dev/null | sort | tail -n1)"
+# Seeed's XIAO core is a fork of the Adafruit one and ships its own uf2conv.py
+# under a different vendor directory, so search both.
+UF2CONV="$(find "$DATA_DIR/packages/adafruit/hardware/nrf52" \
+	"$DATA_DIR/packages/Seeeduino/hardware/nrf52" \
+	-name uf2conv.py 2>/dev/null | sort | tail -n1)"
 if [ -z "$UF2CONV" ]; then
 	echo "gen_uf2.sh: could not find uf2conv.py under $DATA_DIR" >&2
 	exit 1


### PR DESCRIPTION
Adds a build-xiao / deploy-xiao target so OpenPuck runs on the Seeed XIAO nRF52840 (Sense variant tested), using Seeed's non-mbed "Seeed nRF52 Boards" core.

Board deltas vs the Feather/SuperMini build

Seeed's core ships S140 7.3.0, so the app region starts at 0x27000 instead of 0x26000. fw_update.cpp hardcoded the Feather base, which would misplace the staged image; it now derives from a new OPK_APP_BASE in board_config.h. LittleFS (0xED000), bootloader (0xF4000) and its settings page (0xFF000) are unchanged.
status_led.h drives pin 24 for the SuperMini's blue LED, but D24 in the XIAO pin map is P0.21 = QSPI_SCK — driving it fights the on-board QSPI flash. Overridden to LED_BUILTIN on both pins.
The XIAO's RGB LEDs are active-low (variant.cpp parks them HIGH) despite variant.h declaring LED_STATE_ON 1, so WAKE_LED_ON is LOW.

Prerequisite worth knowing about: Seeed's core bundles Adafruit TinyUSB 1.7.0, which hardcodes #define CFG_TUD_HID 1 with no #ifndef guard (silently overriding the build flag) and predates setConfigurationAttribute(), allocEndpoint() and setSerialDescriptor(). A user-library install of 3.7.0–3.7.4 fixes it. Not 3.7.5+ — that added an is_isr parameter to usbd_edpt_xfer() which doesn't compile against mode_xinput.cpp. Worth noting this will break the standard build too whenever Adafruit bumps their core past 3.7.4.

Staged WebUSB updates don't work on this board yet. docs/index.html hardcodes const APP_BASE=0x26000 and rejects any UF2 whose base differs, so a XIAO-built image (0x27000) is refused, while an official release image passes that check but can't run — applying one leaves the board app-less (recoverable via double-tap RST + serial DFU; bootloader untouched). fwupBegin carries no target address, and vectorsPlausible() passes because a Feather image's reset vector still lands inside the XIAO's app region. Documented as unsupported for now; a proper fix means the puck reporting its app base in the status blob and the panel using that instead of a constant. Happy to do that as a follow-up if you want it that way.

gen_uf2.sh also now searches the Seeeduino package dir for uf2conv.py, not just Adafruit's.

Tested on hardware (XIAO nRF52840 Sense, Windows):

Enumerates as Steam Controller Puck ✅
Controller pairs and connects wirelessly ✅
Bond survives reboot, no re-pairing ✅
WebUSB panel connects ✅
Xbox mode (back-4 + X) → host sees Xbox 360 Controller ✅
Switch mode (back-4 + Y) → host sees Switch Pro Controller ✅
Back to Steam mode (back-4 + A) ✅
Staged WebUSB update ❌ (see above)

This was done using Claude Opus 5, I have tested it on my own steam controller and xiao nrf52 and it works.