### PR TITLE
Provide OpenPuck version and Git hash in 0xAE version report

### DIFF
--- a/OpenPuck/puck_hid.cpp
+++ b/OpenPuck/puck_hid.cpp
@@ -8,6 +8,7 @@
 #include "triton.h"
 #include "mode_lizard.h"
 #include "wake_hid.h"
+#include "build_info.h"
 #include "usb_tx.h"
 #include <Adafruit_TinyUSB.h>
 #include <Arduino.h>
@@ -440,14 +441,32 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 			// 16-byte serial 0xA3 returns) -- per device, nothing hardcoded. Copied without a stack temp
 			// (this runs on the fragile 800B usbd task; every byte off the stack helps under a Steam
 			// re-enumeration burst).
+			// TODO: This should not be read from the bond record and instead queried from the controller, see #227.
 			memcpy(S.resp + 3, g_slot[slot].rec + 8, 16);
 		} else {
 			// rid 2 = the puck's own board/unit serials (device-derived). Any other idx -> "NA".
 			const char *s = (rid == 1)	       ? "NA" :
 					(idx == 0 || idx == 4) ? g_board :
 					(idx == 1)	       ? g_unit :
+					(idx == 3)	       ? "OpenPuck " :
 								 "NA";
 			memcpy(S.resp + 3, s, strlen(s));
+			if (rid == 2 && idx == 3) {
+				// The official puck has a 12-character GIT commit hash of the firmware in here.
+				// Since I doubt any official process is ever going to parse / use this,
+				// looks like the perfect place to put the OpenPuck version number.
+				char *off = (char *)(S.resp + 3 + strlen(s));
+				memcpy(off, OPK_BUILD_VERSION,
+				       strlen(OPK_BUILD_VERSION));
+				off += strlen(OPK_BUILD_VERSION);
+				memcpy(off, " ", 1);
+				memcpy(off + 1, OPK_GIT_HASH,
+				       strlen(OPK_GIT_HASH));
+				if (OPK_GIT_DIRTY != 0) {
+					off += 1 + strlen(OPK_GIT_HASH);
+					memcpy(off, "-dirty", 6);
+				}
+			}
 		}
 		S.resp_len = 63;
 		break;


### PR DESCRIPTION
The original puck has multiple different fields where it can return a version number. Field 0 and 4 return some internal version, field 1 returns the serial number on the device sticker. 

Field 3 returns the first 12 characters of the GIT commit hash of the firmware the device is running, while on OpenPuck, it used to just return "NA". 

I didn't want to just return the Git hash like Valve did, so there's still a distinction between an official firmware and an OpenPuck firmware. 

So I tried to put a whole identification string in there - "OpenPuck 0.9.31 096e036" - and that seems to work just fine. Steam doesn't seem to be using this value anywhere, but now third-party software can detect and display the firmware type and version without having to connect to a WebUSB endpoint. 