### PR TITLE
Add MODE_WAKE: smart-power-on wake personality (Lenovo Alt+P)

### DIFF
--- a/CODE_MAP.md
+++ b/CODE_MAP.md
@@ -423,6 +423,18 @@ Reads `g_qamMap`/`g_abSwap`/`g_back[]`. Pure transforms, no buffers beyond calle
   (buttons always 0). Poll interval 10 ms. No buffers/delays/loops; only shared state is
   the one flag set once at begin.
 
+### `mode_wake.cpp` / `mode_wake.h`  (`g_wakeCtl`, MODE_WAKE)
+Boot-keyboard-only wake personality (28DE:574B): powers on a shut-down (S5) host whose
+firmware watches the port for a keyboard hotkey (Lenovo Smart Power On = Alt+P).
+- **loop task only**: `task()` state machine -- RF link quiet >= `WAKE_ARM_DOWN_MS` arms it;
+  the first `anySlotLinkUp()` up-edge sends Alt+P (`WAKE_REPEAT` presses via `usbTxHid`),
+  then `modeSwitchReboot(WAKE_RETURN_MODE)`. Registers no report callbacks and forwards no
+  controller input. `WAKE_SEQ_DEADLINE_MS` bails the sequence if the EC deconfigures us.
+- `wakeAutoRearmTask()` (called from `loop()` in every mode): `WAKE_AUTO_REARM` opt-in --
+  a persistent suspend anywhere reboots into MODE_WAKE so the wake re-arms itself.
+- Enumerates bare -- single boot-protocol keyboard, no wake mouse / WebUSB / CDC (`bareHid`
+  in `setup()`) -- because the S5 embedded controller runs a minimal USB host stack.
+
 ### `webusb_config.cpp` / `webusb_config.h` — browser config channel (loop task)
 - `Adafruit_USBD_WebUSB usb_web`. **No vendor callbacks** — fully **polled from
   `webusbPoll()` in `loop()`** (the library buffers the vendor RX). So nothing here runs

--- a/CODE_MAP.md
+++ b/CODE_MAP.md
@@ -446,7 +446,8 @@ firmware watches the port for a keyboard hotkey (Lenovo Smart Power On = Alt+P).
   once per down-episode (flap filter `WAKE_REARM_FLAP_MS` vs the EC's S5 port-takeover
   re-arm, age cap `WAKE_REARM_EPISODE_MS`); armed = sleeping host, never re-arm. The
   countdown runs from the last suspend edge (`WAKE_AUTO_REARM_MS` continuous), plus a
-  never-enumerated dead-bus path (`WAKE_DEADBUS_REARM_MS`).
+  dead-bus path (`WAKE_DEADBUS_REARM_MS` from the moment the bus was lost) covering
+  reset-style EC takeovers, failed wakes, and plugs into an off host.
 - Enumerates bare -- single boot-protocol keyboard, no wake mouse / WebUSB / CDC (`bareHid`
   in `setup()`) -- because the S5 embedded controller runs a minimal USB host stack.
 

--- a/CODE_MAP.md
+++ b/CODE_MAP.md
@@ -76,8 +76,9 @@ re-add wake mouse + `g_active->mountSlots(k)` + WebUSB in locked instance order,
   (`g_swGyroLegacy` is declared here but lives in `mode_switch_pro.cpp`/`swprocfg.bin`.)
 - `struct Cfg` is serialized to `/cfg.bin` (LittleFS), magic `0xCF`. `rxWin10`,
   `lizKeep`, `landAll87` and the per-type table travel with it; `rsvd0` is the
-  one-shot debug-CDC arm and `rsvd1` the ex-rumble-strength slot (both kept so the
-  on-flash layout is unchanged). New fields are **appended to the tail** (`chordDpad[4]`) —
+  one-shot debug-CDC arm and `wakeHandoff` (ex `rsvd1`, the old rumble-strength slot)
+  the one-shot post-wake-fire handoff arm (0xA5 sentinel; see mode_wake) -- both offsets
+  kept so the on-flash layout is unchanged. New fields are **appended to the tail** (`chordDpad[4]`) —
   `loadCfg()` prefills `0xFF` and accepts a file short by only the tail (`CFG_LEN_MIN`),
   so an upgrade keeps every existing setting and unwritten tail bytes fall back to defaults.
 - `loadCfg()` resolves the boot mode policy: one-shot `bootMode` wins once then clears;
@@ -426,12 +427,26 @@ Reads `g_qamMap`/`g_abSwap`/`g_back[]`. Pure transforms, no buffers beyond calle
 ### `mode_wake.cpp` / `mode_wake.h`  (`g_wakeCtl`, MODE_WAKE)
 Boot-keyboard-only wake personality (28DE:574B): powers on a shut-down (S5) host whose
 firmware watches the port for a keyboard hotkey (Lenovo Smart Power On = Alt+P).
-- **loop task only**: `task()` state machine -- RF link quiet >= `WAKE_ARM_DOWN_MS` arms it;
-  the first `anySlotLinkUp()` up-edge sends Alt+P (`WAKE_REPEAT` presses via `usbTxHid`),
-  then `modeSwitchReboot(WAKE_RETURN_MODE)`. Registers no report callbacks and forwards no
-  controller input. `WAKE_SEQ_DEADLINE_MS` bails the sequence if the EC deconfigures us.
+- **loop task only**: `task()` state machine -- OBSERVED RF link quiet >= `WAKE_ARM_DOWN_MS`
+  arms it (the quiet clock runs only while `rfConnectOpen()`, so unobservable boot time
+  never counts); the gesture is an `anySlotLinkUp()` up-EDGE latched `WAKE_FIRE_LATCH_MS`
+  until `g_kbd.ready()`, which sends the shaped press sequence (`WAKE_MOD_LEAD_MS` Alt
+  alone, `WAKE_HOLD_MS` held chord restated every `WAKE_RESEND_MS`, x `WAKE_REPEAT`) then
+  `modeSwitchReboot(WAKE_RETURN_MODE)` (0xFF = boot-policy default). Registers no report
+  callbacks and forwards no controller input. `WAKE_SEQ_DEADLINE_MS` bails the sequence if
+  the EC deconfigures us.
+- **Post-fire handoff grace**: `wakeHandoffMark()` persists a one-shot 0xA5 sentinel in
+  `Cfg.wakeHandoff` (flash -- this board class's bootloader wipes .noinit) consumed by
+  `loadCfg`; `wakeHandoffActive()` (deadline-only, `WAKE_HANDOFF_GRACE_MS`) holds the
+  suspend controller power-off + auto-rearm through POST, and the grace boot skips the
+  mount wait + opens the RF connect cooldown (`rfConnectOpenNow`). `wakeFireInFlight()` /
+  `wakeHandoffExpired()` are the haptics-side gates.
 - `wakeAutoRearmTask()` (called from `loop()` in every mode): `WAKE_AUTO_REARM` opt-in --
-  a persistent suspend anywhere reboots into MODE_WAKE so the wake re-arms itself.
+  sleep-aware re-arm. Samples the host's `DEVICE_REMOTE_WAKEUP` arming (`tud_suspend_cb`)
+  once per down-episode (flap filter `WAKE_REARM_FLAP_MS` vs the EC's S5 port-takeover
+  re-arm, age cap `WAKE_REARM_EPISODE_MS`); armed = sleeping host, never re-arm. The
+  countdown runs from the last suspend edge (`WAKE_AUTO_REARM_MS` continuous), plus a
+  never-enumerated dead-bus path (`WAKE_DEADBUS_REARM_MS`).
 - Enumerates bare -- single boot-protocol keyboard, no wake mouse / WebUSB / CDC (`bareHid`
   in `setup()`) -- because the S5 embedded controller runs a minimal USB host stack.
 

--- a/OpenPuck/OpenPuck.ino
+++ b/OpenPuck/OpenPuck.ino
@@ -36,6 +36,7 @@ using namespace Adafruit_LittleFS_Namespace;
 #include "lizard_map.h"
 #include "serial_console.h"
 #include "wake_hid.h"
+#include "mode_wake.h" // wakeAutoRearmTask()
 #include "status_led.h"
 #include "usb_mount.h"
 #include "identity.h"
@@ -65,10 +66,9 @@ using namespace Adafruit_LittleFS_Namespace;
 // puck composite (4 HID + WebUSB) exceeds the default 256 B config buffer
 static uint8_t g_usbCfgDesc[512];
 
-// Per-mode USB serial suffix (modes 1..9: X=xbox N=hori L=lizard P=swpro S=ps5 G=hidgyro Q=ps5game D=ds4game 3=ps3).
-static const char MODE_SUFFIX[] = {
-	'X', 'N', 'L', 'P', 'S', 'G', 'Q', 'D', '3'
-};
+// Per-mode USB serial suffix (modes 1..10: X=xbox N=hori L=lizard P=swpro S=ps5 G=hidgyro Q=ps5game D=ds4game 3=ps3 W=wake).
+static const char MODE_SUFFIX[] = { 'X', 'N', 'L', 'P', 'S',
+				    'G', 'Q', 'D', '3', 'W' };
 // Fixed-interface flags captured at boot so usbReenumerate (dynamic mount, no reboot) replays them.
 static bool s_dynWantWebusb = false, s_dynWantWakeMouse = false;
 
@@ -84,11 +84,11 @@ void usbReenumerate(uint8_t k)
 	USBDevice.setConfigurationBuffer(g_usbCfgDesc, sizeof g_usbCfgDesc);
 	g_active->usbIdentity(); // clearConfiguration reset VID/PID/strings -- restore them
 	// serial carries the mounted count so the host invalidates its cached config descriptor on a change
-	snprintf(
-		g_usbSerial, sizeof g_usbSerial, "%s%c%u", g_unit,
-		MODE_SUFFIX[(g_usbMode >= 1 && g_usbMode <= 9) ? g_usbMode - 1 :
-								 0],
-		(unsigned)k);
+	snprintf(g_usbSerial, sizeof g_usbSerial, "%s%c%u", g_unit,
+		 MODE_SUFFIX[(g_usbMode >= 1 && g_usbMode <= MODE_MAX) ?
+				     g_usbMode - 1 :
+				     0],
+		 (unsigned)k);
 	USBDevice.setSerialDescriptor(g_usbSerial);
 	if (s_dynWantWakeMouse)
 		wakeHidAddInterface(); // HID instance 0
@@ -179,6 +179,12 @@ void setup()
 	// clean-PS modes skip BOTH the wake mouse and WebUSB -- no config panel / host-wake; chord back to Steam
 	// (back-paddle 4 + A) to reach the panel. Normal MODE_PS5 / MODE_HIDGYRO keep wake + panel.
 	const bool psClean = modeIsCleanPS(g_usbMode);
+	// MODE_WAKE shows the same bare single-HID shape as the clean-PS modes, for a different reason: the
+	// embedded controller watching this port in S5 (Lenovo Smart Power On) enumerates with a minimal USB
+	// stack written against real keyboards, so we give it exactly one boot-protocol keyboard interface and
+	// nothing else. It keeps remote-wakeup in bmAttributes (a real keyboard advertises it) -- only the
+	// clean-PS modes drop that, to match a genuine Sony pad.
+	const bool bareHid = psClean || modeIsWake(g_usbMode);
 	const bool dynamic = g_active->dynamicMount();
 
 	if (dynamic) {
@@ -240,12 +246,12 @@ void setup()
 		// Boot-mouse wake interface for clean (non-puck) modes, and for puck on the one-shot debug boot (CDC on,
 		// no endpoint room for wake mouse on a normal puck boot -- wake is registered above instead). Skipped for PS
 		// modes so the device stays a single clean HID gamepad (see psClean above).
-		if (!puckMode && !keepCdc && !psClean)
+		if (!puckMode && !keepCdc && !bareHid)
 			wakeHidBegin();
 
 		// WebUSB config panel -- every mode EXCEPT the PlayStation modes. Puck: registered above (IF 0) before wake +
 		// slots; other clean modes after controller. PS modes omit it to present a genuine single-HID PS controller.
-		if (!puckMode && !psClean)
+		if (!puckMode && !bareHid)
 			usb_web.begin();
 		// bmAttributes: required(0x80) | remote_wakeup(0x20). Remote Wakeup lets us signal wake-from-sleep.
 		// The PS3/Sixaxis (the only clean-PS mode on this static path) advertises 0x80 only -- match it so a
@@ -273,7 +279,8 @@ void setup()
 		"SWITCH(horipad)",     "LIZARD(puck kb/mouse)",
 		"SWITCH(pro+gyro)",    "PS5(dualsense)",
 		"HIDGYRO(ds4+motion)", "PS5(dualsense,game/clean)",
-		"DS4(ds4,game/clean)", "PS3(dualshock3/sixaxis)"
+		"DS4(ds4,game/clean)", "PS3(dualshock3/sixaxis)",
+		"WAKE(alt+p keyboard)"
 	};
 	Serial.printf("# copycat up: unit=%s board=%s, mode=%s\n", g_unit,
 		      g_board,
@@ -341,6 +348,8 @@ void loop()
 	hapticStabTask(); // stability-test keepalive buzz (no-op unless armed via WebUSB)
 	// cross-check HFCLK(micros) vs LFCLK(millis) once a second -- cheap, both builds (clone clock diagnostic)
 	clockDiagTick();
+	// opt-in auto re-arm of the smart-power-on wake mode (no-op unless built with WAKE_AUTO_REARM)
+	wakeAutoRearmTask();
 	if (g_dirty) {
 		g_dirty = false;
 		// A bond flash write erases+programs a page with interrupts effectively stalled for ms -- a known

--- a/OpenPuck/OpenPuck.ino
+++ b/OpenPuck/OpenPuck.ino
@@ -69,6 +69,8 @@ static uint8_t g_usbCfgDesc[512];
 // Per-mode USB serial suffix (modes 1..10: X=xbox N=hori L=lizard P=swpro S=ps5 G=hidgyro Q=ps5game D=ds4game 3=ps3 W=wake).
 static const char MODE_SUFFIX[] = { 'X', 'N', 'L', 'P', 'S',
 				    'G', 'Q', 'D', '3', 'W' };
+static_assert(sizeof MODE_SUFFIX == MODE_MAX,
+	      "MODE_SUFFIX must have one entry per mode 1..MODE_MAX");
 // Fixed-interface flags captured at boot so usbReenumerate (dynamic mount, no reboot) replays them.
 static bool s_dynWantWebusb = false, s_dynWantWakeMouse = false;
 
@@ -268,13 +270,15 @@ void setup()
 	// Skip straight to bringing the RF side up; opening the connect cooldown makes the first beacons go
 	// out on the first loop() pass instead of at t=2.5 s.
 	if (wakeHandoffActive())
-		g_connCooldown = millis() - 2600u;
+		rfConnectOpenNow();
 	else
 		for (int i = 0; i < 300 && !USBDevice.mounted(); i++)
-			delay(10); // wait up to 3s for USB mount, but NEVER hang
+			delay(10); // up to 3s for USB mount, NEVER hang
 	if (USBDevice.suspended()) {
 		USBDevice.remoteWakeup();
-		ledWakePulse();
+		// wake mode reserves the LED for hotkey presses (WAKE_MODE.md diagnostic table)
+		if (!modeIsWake(g_usbMode))
+			ledWakePulse();
 	} // wake host if bus was sleeping when we (re-)attached
 	// Route all device->host HID sends through the usbd task (SOF drain) so loop() never calls tud_* directly
 	// -> the cross-task blocking-defer that deadlocked the loop under comms load can no longer happen.

--- a/OpenPuck/OpenPuck.ino
+++ b/OpenPuck/OpenPuck.ino
@@ -263,8 +263,15 @@ void setup()
 		USBDevice.attach();
 	}
 	Serial.begin(115200);
-	for (int i = 0; i < 300 && !USBDevice.mounted(); i++)
-		delay(10); // wait up to 3s for USB mount, but NEVER hang
+	// Post-wake-fire boot: the machine is POSTing and will not mount us for many seconds -- waiting here
+	// just extends the RF outage for the controller that triggered the wake (it gives up and powers off).
+	// Skip straight to bringing the RF side up; opening the connect cooldown makes the first beacons go
+	// out on the first loop() pass instead of at t=2.5 s.
+	if (wakeHandoffActive())
+		g_connCooldown = millis() - 2600u;
+	else
+		for (int i = 0; i < 300 && !USBDevice.mounted(); i++)
+			delay(10); // wait up to 3s for USB mount, but NEVER hang
 	if (USBDevice.suspended()) {
 		USBDevice.remoteWakeup();
 		ledWakePulse();

--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -19,6 +19,10 @@ uint8_t g_chordDpad[4] = { MODE_PS3, MODE_DS4_GAME, MODE_PS5_GAME,
 			   MODE_SW_HORI };
 bool g_persistMode = false;
 uint8_t g_bootMode = 0xFF;
+// One-shot post-wake-fire handoff (Cfg.wakeHandoff): arm = persisted by the wake fire's saveMode; boot =
+// this boot came from a wake fire (consumed like bootMode/debugCdc so the next boot is normal).
+uint8_t g_wakeHandoffArm = 0;
+bool g_wakeHandoffBoot = false;
 
 bool g_debugCdcThisBoot = false;
 
@@ -91,9 +95,11 @@ uint32_t g_pollUs = POLL_US_DEFAULT;
 #define CFG_MAGIC 0xCF
 struct Cfg {
 	uint8_t magic, mode, mDiv, mFric, rsvd0, pollU100, persistMode,
-		bootMode, chordBtn[3], rsvd1;
-	// rsvd1: legacy rumble-strength slot (strength now fixed at RUMBLE_SCALE_PCT; ignored -- kept so the
-	// on-flash layout is unchanged and an existing cfg.bin still loads).
+		bootMode, chordBtn[3], wakeHandoff;
+	// wakeHandoff: ex rumble-strength slot (same offset, so an existing cfg.bin still loads; old files
+	// hold 0 = unarmed). Now the one-shot post-wake-fire handoff arm: MODE_WAKE sets 1 right before its
+	// return reboot, loadCfg honors it for that boot and consumes it. In FLASH, not .noinit, because this
+	// board class's bootloader wipes .noinit RAM on every reset.
 	// rxWin10: legacy RF tunable slot (window now fixed; ignored). lizKeep: the id9=0 hold enable (see
 	// haptics.h LIZKEEP_MS). landAll87: the verbatim-0x87-relay experiment toggle (haptics.h g_landAll87).
 	uint8_t rxWin10, lizKeep, landAll87;
@@ -121,7 +127,7 @@ void saveCfg()
 		  (uint8_t)(g_persistMode ? 1 : 0),
 		  g_bootMode,
 		  { g_chordBtn[0], g_chordBtn[1], g_chordBtn[2] },
-		  0, // rsvd1 (ex rumble strength)
+		  g_wakeHandoffArm,
 		  (uint8_t)(g_rxWin / 10),
 		  g_lizKeep,
 		  g_landAll87,
@@ -165,6 +171,13 @@ void loadCfg()
 			g_debugCdcThisBoot = c.rsvd0 ? true : false;
 			if (c.rsvd0) {
 				g_debugCdc = 0;
+				consume = true;
+			}
+			// one-shot wake handoff: this boot follows a MODE_WAKE fire; honored (grace + fast RF
+			// bring-up) then consumed. ==1 exactly: 0xFF here means a corrupt/short file, not an arm.
+			if (c.wakeHandoff == 1) {
+				g_wakeHandoffBoot = true;
+				g_wakeHandoffArm = 0;
 				consume = true;
 			}
 			// poll rate is fixed; rewrite cfg so the persisted byte matches the new default.

--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -101,11 +101,12 @@ struct Cfg {
 	uint8_t magic, mode, mDiv, mFric, rsvd0, pollU100, persistMode,
 		bootMode, chordBtn[3], wakeHandoff;
 	// wakeHandoff: ex rumble-strength slot (same offset and magic, so an existing cfg.bin still loads --
-	// which also means a pre-rework file can hold a live rumble VALUE here, not 0). Now the one-shot
-	// post-wake-fire handoff arm: MODE_WAKE sets exactly 1 right before its return reboot, loadCfg honors
-	// ==1 for that boot and consumes ANY nonzero (so a legacy value, or a 1 stranded by flashing an old
-	// firmware between the fire and the consume, is scrubbed rather than read as an arm later). In FLASH,
-	// not .noinit, because this board class's bootloader wipes .noinit RAM on every reset.
+	// which also means a pre-rework file can hold a live rumble VALUE here, 0..100). Now the one-shot
+	// post-wake-fire handoff arm: MODE_WAKE writes the 0xA5 sentinel (outside the legacy range) right
+	// before its return reboot; loadCfg honors ==0xA5 for that boot and consumes ANY nonzero (so a
+	// legacy value, or a sentinel stranded by flashing an old firmware between the fire and the consume,
+	// is scrubbed rather than read as an arm later). In FLASH, not .noinit, because this board class's
+	// bootloader wipes .noinit RAM on every reset.
 	// rxWin10: legacy RF tunable slot (window now fixed; ignored). lizKeep: the id9=0 hold enable (see
 	// haptics.h LIZKEEP_MS). landAll87: the verbatim-0x87-relay experiment toggle (haptics.h g_landAll87).
 	uint8_t rxWin10, lizKeep, landAll87;
@@ -180,10 +181,11 @@ void loadCfg()
 				consume = true;
 			}
 			// one-shot wake handoff: this boot follows a MODE_WAKE fire; honored (grace + fast RF
-			// bring-up) then consumed. Honor ==1 exactly (the only value the fire writes) but consume
-			// any nonzero so legacy rumble-era values in this byte are scrubbed, not resurrected.
+			// bring-up) then consumed. Honor the 0xA5 sentinel exactly -- this byte is the legacy
+			// rumble-strength slot (0..100), so a real legacy value can never fake an arm -- and
+			// consume any nonzero so stale values are scrubbed, not resurrected.
 			if (c.wakeHandoff != 0) {
-				g_wakeHandoffBoot = (c.wakeHandoff == 1);
+				g_wakeHandoffBoot = (c.wakeHandoff == 0xA5);
 				g_wakeHandoffArm = 0;
 				consume = true;
 			}

--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -19,10 +19,14 @@ uint8_t g_chordDpad[4] = { MODE_PS3, MODE_DS4_GAME, MODE_PS5_GAME,
 			   MODE_SW_HORI };
 bool g_persistMode = false;
 uint8_t g_bootMode = 0xFF;
-// One-shot post-wake-fire handoff (Cfg.wakeHandoff): arm = persisted by the wake fire's saveMode; boot =
+// One-shot post-wake-fire handoff (Cfg.wakeHandoff): arm = persisted by wakeHandoffMark's saveCfg; boot =
 // this boot came from a wake fire (consumed like bootMode/debugCdc so the next boot is normal).
 uint8_t g_wakeHandoffArm = 0;
 bool g_wakeHandoffBoot = false;
+// The mode saveCfg persists as Cfg.mode. Tracks the last REAL (non-wake) personality: while the live mode
+// is MODE_WAKE, any saveCfg (the loadCfg consume-save included) must not leak 10 into the persisted mode,
+// or persist-last-mode users would boot into the panel-less keyboard on every replug.
+static uint8_t g_modePersist = 0;
 
 bool g_debugCdcThisBoot = false;
 
@@ -96,10 +100,12 @@ uint32_t g_pollUs = POLL_US_DEFAULT;
 struct Cfg {
 	uint8_t magic, mode, mDiv, mFric, rsvd0, pollU100, persistMode,
 		bootMode, chordBtn[3], wakeHandoff;
-	// wakeHandoff: ex rumble-strength slot (same offset, so an existing cfg.bin still loads; old files
-	// hold 0 = unarmed). Now the one-shot post-wake-fire handoff arm: MODE_WAKE sets 1 right before its
-	// return reboot, loadCfg honors it for that boot and consumes it. In FLASH, not .noinit, because this
-	// board class's bootloader wipes .noinit RAM on every reset.
+	// wakeHandoff: ex rumble-strength slot (same offset and magic, so an existing cfg.bin still loads --
+	// which also means a pre-rework file can hold a live rumble VALUE here, not 0). Now the one-shot
+	// post-wake-fire handoff arm: MODE_WAKE sets exactly 1 right before its return reboot, loadCfg honors
+	// ==1 for that boot and consumes ANY nonzero (so a legacy value, or a 1 stranded by flashing an old
+	// firmware between the fire and the consume, is scrubbed rather than read as an arm later). In FLASH,
+	// not .noinit, because this board class's bootloader wipes .noinit RAM on every reset.
 	// rxWin10: legacy RF tunable slot (window now fixed; ignored). lizKeep: the id9=0 hold enable (see
 	// haptics.h LIZKEEP_MS). landAll87: the verbatim-0x87-relay experiment toggle (haptics.h g_landAll87).
 	uint8_t rxWin10, lizKeep, landAll87;
@@ -119,7 +125,7 @@ struct Cfg {
 void saveCfg()
 {
 	Cfg c = { CFG_MAGIC,
-		  g_usbMode,
+		  modeIsWake(g_usbMode) ? g_modePersist : g_usbMode,
 		  (uint8_t)g_mDiv,
 		  (uint8_t)g_mFric,
 		  g_debugCdc,
@@ -174,9 +180,10 @@ void loadCfg()
 				consume = true;
 			}
 			// one-shot wake handoff: this boot follows a MODE_WAKE fire; honored (grace + fast RF
-			// bring-up) then consumed. ==1 exactly: 0xFF here means a corrupt/short file, not an arm.
-			if (c.wakeHandoff == 1) {
-				g_wakeHandoffBoot = true;
+			// bring-up) then consumed. Honor ==1 exactly (the only value the fire writes) but consume
+			// any nonzero so legacy rumble-era values in this byte are scrubbed, not resurrected.
+			if (c.wakeHandoff != 0) {
+				g_wakeHandoffBoot = (c.wakeHandoff == 1);
 				g_wakeHandoffArm = 0;
 				consume = true;
 			}
@@ -194,6 +201,9 @@ void loadCfg()
 								     c.mode :
 								     0) :
 							    0;
+			// the persisted-mode slot must survive a trip through MODE_WAKE (see g_modePersist)
+			if (modeValid(c.mode) && !modeIsWake(c.mode))
+				g_modePersist = c.mode;
 			static const uint8_t CHORD_DEF[3] = { MODE_LIZARD,
 							      MODE_XBOX,
 							      MODE_SW_PRO };
@@ -238,8 +248,12 @@ void loadCfg()
 
 void saveMode(uint8_t m)
 {
-	if (g_persistMode) {
+	// MODE_WAKE is inherently transient (one wake, then back) -- it is ALWAYS a one-shot bootMode, even
+	// for persist-last-mode users, so the persisted personality is never overwritten by a wake trip and
+	// the fire's modeSwitchReboot(0xFF) return lands back in the user's own mode.
+	if (g_persistMode && !modeIsWake(m)) {
 		g_usbMode = m;
+		g_modePersist = m;
 		g_bootMode = 0xFF;
 	} else {
 		g_bootMode = m;

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -209,6 +209,12 @@ void swProSaveCfg();
 // enough to clear the dying controller's ~1 s F1 tail plus the 2.5 s post-disconnect cooldown, so a
 // retry can never transmit into the power-down window and re-wake it.
 #define SUSPEND_OFF_RETRY_MS 4000u
+// Reset-style shutdowns: some ECs RESET the bus when taking the port for S5 (observed on the M90q,
+// intermixed with suspend-style takeovers). A reset clears TinyUSB's connected state, so suspended()
+// never reads true again and the suspend-edge power-off above can never fire. "Was mounted, then the bus
+// died and stayed dead this long" is the equivalent signal -- long past any normal boot's ~10-20 s
+// re-enumeration gap, so it can never kill the controller during a reboot.
+#define SUSPEND_OFF_LOST_MS 30000u
 #define SUSPEND_OFF_RETRIES 2u
 // RF poll cadence (us). Defaults to POLL_US_DEFAULT; live-adjustable via the console "PR<hz>" command
 // (session-only -- NOT persisted; loadCfg always forces the default on boot) so the sweet spot can be

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -204,9 +204,11 @@ void swProSaveCfg();
 // (host idle power-management) resumes in <1s and must not trigger a self-inflicted power-off -> the
 // resulting disconnect/reconnect churn looked like random controller drops. Real host sleep persists.
 #define SUSPEND_OFF_MS 4000u
-// The suspend power-off relay is NO-ACK RF; if a controller is still linked this long after the off was
-// sent, the burst was lost -- resend, at most SUSPEND_OFF_RETRIES times.
-#define SUSPEND_OFF_RETRY_MS 2000u
+// The suspend power-off relay is NO-ACK RF; a controller still CONTINUOUSLY linked (no 0xF2 disconnect
+// seen) this long after the send missed the burst -- resend, at most SUSPEND_OFF_RETRIES times. Long
+// enough to clear the dying controller's ~1 s F1 tail plus the 2.5 s post-disconnect cooldown, so a
+// retry can never transmit into the power-down window and re-wake it.
+#define SUSPEND_OFF_RETRY_MS 4000u
 #define SUSPEND_OFF_RETRIES 2u
 // RF poll cadence (us). Defaults to POLL_US_DEFAULT; live-adjustable via the console "PR<hz>" command
 // (session-only -- NOT persisted; loadCfg always forces the default on boot) so the sweet spot can be

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -121,6 +121,9 @@ extern uint8_t g_chordDpad[4];
 // instead remembers the last selected mode across reboots.
 // false (default) = always boot Steam; true = boot into last mode
 extern bool g_persistMode;
+// one-shot post-wake-fire handoff flag (see Cfg.wakeHandoff in config.cpp)
+extern uint8_t g_wakeHandoffArm;
+extern bool g_wakeHandoffBoot;
 // one-shot: boot into this mode once then clear (!persistMode + explicit switch)
 extern uint8_t g_bootMode;
 

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -204,6 +204,10 @@ void swProSaveCfg();
 // (host idle power-management) resumes in <1s and must not trigger a self-inflicted power-off -> the
 // resulting disconnect/reconnect churn looked like random controller drops. Real host sleep persists.
 #define SUSPEND_OFF_MS 4000u
+// The suspend power-off relay is NO-ACK RF; if a controller is still linked this long after the off was
+// sent, the burst was lost -- resend, at most SUSPEND_OFF_RETRIES times.
+#define SUSPEND_OFF_RETRY_MS 2000u
+#define SUSPEND_OFF_RETRIES 2u
 // RF poll cadence (us). Defaults to POLL_US_DEFAULT; live-adjustable via the console "PR<hz>" command
 // (session-only -- NOT persisted; loadCfg always forces the default on boot) so the sweet spot can be
 // swept on hardware while watching the delivered report rate.

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -41,7 +41,12 @@
 // console wants a bare Sixaxis HID, not a composite). Answers the PS3's GET_REPORT(0xF2/0xF5/0xEF/0x01)
 // enable handshake. + gyro/accel + rumble.
 #define MODE_PS3 9
-#define MODE_MAX 9
+// Boot-keyboard-only wake personality: sends the firmware smart-power-on hotkey (Alt+P on Lenovo
+// ThinkCentre) when a controller connects, then reboots into WAKE_RETURN_MODE. Presents a single clean HID
+// keyboard -- no wake mouse, no WebUSB, no CDC -- because the EC that watches this port while the machine
+// is in S5 runs a minimal USB stack. See mode_wake.h.
+#define MODE_WAKE 10
+#define MODE_MAX 10
 
 // The two "game" personalities drop the wake-mouse + WebUSB interfaces so the device is a genuine single-HID PS
 // controller (some PC games -- e.g. Fortnite/UE GameInput -- refuse PS classification when extra interfaces are
@@ -49,6 +54,13 @@
 static inline bool modeIsCleanPS(uint8_t m)
 {
 	return m == MODE_PS5_GAME || m == MODE_DS4_GAME || m == MODE_PS3;
+}
+
+// Wake mode is a one-shot utility personality, not a controller: it forwards no input and enumerates as a
+// bare keyboard, so setup() gates it out of the wake-mouse / WebUSB interfaces like the clean-PS modes.
+static inline bool modeIsWake(uint8_t m)
+{
+	return m == MODE_WAKE;
 }
 
 static inline bool modeIsPuck(uint8_t m)

--- a/OpenPuck/controllers.cpp
+++ b/OpenPuck/controllers.cpp
@@ -7,6 +7,7 @@
 #include "mode_ps5.h"
 #include "mode_hidgyro.h"
 #include "mode_ps3.h"
+#include "mode_wake.h"
 
 IController *g_active = nullptr;
 
@@ -39,6 +40,8 @@ IController *controllerFor(uint8_t mode)
 		return &g_hidGyroCtl;
 	case MODE_PS3:
 		return &g_ps3Ctl;
+	case MODE_WAKE:
+		return &g_wakeCtl;
 	default:
 		return &g_steamPuck;
 	}

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -6,6 +6,7 @@
 #include "puck_hid.h" // puckLizardActive() -- gate the lizard-suppression keepalive
 
 #include "fault_diag.h" // faultDiagTrace() -- flight recorder
+#include "mode_wake.h" // wakeHandoffActive() -- post-fire boot grace
 // USBDevice.suspended() -> autonomous controller power-off on host sleep
 #include <Adafruit_TinyUSB.h>
 #include <Arduino.h>
@@ -744,7 +745,17 @@ void hapticTask()
 			faultDiagTrace(FR_RESUME, 0);
 		suspArmed = false;
 	}
-	if (suspArmed && vbus && (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
+	// Two wake-flow windows where "suspend persisted" does NOT mean "host went to sleep" and firing here
+	// kills the controller that just triggered the wake (the double-power-on symptom):
+	//   - MODE_WAKE itself: the EC hands the port to the chipset the moment the hotkey lands, so the bus
+	//     suspends WHILE the press sequence is still running. A down/POSTing host is this mode's normal
+	//     operating environment -- never auto-off here.
+	//   - the post-fire return boot: POST has not enumerated the reborn puck yet. The handoff grace
+	//     resolves when a host mounts us or after WAKE_HANDOFF_GRACE_MS; if the machine truly never
+	//     boots, the timer keeps running and this fires then -- the battery still gets saved.
+	if (suspArmed && vbus && !modeIsWake(g_usbMode) &&
+	    !wakeHandoffActive() &&
+	    (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
 		hapticSendShutdown();
 		suspArmed = false; // fire once per suspend
 	}

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -732,6 +732,8 @@ void hapticTask()
 	static bool wasSusp = true;
 	static unsigned long suspSinceMs = 0;
 	static bool suspArmed = false;
+	static unsigned long s_offSentMs = 0;
+	static uint8_t s_offRetries = 0;
 	bool susp = USBDevice.suspended();
 	bool vbus = (NRF_POWER->USBREGSTATUS &
 		     POWER_USBREGSTATUS_VBUSDETECT_Msk) != 0;
@@ -758,6 +760,23 @@ void hapticTask()
 	    (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
 		hapticSendShutdown();
 		suspArmed = false; // fire once per suspend
+		// The off relay is a NO-ACK burst of HAPTIC_SHUTDOWN_SHOTS packets inside ~10 ms -- one bad
+		// RF moment loses all of them and the controller stays on all night (observed once on the
+		// M90q). A controller that actually received it drops its link within a second, so "still
+		// linked a while later" IS the missed-delivery signal; resend a bounded number of times.
+		s_offSentMs = millis();
+		s_offRetries = SUSPEND_OFF_RETRIES;
+	}
+	if (s_offRetries &&
+	    (unsigned long)(millis() - s_offSentMs) >= SUSPEND_OFF_RETRY_MS) {
+		if (susp && vbus && anySlotLinkUp()) {
+			hapticSendShutdown();
+			s_offSentMs = millis();
+			s_offRetries--;
+		} else {
+			s_offRetries =
+				0; // delivered (link down) or host came back
+		}
 	}
 	// Never-booted fallback: a failed wake's return boot never gets a SETUP packet, and TinyUSB only
 	// reports suspend on a CONNECTED bus -- so neither the suspArmed edge above nor suspended() itself

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -759,15 +759,14 @@ void hapticTask()
 		hapticSendShutdown();
 		suspArmed = false; // fire once per suspend
 	}
-	// Never-booted fallback: the grace boot lands on an ALREADY-suspended bus (machine off / POST hung),
-	// so the false->true edge above never arms. When the grace expires with the bus still suspended
-	// since boot, power the controller off once -- the wake failed; save its battery.
+	// Never-booted fallback: a failed wake's return boot never gets a SETUP packet, and TinyUSB only
+	// reports suspend on a CONNECTED bus -- so neither the suspArmed edge above nor suspended() itself
+	// can see that state. "Handoff grace expired and no host ever configured us" is the workable
+	// signal: a machine that actually booted mounts the puck long before the 90 s grace runs out.
 	{
-		static bool bootSusp = true;
 		static bool expiredFired = false;
-		if (!susp)
-			bootSusp = false;
-		if (bootSusp && vbus && !expiredFired && wakeHandoffExpired()) {
+		if (!expiredFired && vbus && !USBDevice.mounted() &&
+		    wakeHandoffExpired()) {
 			hapticSendShutdown();
 			expiredFired = true;
 		}

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -761,66 +761,87 @@ void hapticTask()
 		hapticSendShutdown();
 		suspArmed = false; // fire once per suspend
 		// The off relay is a NO-ACK burst of HAPTIC_SHUTDOWN_SHOTS packets inside ~10 ms -- one bad
-		// RF moment loses all of them and the controller stays on all night (observed once on the
-		// M90q). A controller that actually received it drops its link within a second, so "still
-		// linked a while later" IS the missed-delivery signal; resend a bounded number of times.
-		s_offSentMs = millis();
-		s_offRetries = SUSPEND_OFF_RETRIES;
+		// RF moment loses all of them and the controller stays on all night. Arm retries only if a
+		// controller was actually linked at the send: an off broadcast into vacuum needs no retry,
+		// and a pending retry must never target a controller that connects LATER (that connect is
+		// the wake gesture or a fresh session, not a missed delivery).
+		if (anySlotLinkUp()) {
+			s_offSentMs = millis();
+			s_offRetries = SUSPEND_OFF_RETRIES;
+		}
 	}
 	// Reset-style shutdown fallback (SUSPEND_OFF_LOST_MS): some EC takeovers RESET the bus instead of
 	// suspending it; that clears TinyUSB's connected state, so suspended() never reads true again and
 	// the suspend-edge path above cannot fire. "Was mounted, then the bus died and stayed dead 30 s"
-	// is the equivalent signal -- far past a normal boot's re-enumeration gap. Latched per loss.
+	// is the equivalent signal -- far past a normal boot's re-enumeration gap. EDGE-triggered: the
+	// decision is made exactly once, when the 30 s deadline passes -- a controller powered on hours
+	// into the dead-bus night must not be executed on sight by stale state.
 	{
 		static bool everMounted = false;
 		static unsigned long lostMs = 0;
-		static bool lostFired = false;
+		static bool lostChecked = false;
 		if (USBDevice.mounted()) {
 			everMounted = true;
 			lostMs = 0;
-			lostFired = false;
+			lostChecked = false;
 		} else if (everMounted && !susp) {
 			if (!lostMs)
 				lostMs = millis();
-			if (!lostFired && vbus && !wakeFireInFlight() &&
-			    !wakeHandoffActive() && anySlotLinkUp() &&
+			if (!lostChecked &&
 			    (unsigned long)(millis() - lostMs) >=
 				    SUSPEND_OFF_LOST_MS) {
-				hapticSendShutdown();
-				lostFired = true;
-				s_offSentMs = millis();
-				s_offRetries = SUSPEND_OFF_RETRIES;
+				lostChecked = true;
+				if (vbus && !wakeFireInFlight() &&
+				    !wakeHandoffActive() && anySlotLinkUp()) {
+					hapticSendShutdown();
+					s_offSentMs = millis();
+					s_offRetries = SUSPEND_OFF_RETRIES;
+				}
 			}
 		}
 	}
+	// Retries are PER-SLOT: at SUSPEND_OFF_RETRY_MS after a send the post-off F1 tail (<1 s) is long
+	// over, so a slot still linked missed the burst and a slot whose link dropped received it -- the
+	// link itself is the per-controller delivery receipt (the global g_connCooldown 0xF2 stamp cannot
+	// attribute receipts with two controllers, and its 0-means-idle sentinel breaks the comparison on
+	// multi-week uptimes). Slot-targeted resends never re-enter a delivered controller's power-down,
+	// and the wake-flow exemptions match the initial-fire paths so a retry can never execute the
+	// controller whose connect is the wake gesture.
 	if (s_offRetries &&
 	    (unsigned long)(millis() - s_offSentMs) >= SUSPEND_OFF_RETRY_MS) {
-		// Retry ONLY a controller that is provably still alive: continuously linked AND no 0xF2
-		// disconnect since the send (g_connCooldown timestamps the 0xF2). A dying controller's F1
-		// tail can hold anySlotLinkUp() true past the send, and a retry volley's poll+relay TX into
-		// that power-down window RE-WAKES it -- the exact hazard the post-disconnect cooldown
-		// exists to avoid.
-		bool discSinceSend = (long)(g_connCooldown - s_offSentMs) >= 0;
+		bool resent = false;
 		bool hostDown = susp || !USBDevice.mounted();
-		if (hostDown && vbus && anySlotLinkUp() && !discSinceSend) {
-			hapticSendShutdown();
+		if (hostDown && vbus && !wakeFireInFlight() &&
+		    !wakeHandoffActive()) {
+			for (int rs = 0; rs < NSLOT; rs++)
+				if (g_slot[rs].used && g_connReplyMs[rs] != 0 &&
+				    millis() - g_connReplyMs[rs] < 300) {
+					hapticSendShutdown((uint8_t)rs);
+					resent = true;
+				}
+		}
+		if (resent) {
 			s_offSentMs = millis();
 			s_offRetries--;
 		} else {
-			s_offRetries =
-				0; // delivered (0xF2/link down) or host back
+			s_offRetries = 0; // all delivered, or host came back
 		}
 	}
 	// Never-booted fallback: a failed wake's return boot never gets a SETUP packet, and TinyUSB only
 	// reports suspend on a CONNECTED bus -- so neither the suspArmed edge above nor suspended() itself
-	// can see that state. "Handoff grace expired and no host ever configured us" is the workable
-	// signal: a machine that actually booted mounts the puck long before the 90 s grace runs out.
+	// can see that state. Gated on the bus NEVER having mounted THIS BOOT: on a successful wake the
+	// grace also expires (early-end) and a later transient unmount -- usbReenumerate's detach window,
+	// a warm reboot, an S3 resume reset -- must not detonate a stale broadcast mid-session.
 	{
+		static bool fbEverMounted = false;
 		static bool expiredFired = false;
-		if (!expiredFired && vbus && !USBDevice.mounted() &&
+		if (USBDevice.mounted())
+			fbEverMounted = true;
+		if (!expiredFired && !fbEverMounted && vbus &&
 		    wakeHandoffExpired()) {
-			hapticSendShutdown();
 			expiredFired = true;
+			if (anySlotLinkUp())
+				hapticSendShutdown();
 		}
 	}
 	wasSusp = susp;

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -734,6 +734,8 @@ void hapticTask()
 	static bool suspArmed = false;
 	static unsigned long s_offSentMs = 0;
 	static uint8_t s_offRetries = 0;
+	static uint8_t s_offMask =
+		0; // slots linked at the last off send, minus down edges since
 	bool susp = USBDevice.suspended();
 	bool vbus = (NRF_POWER->USBREGSTATUS &
 		     POWER_USBREGSTATUS_VBUSDETECT_Msk) != 0;
@@ -756,92 +758,118 @@ void hapticTask()
 	//     mode arm at all.
 	//   - the post-fire return boot: POST has not enumerated the reborn puck yet; hold through the
 	//     handoff grace (deadline-only -- see mode_wake.h).
-	if (suspArmed && vbus && !wakeFireInFlight() && !wakeHandoffActive() &&
-	    (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
-		hapticSendShutdown();
-		suspArmed = false; // fire once per suspend
-		// The off relay is a NO-ACK burst of HAPTIC_SHUTDOWN_SHOTS packets inside ~10 ms -- one bad
-		// RF moment loses all of them and the controller stays on all night. Arm retries only if a
-		// controller was actually linked at the send: an off broadcast into vacuum needs no retry,
-		// and a pending retry must never target a controller that connects LATER (that connect is
-		// the wake gesture or a fresh session, not a missed delivery).
-		if (anySlotLinkUp()) {
-			s_offSentMs = millis();
-			s_offRetries = SUSPEND_OFF_RETRIES;
-		}
-	}
-	// Reset-style shutdown fallback (SUSPEND_OFF_LOST_MS): some EC takeovers RESET the bus instead of
-	// suspending it; that clears TinyUSB's connected state, so suspended() never reads true again and
-	// the suspend-edge path above cannot fire. "Was mounted, then the bus died and stayed dead 30 s"
-	// is the equivalent signal -- far past a normal boot's re-enumeration gap. EDGE-triggered: the
-	// decision is made exactly once, when the 30 s deadline passes -- a controller powered on hours
-	// into the dead-bus night must not be executed on sight by stale state.
+	// ---- suspend/lost-bus power-off + per-slot retry bookkeeping ---------------------------------
+	// Every off send SNAPSHOTS which slots were linked at that moment (s_offMask). A slot leaves the
+	// mask the moment its link drops (the off was delivered -- or the slot vanished, in which case a
+	// resend is moot); a retry may only target a slot that was linked at the send AND has been linked
+	// continuously since. A controller that connects LATER -- the wake gesture, or one the user just
+	// re-powered after the off -- was never in the mask and can never be targeted; a slot that drops
+	// and relinks left the mask at the drop. Interference that drops a link without delivery reads as
+	// delivered and the controller stays on: the safe failure (battery) over the harmful one.
 	{
-		static bool everMounted = false;
-		static unsigned long lostMs = 0;
-		static bool lostChecked = false;
-		if (USBDevice.mounted()) {
-			everMounted = true;
-			lostMs = 0;
-			lostChecked = false;
-		} else if (everMounted && !susp) {
-			if (!lostMs)
-				lostMs = millis();
-			if (!lostChecked &&
-			    (unsigned long)(millis() - lostMs) >=
-				    SUSPEND_OFF_LOST_MS) {
-				lostChecked = true;
-				if (vbus && !wakeFireInFlight() &&
-				    !wakeHandoffActive() && anySlotLinkUp()) {
-					hapticSendShutdown();
-					s_offSentMs = millis();
-					s_offRetries = SUSPEND_OFF_RETRIES;
+		static uint8_t prevLinked = 0;
+		uint8_t linked = 0;
+		for (int ls = 0; ls < NSLOT; ls++)
+			if (g_slot[ls].used && g_connReplyMs[ls] != 0 &&
+			    millis() - g_connReplyMs[ls] < 300)
+				linked |= (uint8_t)(1u << ls);
+		s_offMask &= (uint8_t) ~(prevLinked &
+					 ~linked); // down edges leave the mask
+		prevLinked = linked;
+		// Suspend-edge off (host went to sleep / suspend-style shutdown).
+		if (suspArmed && vbus && !wakeFireInFlight() &&
+		    !wakeHandoffActive() &&
+		    (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
+			hapticSendShutdown();
+			suspArmed = false; // fire once per suspend
+			s_offMask = linked;
+			s_offSentMs = millis();
+			s_offRetries = linked ? SUSPEND_OFF_RETRIES : 0;
+		}
+		// Reset-style shutdown off (SUSPEND_OFF_LOST_MS): some EC takeovers RESET the bus instead
+		// of suspending; connected clears, so suspended() never reads true and the edge path above
+		// cannot fire. "Was mounted, then the bus stayed dead" is the equivalent signal. The
+		// decision holds a RE-CHECK WINDOW (deadline .. +SUSPEND_OFF_RETRY_MS) rather than one
+		// sample instant, and the one-shot is only consumed once the decision was actually
+		// takeable -- a deadline spent inside the handoff grace or a fire sequence, or a transient
+		// reply gap at one instant, must not forfeit the episode's only off.
+		{
+			static bool everMounted = false;
+			static unsigned long lostMs = 0;
+			static bool lostDone = false;
+			if (USBDevice.mounted()) {
+				everMounted = true;
+				lostMs = 0;
+				lostDone = false;
+			} else if (everMounted && !susp) {
+				if (!lostMs)
+					lostMs = millis();
+				unsigned long since = millis() - lostMs;
+				if (!lostDone && since >= SUSPEND_OFF_LOST_MS &&
+				    !wakeFireInFlight() &&
+				    !wakeHandoffActive()) {
+					if (vbus && linked) {
+						hapticSendShutdown();
+						lostDone = true;
+						s_offMask = linked;
+						s_offSentMs = millis();
+						s_offRetries =
+							SUSPEND_OFF_RETRIES;
+					} else if (since >=
+						   SUSPEND_OFF_LOST_MS +
+							   SUSPEND_OFF_RETRY_MS) {
+						lostDone =
+							true; // window closed
+					}
 				}
 			}
 		}
-	}
-	// Retries are PER-SLOT: at SUSPEND_OFF_RETRY_MS after a send the post-off F1 tail (<1 s) is long
-	// over, so a slot still linked missed the burst and a slot whose link dropped received it -- the
-	// link itself is the per-controller delivery receipt (the global g_connCooldown 0xF2 stamp cannot
-	// attribute receipts with two controllers, and its 0-means-idle sentinel breaks the comparison on
-	// multi-week uptimes). Slot-targeted resends never re-enter a delivered controller's power-down,
-	// and the wake-flow exemptions match the initial-fire paths so a retry can never execute the
-	// controller whose connect is the wake gesture.
-	if (s_offRetries &&
-	    (unsigned long)(millis() - s_offSentMs) >= SUSPEND_OFF_RETRY_MS) {
-		bool resent = false;
-		bool hostDown = susp || !USBDevice.mounted();
-		if (hostDown && vbus && !wakeFireInFlight() &&
-		    !wakeHandoffActive()) {
-			for (int rs = 0; rs < NSLOT; rs++)
-				if (g_slot[rs].used && g_connReplyMs[rs] != 0 &&
-				    millis() - g_connReplyMs[rs] < 300) {
-					hapticSendShutdown((uint8_t)rs);
-					resent = true;
+		// Never-booted fallback: a failed wake's return boot never gets a SETUP packet, so neither
+		// mounted() nor suspended() can ever read true and both paths above are dead. Fires in a
+		// re-check window after the grace expires, only if the bus never mounted THIS boot -- on a
+		// successful wake a later transient unmount must not detonate a stale broadcast.
+		{
+			static bool fbEverMounted = false;
+			static bool fbDone = false;
+			static unsigned long fbExpiredMs = 0;
+			if (USBDevice.mounted())
+				fbEverMounted = true;
+			if (!fbDone && !fbEverMounted && wakeHandoffExpired()) {
+				if (!fbExpiredMs)
+					fbExpiredMs = millis();
+				if (vbus && linked) {
+					hapticSendShutdown();
+					fbDone = true;
+					s_offMask = linked;
+					s_offSentMs = millis();
+					s_offRetries = SUSPEND_OFF_RETRIES;
+				} else if ((unsigned long)(millis() -
+							   fbExpiredMs) >=
+					   SUSPEND_OFF_RETRY_MS) {
+					fbDone = true; // window closed
 				}
+			}
 		}
-		if (resent) {
-			s_offSentMs = millis();
-			s_offRetries--;
-		} else {
-			s_offRetries = 0; // all delivered, or host came back
-		}
-	}
-	// Never-booted fallback: a failed wake's return boot never gets a SETUP packet, and TinyUSB only
-	// reports suspend on a CONNECTED bus -- so neither the suspArmed edge above nor suspended() itself
-	// can see that state. Gated on the bus NEVER having mounted THIS BOOT: on a successful wake the
-	// grace also expires (early-end) and a later transient unmount -- usbReenumerate's detach window,
-	// a warm reboot, an S3 resume reset -- must not detonate a stale broadcast mid-session.
-	{
-		static bool fbEverMounted = false;
-		static bool expiredFired = false;
-		if (USBDevice.mounted())
-			fbEverMounted = true;
-		if (!expiredFired && !fbEverMounted && vbus &&
-		    wakeHandoffExpired()) {
-			expiredFired = true;
-			if (anySlotLinkUp())
-				hapticSendShutdown();
+		// Per-slot retries: at SUSPEND_OFF_RETRY_MS after a send the post-off F1 tail (<1 s) is
+		// long over, so a mask slot still continuously linked missed its burst -- resend to exactly
+		// those slots. Wake-flow exemptions match the fire paths.
+		if (s_offRetries && s_offMask &&
+		    (unsigned long)(millis() - s_offSentMs) >=
+			    SUSPEND_OFF_RETRY_MS) {
+			bool hostDown = susp || !USBDevice.mounted();
+			uint8_t targets = (uint8_t)(s_offMask & linked);
+			if (hostDown && vbus && !wakeFireInFlight() &&
+			    !wakeHandoffActive() && targets) {
+				for (int rs = 0; rs < NSLOT; rs++)
+					if (targets & (1u << rs))
+						hapticSendShutdown((uint8_t)rs);
+				s_offSentMs = millis();
+				s_offRetries--;
+			} else {
+				// no targets (every masked slot dropped: delivered), or the
+				// host came back / the wake flow owns the bus
+				s_offRetries = 0;
+			}
 		}
 	}
 	wasSusp = susp;

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -767,15 +767,48 @@ void hapticTask()
 		s_offSentMs = millis();
 		s_offRetries = SUSPEND_OFF_RETRIES;
 	}
+	// Reset-style shutdown fallback (SUSPEND_OFF_LOST_MS): some EC takeovers RESET the bus instead of
+	// suspending it; that clears TinyUSB's connected state, so suspended() never reads true again and
+	// the suspend-edge path above cannot fire. "Was mounted, then the bus died and stayed dead 30 s"
+	// is the equivalent signal -- far past a normal boot's re-enumeration gap. Latched per loss.
+	{
+		static bool everMounted = false;
+		static unsigned long lostMs = 0;
+		static bool lostFired = false;
+		if (USBDevice.mounted()) {
+			everMounted = true;
+			lostMs = 0;
+			lostFired = false;
+		} else if (everMounted && !susp) {
+			if (!lostMs)
+				lostMs = millis();
+			if (!lostFired && vbus && !wakeFireInFlight() &&
+			    !wakeHandoffActive() && anySlotLinkUp() &&
+			    (unsigned long)(millis() - lostMs) >=
+				    SUSPEND_OFF_LOST_MS) {
+				hapticSendShutdown();
+				lostFired = true;
+				s_offSentMs = millis();
+				s_offRetries = SUSPEND_OFF_RETRIES;
+			}
+		}
+	}
 	if (s_offRetries &&
 	    (unsigned long)(millis() - s_offSentMs) >= SUSPEND_OFF_RETRY_MS) {
-		if (susp && vbus && anySlotLinkUp()) {
+		// Retry ONLY a controller that is provably still alive: continuously linked AND no 0xF2
+		// disconnect since the send (g_connCooldown timestamps the 0xF2). A dying controller's F1
+		// tail can hold anySlotLinkUp() true past the send, and a retry volley's poll+relay TX into
+		// that power-down window RE-WAKES it -- the exact hazard the post-disconnect cooldown
+		// exists to avoid.
+		bool discSinceSend = (long)(g_connCooldown - s_offSentMs) >= 0;
+		bool hostDown = susp || !USBDevice.mounted();
+		if (hostDown && vbus && anySlotLinkUp() && !discSinceSend) {
 			hapticSendShutdown();
 			s_offSentMs = millis();
 			s_offRetries--;
 		} else {
 			s_offRetries =
-				0; // delivered (link down) or host came back
+				0; // delivered (0xF2/link down) or host back
 		}
 	}
 	// Never-booted fallback: a failed wake's return boot never gets a SETUP packet, and TinyUSB only

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -747,17 +747,30 @@ void hapticTask()
 	}
 	// Two wake-flow windows where "suspend persisted" does NOT mean "host went to sleep" and firing here
 	// kills the controller that just triggered the wake (the double-power-on symptom):
-	//   - MODE_WAKE itself: the EC hands the port to the chipset the moment the hotkey lands, so the bus
-	//     suspends WHILE the press sequence is still running. A down/POSTing host is this mode's normal
-	//     operating environment -- never auto-off here.
-	//   - the post-fire return boot: POST has not enumerated the reborn puck yet. The handoff grace
-	//     resolves when a host mounts us or after WAKE_HANDOFF_GRACE_MS; if the machine truly never
-	//     boots, the timer keeps running and this fires then -- the battery still gets saved.
-	if (suspArmed && vbus && !modeIsWake(g_usbMode) &&
-	    !wakeHandoffActive() &&
+	//   - a press sequence in flight (wakeFireInFlight): the EC hands the port to the chipset the moment
+	//     the hotkey lands, so the bus suspends WHILE the sequence is still running. Only the in-flight
+	//     window is exempt -- in W_WAIT_DOWN/W_ARMED this power-off is still wanted: it is both the
+	//     battery saver AND what quiets the link so a controller left on across a shutdown lets the
+	//     mode arm at all.
+	//   - the post-fire return boot: POST has not enumerated the reborn puck yet; hold through the
+	//     handoff grace (deadline-only -- see mode_wake.h).
+	if (suspArmed && vbus && !wakeFireInFlight() && !wakeHandoffActive() &&
 	    (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
 		hapticSendShutdown();
 		suspArmed = false; // fire once per suspend
+	}
+	// Never-booted fallback: the grace boot lands on an ALREADY-suspended bus (machine off / POST hung),
+	// so the false->true edge above never arms. When the grace expires with the bus still suspended
+	// since boot, power the controller off once -- the wake failed; save its battery.
+	{
+		static bool bootSusp = true;
+		static bool expiredFired = false;
+		if (!susp)
+			bootSusp = false;
+		if (bootSusp && vbus && !expiredFired && wakeHandoffExpired()) {
+			hapticSendShutdown();
+			expiredFired = true;
+		}
 	}
 	wasSusp = susp;
 	// Steam-mode quiet timeout: mark 0x82 stream inactive. No synthesized stop -- Steam forwards its own.

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -72,6 +72,21 @@ void hapticSendShutdown(uint8_t slot)
 	puckNotePowerOff(slot);
 }
 
+// ---- suspend/lost-bus power-off retry state (see the off region in hapticTask) -----------------------
+// Every off send snapshots the currently-linked slots; a down edge removes a slot (delivered); retries
+// target exactly mask-and-still-linked. Centralized in offArm() so a future off path CANNOT forget the
+// snapshot -- per-site ad-hoc copies of this state are precisely how earlier review rounds' bugs arose.
+static unsigned long g_offSentMs = 0;
+static uint8_t g_offRetries = 0;
+static uint8_t g_offMask =
+	0; // slots linked at the last off send, minus down edges since
+static void offArm(uint8_t linkedMask)
+{
+	g_offMask = linkedMask;
+	g_offSentMs = millis();
+	g_offRetries = SUSPEND_OFF_RETRIES;
+}
+
 // millis of last 0x82 haptic OUTPUT relayed (Steam mode)
 static unsigned long g_haptic82Ms = 0;
 
@@ -732,10 +747,6 @@ void hapticTask()
 	static bool wasSusp = true;
 	static unsigned long suspSinceMs = 0;
 	static bool suspArmed = false;
-	static unsigned long s_offSentMs = 0;
-	static uint8_t s_offRetries = 0;
-	static uint8_t s_offMask =
-		0; // slots linked at the last off send, minus down edges since
 	bool susp = USBDevice.suspended();
 	bool vbus = (NRF_POWER->USBREGSTATUS &
 		     POWER_USBREGSTATUS_VBUSDETECT_Msk) != 0;
@@ -759,7 +770,7 @@ void hapticTask()
 	//   - the post-fire return boot: POST has not enumerated the reborn puck yet; hold through the
 	//     handoff grace (deadline-only -- see mode_wake.h).
 	// ---- suspend/lost-bus power-off + per-slot retry bookkeeping ---------------------------------
-	// Every off send SNAPSHOTS which slots were linked at that moment (s_offMask). A slot leaves the
+	// Every off send SNAPSHOTS which slots were linked at that moment (g_offMask). A slot leaves the
 	// mask the moment its link drops (the off was delivered -- or the slot vanished, in which case a
 	// resend is moot); a retry may only target a slot that was linked at the send AND has been linked
 	// continuously since. A controller that connects LATER -- the wake gesture, or one the user just
@@ -769,11 +780,14 @@ void hapticTask()
 	{
 		static uint8_t prevLinked = 0;
 		uint8_t linked = 0;
+		// Deliberately NOT hapticLinkUp(): that helper lacks the != 0 guard, and a used-but-never-
+		// replied slot must not read linked in the first 300 ms of uptime (it would seed the mask
+		// with phantom slots). Same 300 ms recency window as anySlotLinkUp().
 		for (int ls = 0; ls < NSLOT; ls++)
 			if (g_slot[ls].used && g_connReplyMs[ls] != 0 &&
 			    millis() - g_connReplyMs[ls] < 300)
 				linked |= (uint8_t)(1u << ls);
-		s_offMask &= (uint8_t) ~(prevLinked &
+		g_offMask &= (uint8_t) ~(prevLinked &
 					 ~linked); // down edges leave the mask
 		prevLinked = linked;
 		// Suspend-edge off (host went to sleep / suspend-style shutdown).
@@ -782,9 +796,7 @@ void hapticTask()
 		    (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
 			hapticSendShutdown();
 			suspArmed = false; // fire once per suspend
-			s_offMask = linked;
-			s_offSentMs = millis();
-			s_offRetries = linked ? SUSPEND_OFF_RETRIES : 0;
+			offArm(linked);
 		}
 		// Reset-style shutdown off (SUSPEND_OFF_LOST_MS): some EC takeovers RESET the bus instead
 		// of suspending; connected clears, so suspended() never reads true and the edge path above
@@ -796,28 +808,35 @@ void hapticTask()
 		{
 			static bool everMounted = false;
 			static unsigned long lostMs = 0;
+			static unsigned long lostOpenMs = 0;
 			static bool lostDone = false;
 			if (USBDevice.mounted()) {
 				everMounted = true;
 				lostMs = 0;
+				lostOpenMs = 0;
 				lostDone = false;
 			} else if (everMounted && !susp) {
 				if (!lostMs)
 					lostMs = millis();
-				unsigned long since = millis() - lostMs;
-				if (!lostDone && since >= SUSPEND_OFF_LOST_MS &&
+				// The re-check window is anchored at the first pass where the
+				// gates are actually OPEN (like the fallback's fbExpiredMs),
+				// not at lostMs: a deadline that elapses while the handoff
+				// grace holds the gates shut must still get its full window
+				// at gate-open, not a degenerate single-instant sample.
+				if (!lostDone &&
+				    (unsigned long)(millis() - lostMs) >=
+					    SUSPEND_OFF_LOST_MS &&
 				    !wakeFireInFlight() &&
 				    !wakeHandoffActive()) {
+					if (!lostOpenMs)
+						lostOpenMs = millis();
 					if (vbus && linked) {
 						hapticSendShutdown();
 						lostDone = true;
-						s_offMask = linked;
-						s_offSentMs = millis();
-						s_offRetries =
-							SUSPEND_OFF_RETRIES;
-					} else if (since >=
-						   SUSPEND_OFF_LOST_MS +
-							   SUSPEND_OFF_RETRY_MS) {
+						offArm(linked);
+					} else if ((unsigned long)(millis() -
+								   lostOpenMs) >=
+						   SUSPEND_OFF_RETRY_MS) {
 						lostDone =
 							true; // window closed
 					}
@@ -840,9 +859,7 @@ void hapticTask()
 				if (vbus && linked) {
 					hapticSendShutdown();
 					fbDone = true;
-					s_offMask = linked;
-					s_offSentMs = millis();
-					s_offRetries = SUSPEND_OFF_RETRIES;
+					offArm(linked);
 				} else if ((unsigned long)(millis() -
 							   fbExpiredMs) >=
 					   SUSPEND_OFF_RETRY_MS) {
@@ -853,22 +870,25 @@ void hapticTask()
 		// Per-slot retries: at SUSPEND_OFF_RETRY_MS after a send the post-off F1 tail (<1 s) is
 		// long over, so a mask slot still continuously linked missed its burst -- resend to exactly
 		// those slots. Wake-flow exemptions match the fire paths.
-		if (s_offRetries && s_offMask &&
-		    (unsigned long)(millis() - s_offSentMs) >=
+		if (g_offRetries && g_offMask &&
+		    (unsigned long)(millis() - g_offSentMs) >=
 			    SUSPEND_OFF_RETRY_MS) {
 			bool hostDown = susp || !USBDevice.mounted();
-			uint8_t targets = (uint8_t)(s_offMask & linked);
+			// After the top-of-pass down-edge clear, g_offMask is provably a
+			// subset of `linked`; the & is kept as cheap armor, not a filter.
+			uint8_t targets = (uint8_t)(g_offMask & linked);
 			if (hostDown && vbus && !wakeFireInFlight() &&
 			    !wakeHandoffActive() && targets) {
 				for (int rs = 0; rs < NSLOT; rs++)
 					if (targets & (1u << rs))
 						hapticSendShutdown((uint8_t)rs);
-				s_offSentMs = millis();
-				s_offRetries--;
+				g_offSentMs = millis();
+				g_offRetries--;
 			} else {
-				// no targets (every masked slot dropped: delivered), or the
-				// host came back / the wake flow owns the bus
-				s_offRetries = 0;
+				// host came back, vbus dropped, or the wake flow owns the
+				// bus (an emptied mask cannot reach here: the outer gate
+				// requires it nonzero)
+				g_offRetries = 0;
 			}
 		}
 	}

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -231,6 +231,20 @@ bool wakeFireInFlight()
 // "no mode switch while suspended" convention the chord + console paths follow: their rule exists so a
 // SLEEPING host never resumes to find a different device, and here a long suspend meaning "the host is
 // down" is the entire premise.
+#if WAKE_AUTO_REARM
+// The one device-visible difference between "asleep" and "off": an OS entering S3/s2idle arms
+// DEVICE_REMOTE_WAKEUP on wakeup-enabled devices BEFORE suspending (the existing wake-from-S3 path only
+// works because it does), while a shutdown never sets the feature. TinyUSB samples the flag at each
+// suspend edge and hands it to this weak callback (nothing else in the core claims it). A host that has
+// wakeup disabled for the device sends no SET_FEATURE, so its sleep reads as a shutdown -- that just
+// degrades to the old always-re-arm behavior, documented in WAKE_MODE.md.
+static volatile bool s_suspWkArmed = false;
+extern "C" void tud_suspend_cb(bool remote_wakeup_en)
+{
+	s_suspWkArmed = remote_wakeup_en;
+}
+#endif
+
 void wakeAutoRearmTask()
 {
 #if WAKE_AUTO_REARM
@@ -245,6 +259,11 @@ void wakeAutoRearmTask()
 		downAt = millis();
 	wasSusp = susp;
 	if (!susp || modeIsWake(g_usbMode))
+		return;
+	// Host armed remote wakeup for this suspend => it is SLEEPING and expects to find the puck on
+	// resume; do not swap in the keyboard. (A boot into an already-suspended bus never saw a
+	// SET_FEATURE, so the flag is false and the plugged-into-a-dead-host re-arm still works.)
+	if (s_suspWkArmed)
 		return;
 	if (millis() - downAt >= WAKE_AUTO_REARM_MS)
 		modeSwitchReboot(MODE_WAKE);

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -24,8 +24,9 @@ static Adafruit_USBD_HID g_kbd;
 enum {
 	W_WAIT_DOWN, // link must go quiet before we arm (see WAKE_ARM_DOWN_MS)
 	W_ARMED, // waiting for a controller to connect
-	W_PRESS, // send key-down
-	W_RELEASE, // hold, then send key-up
+	W_PRESS, // send modifier-down
+	W_MODLEAD, // modifier alone, then add the key
+	W_RELEASE, // hold (re-sending), then send key-up
 	W_GAP, // spacing between repeats
 	W_SETTLE, // let the key-up land before we tear the device down
 	W_DONE // reboot issued (modeSwitchReboot does not return)
@@ -33,6 +34,7 @@ enum {
 static uint8_t s_st = W_WAIT_DOWN;
 static uint32_t s_t = 0; // start of the current timed phase
 static uint32_t s_dl = 0; // press-sequence start, for WAKE_SEQ_DEADLINE_MS
+static uint32_t s_resend = 0; // last held-report re-send (WAKE_RESEND_MS)
 static uint8_t s_shots = 0;
 
 // One boot-keyboard report. Queued for the usbTx drain like every other report in this firmware -- loop()
@@ -111,16 +113,36 @@ void WakeController::task()
 		}
 		if (!g_kbd.ready())
 			break;
+		// Stage the press like a human types it: Alt down alone first. A
+		// minimal EC hotkey parser may track modifier-then-key transitions
+		// rather than accepting a combined report out of nowhere.
+		kbdSend(WAKE_MOD, 0);
+		s_t = now;
+		s_st = W_MODLEAD;
+		break;
+
+	case W_MODLEAD:
+		if (now - s_t < WAKE_MOD_LEAD_MS)
+			break;
 		kbdSend(WAKE_MOD, WAKE_KEY);
 		// wake-debugger convention: flash = a wake was actually sent
 		ledWakePulse();
+		s_resend = now;
 		s_t = now;
 		s_st = W_RELEASE;
 		break;
 
 	case W_RELEASE:
-		if (now - s_t < WAKE_HOLD_MS)
+		if (now - s_t < WAKE_HOLD_MS) {
+			// Keep restating the held chord: an EC that samples the
+			// current report (rather than edge-detecting) can miss a
+			// single transfer.
+			if (now - s_resend >= WAKE_RESEND_MS && g_kbd.ready()) {
+				kbdSend(WAKE_MOD, WAKE_KEY);
+				s_resend = now;
+			}
 			break;
+		}
 		kbdSend(0, 0);
 		s_t = now;
 		s_st = (++s_shots < WAKE_REPEAT) ? W_GAP : W_SETTLE;

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -21,6 +21,33 @@ WakeController g_wakeCtl;
 static const uint8_t WAKE_KBD_DESC[] = { TUD_HID_REPORT_DESC_KEYBOARD() };
 static Adafruit_USBD_HID g_kbd;
 
+// Post-fire handoff grace (see mode_wake.h). The arm is PERSISTED (Cfg.wakeHandoff, one-shot consumed by
+// loadCfg like bootMode) because this board class's bootloader wipes .noinit RAM on every reset -- a RAM
+// flag simply does not survive the return reboot. The flash write costs nothing extra: the return mode
+// switch already rewrites cfg for its own one-shot bootMode.
+void wakeHandoffMark()
+{
+	g_wakeHandoffArm =
+		1; // persisted by the modeSwitchReboot save that follows
+}
+
+bool wakeHandoffActive()
+{
+	static bool checked = false, active = false;
+	static uint32_t t0 = 0;
+	if (!checked) {
+		checked = true;
+		if (g_wakeHandoffBoot) {
+			active = true;
+			t0 = millis();
+		}
+	}
+	if (active &&
+	    (USBDevice.mounted() || millis() - t0 >= WAKE_HANDOFF_GRACE_MS))
+		active = false;
+	return active;
+}
+
 enum {
 	W_WAIT_DOWN, // link must go quiet before we arm (see WAKE_ARM_DOWN_MS)
 	W_ARMED, // waiting for a controller to connect
@@ -159,6 +186,9 @@ void WakeController::task()
 		if (now - s_t < WAKE_SETTLE_MS)
 			break;
 		s_st = W_DONE;
+		// The machine is now powering on but will look bus-suspended until POST enumerates the reborn
+		// puck; hold the suspend policies off across that window (see mode_wake.h).
+		wakeHandoffMark();
 		// Clean detach + reboot into the puck. Does not return.
 		modeSwitchReboot(WAKE_RETURN_MODE);
 		break;
@@ -179,6 +209,10 @@ void wakeAutoRearmTask()
 #if WAKE_AUTO_REARM
 	static uint32_t downAt = 0;
 	static bool wasSusp = false;
+	// A machine POSTing after our own wake fire looks suspended; re-arming now would swap the puck out
+	// from under the boot. Hold off until the handoff grace resolves (host mounts us, or deadline).
+	if (wakeHandoffActive())
+		return;
 	const bool susp = USBDevice.suspended();
 	if (susp && !wasSusp)
 		downAt = millis();

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -283,24 +283,39 @@ void wakeAutoRearmTask()
 		if (downAt == 0 ||
 		    (uint32_t)(millis() - lastResumeMs) >= WAKE_REARM_FLAP_MS ||
 		    (uint32_t)(millis() - downAt) >= WAKE_REARM_EPISODE_MS) {
-			epArmed = s_suspWkArmed;
+			// The arming only counts as the OS's sleep intent if a real host is actually
+			// CONFIGURED on the bus: a reset-then-suspend EC takeover clears the config and
+			// then SET_FEATUREs remote wakeup itself before suspending -- with no resume edge
+			// since the reset, that reads as a fresh episode, and sampling the bare flag there
+			// classified every such shutdown as a sleeping host and vetoed the re-arm. An OS
+			// entering S3 is always mounted at its suspend edge.
+			epArmed = s_suspWkArmed && USBDevice.mounted();
 			downAt = millis();
 		}
 	}
 	if (!susp && wasSusp)
 		lastResumeMs = millis();
 	wasSusp = susp;
+	// Track the bus-lost clock UNCONDITIONALLY (like the episode tracking above): latching it below
+	// the grace gate made a failed wake's 45 s dead-bus countdown start only after the 90 s grace,
+	// re-arming at ~140 s instead of the documented ~grace-end.
+	static uint32_t busLostMs = 0;
+	if (USBDevice.mounted())
+		busLostMs = 0;
+	else if (!busLostMs)
+		busLostMs = millis() ? millis() : 1;
 	// A machine POSTing after our own wake fire looks suspended (or dead); re-arming now would swap
 	// the puck out from under the boot. Track above, act only past the grace -- and give haptics'
-	// suspend power-off (ripe at suspend+4 s, vs our 15 s) a head start when the grace ends with the
-	// bus already down, so the re-arm reboot can never preempt the controller's off.
+	// suspend power-off AND its full retry schedule (ripe through send + RETRIES x RETRY_MS = 12 s)
+	// a head start when the grace ends with the bus already down, so the re-arm reboot can never
+	// destroy a pending resend.
 	if (wakeHandoffActive() || modeIsWake(g_usbMode))
 		return;
 	static uint32_t graceClearMs = 0;
 	if (g_wakeHandoffBoot) {
 		if (!graceClearMs)
 			graceClearMs = millis();
-		if ((uint32_t)(millis() - graceClearMs) < 5000u)
+		if ((uint32_t)(millis() - graceClearMs) < 15000u)
 			return;
 	}
 	if (susp) {
@@ -314,17 +329,11 @@ void wakeAutoRearmTask()
 		return;
 	}
 	// Dead-bus path (see WAKE_DEADBUS_REARM_MS): the bus is neither mounted nor suspended -- a
-	// reset-style shutdown, a failed wake's return boot, or a plug into an off host. Measured from
-	// the moment the bus was lost (boot, if it was never mounted), NOT puck uptime: an uptime clock
-	// fired mid-shutdown and rebooted the puck out from under the pending controller power-off.
-	static uint32_t busLostMs = 0;
-	if (USBDevice.mounted()) {
-		busLostMs = 0;
-	} else {
-		if (!busLostMs)
-			busLostMs = millis() ? millis() : 1;
-		if ((uint32_t)(millis() - busLostMs) >= WAKE_DEADBUS_REARM_MS)
-			modeSwitchReboot(MODE_WAKE);
-	}
+	// reset-style shutdown, a failed wake's return boot, or a plug into an off host. The clock runs
+	// from the moment the bus was lost (tracked above, through the grace), NOT puck uptime: an
+	// uptime clock fired mid-shutdown and rebooted the puck out from under the pending power-off.
+	if (busLostMs &&
+	    (uint32_t)(millis() - busLostMs) >= WAKE_DEADBUS_REARM_MS)
+		modeSwitchReboot(MODE_WAKE);
 #endif
 }

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -35,15 +35,31 @@ void wakeHandoffMark()
 
 bool wakeHandoffActive()
 {
-	// Deadline-only (mode_wake.h): a POST-time SET_CONFIGURATION reads mounted() long before the OS is
-	// up, so an early exit on mount would re-expose the suspend power-off during the BIOS->kernel gap.
-	static bool init = false;
-	static uint32_t t0 = 0;
+	// Deadline-based (mode_wake.h): a POST-time SET_CONFIGURATION reads mounted() long before the OS
+	// is up, so a bare mounted() exit would re-expose the suspend power-off during the BIOS->kernel
+	// gap. The early end below instead requires a SUSTAINED mounted+active session -- something POST
+	// never produces -- so a shutdown shortly after a wake-boot gets normal power-off behavior back.
+	static bool init = false, done = false;
+	static uint32_t t0 = 0, upSince = 0;
+	if (!g_wakeHandoffBoot)
+		return false;
 	if (!init) {
 		init = true;
 		t0 = millis();
 	}
-	return g_wakeHandoffBoot && millis() - t0 < WAKE_HANDOFF_GRACE_MS;
+	if (done)
+		return false;
+	if (USBDevice.mounted() && !USBDevice.suspended()) {
+		if (!upSince)
+			upSince = millis();
+		else if (millis() - upSince >= WAKE_HANDOFF_MOUNTED_MS)
+			done = true;
+	} else {
+		upSince = 0;
+	}
+	if (millis() - t0 >= WAKE_HANDOFF_GRACE_MS)
+		done = true;
+	return !done;
 }
 
 bool wakeHandoffExpired()
@@ -275,9 +291,18 @@ void wakeAutoRearmTask()
 		lastResumeMs = millis();
 	wasSusp = susp;
 	// A machine POSTing after our own wake fire looks suspended (or dead); re-arming now would swap
-	// the puck out from under the boot. Track above, act only past the grace.
+	// the puck out from under the boot. Track above, act only past the grace -- and give haptics'
+	// suspend power-off (ripe at suspend+4 s, vs our 15 s) a head start when the grace ends with the
+	// bus already down, so the re-arm reboot can never preempt the controller's off.
 	if (wakeHandoffActive() || modeIsWake(g_usbMode))
 		return;
+	static uint32_t graceClearMs = 0;
+	if (g_wakeHandoffBoot) {
+		if (!graceClearMs)
+			graceClearMs = millis();
+		if ((uint32_t)(millis() - graceClearMs) < 5000u)
+			return;
+	}
 	if (susp) {
 		// Countdown from the LAST suspend edge, not the episode start: a manual power-on's POST
 		// flaps continue the shutdown episode, and counting from its start would fire the re-arm
@@ -288,10 +313,18 @@ void wakeAutoRearmTask()
 			modeSwitchReboot(MODE_WAKE);
 		return;
 	}
-	// Dead-bus path (see WAKE_DEADBUS_REARM_MS): never enumerated => never mounted AND never
-	// suspended. A failed wake's return boot and a plug into an off host both land here; a live
-	// host mounts us long before the deadline and never enters this branch.
-	if (!USBDevice.mounted() && millis() >= WAKE_DEADBUS_REARM_MS)
-		modeSwitchReboot(MODE_WAKE);
+	// Dead-bus path (see WAKE_DEADBUS_REARM_MS): the bus is neither mounted nor suspended -- a
+	// reset-style shutdown, a failed wake's return boot, or a plug into an off host. Measured from
+	// the moment the bus was lost (boot, if it was never mounted), NOT puck uptime: an uptime clock
+	// fired mid-shutdown and rebooted the puck out from under the pending controller power-off.
+	static uint32_t busLostMs = 0;
+	if (USBDevice.mounted()) {
+		busLostMs = 0;
+	} else {
+		if (!busLostMs)
+			busLostMs = millis() ? millis() : 1;
+		if ((uint32_t)(millis() - busLostMs) >= WAKE_DEADBUS_REARM_MS)
+			modeSwitchReboot(MODE_WAKE);
+	}
 #endif
 }

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -249,21 +249,35 @@ void wakeAutoRearmTask()
 {
 #if WAKE_AUTO_REARM
 	static uint32_t downAt = 0;
+	static uint32_t lastResumeMs = 0;
 	static bool wasSusp = false;
+	static bool epArmed =
+		false; // this down-episode's sleep-vs-shutdown decision
 	// A machine POSTing after our own wake fire looks suspended; re-arming now would swap the puck out
 	// from under the boot. Hold off until the handoff grace resolves (host mounts us, or deadline).
 	if (wakeHandoffActive())
 		return;
 	const bool susp = USBDevice.suspended();
-	if (susp && !wasSusp)
-		downAt = millis();
+	if (susp && !wasSusp) {
+		// Suspend edge. A fresh episode (bus was up >= WAKE_REARM_FLAP_MS, or first ever) samples
+		// the OS's intent NOW: armed remote wakeup = sleeping, clear = shutting down. A short flap
+		// (the EC's S5 port takeover) continues the current episode -- keep both the decision and
+		// the countdown start, or the EC's own arming would masquerade as a sleeping OS.
+		if (downAt == 0 ||
+		    (uint32_t)(millis() - lastResumeMs) >= WAKE_REARM_FLAP_MS) {
+			epArmed = s_suspWkArmed;
+			downAt = millis();
+		}
+	}
+	if (!susp && wasSusp)
+		lastResumeMs = millis();
 	wasSusp = susp;
 	if (!susp || modeIsWake(g_usbMode))
 		return;
-	// Host armed remote wakeup for this suspend => it is SLEEPING and expects to find the puck on
-	// resume; do not swap in the keyboard. (A boot into an already-suspended bus never saw a
-	// SET_FEATURE, so the flag is false and the plugged-into-a-dead-host re-arm still works.)
-	if (s_suspWkArmed)
+	// A sleeping host expects to find the puck on resume; do not swap in the keyboard. (A boot into an
+	// already-suspended bus never saw a SET_FEATURE, so the decision reads shutdown and the
+	// plugged-into-a-dead-host re-arm still works.)
+	if (epArmed)
 		return;
 	if (millis() - downAt >= WAKE_AUTO_REARM_MS)
 		modeSwitchReboot(MODE_WAKE);

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -27,7 +27,9 @@ static Adafruit_USBD_HID g_kbd;
 // modeSwitchReboot(0xFF) ("keep current"), which intentionally skips its own saveMode.
 void wakeHandoffMark()
 {
-	g_wakeHandoffArm = 1;
+	// 0xA5, not 1: this byte is the repurposed legacy rumble-strength slot (0..100), so a plausible
+	// legacy value must not read as an arm after a firmware upgrade. 0xA5 is outside that range.
+	g_wakeHandoffArm = 0xA5;
 	saveCfg();
 }
 
@@ -248,23 +250,23 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en)
 void wakeAutoRearmTask()
 {
 #if WAKE_AUTO_REARM
-	static uint32_t downAt = 0;
+	static uint32_t suspSince = 0; // last suspend EDGE (flaps included)
+	static uint32_t downAt = 0; // episode start (0 = none yet)
 	static uint32_t lastResumeMs = 0;
 	static bool wasSusp = false;
-	static bool epArmed =
-		false; // this down-episode's sleep-vs-shutdown decision
-	// A machine POSTing after our own wake fire looks suspended; re-arming now would swap the puck out
-	// from under the boot. Hold off until the handoff grace resolves (host mounts us, or deadline).
-	if (wakeHandoffActive())
-		return;
+	static bool epArmed = false; // episode's sleep-vs-shutdown decision
 	const bool susp = USBDevice.suspended();
+	// Track episodes UNCONDITIONALLY -- only the reboot action is gated below. Skipping the tracking
+	// during the handoff grace left a shutdown-inside-the-grace unrecorded, so the first post-grace
+	// edge sampled the EC's stale remote-wakeup arming as if it were the OS sleeping.
 	if (susp && !wasSusp) {
-		// Suspend edge. A fresh episode (bus was up >= WAKE_REARM_FLAP_MS, or first ever) samples
-		// the OS's intent NOW: armed remote wakeup = sleeping, clear = shutting down. A short flap
-		// (the EC's S5 port takeover) continues the current episode -- keep both the decision and
-		// the countdown start, or the EC's own arming would masquerade as a sleeping OS.
+		suspSince = millis();
+		// Fresh episode: bus was up >= WAKE_REARM_FLAP_MS (a real host session, however brief), no
+		// episode yet, or the current one aged past WAKE_REARM_EPISODE_MS. Otherwise this edge is
+		// a flap continuing the current episode: keep its decision.
 		if (downAt == 0 ||
-		    (uint32_t)(millis() - lastResumeMs) >= WAKE_REARM_FLAP_MS) {
+		    (uint32_t)(millis() - lastResumeMs) >= WAKE_REARM_FLAP_MS ||
+		    (uint32_t)(millis() - downAt) >= WAKE_REARM_EPISODE_MS) {
 			epArmed = s_suspWkArmed;
 			downAt = millis();
 		}
@@ -272,14 +274,24 @@ void wakeAutoRearmTask()
 	if (!susp && wasSusp)
 		lastResumeMs = millis();
 	wasSusp = susp;
-	if (!susp || modeIsWake(g_usbMode))
+	// A machine POSTing after our own wake fire looks suspended (or dead); re-arming now would swap
+	// the puck out from under the boot. Track above, act only past the grace.
+	if (wakeHandoffActive() || modeIsWake(g_usbMode))
 		return;
-	// A sleeping host expects to find the puck on resume; do not swap in the keyboard. (A boot into an
-	// already-suspended bus never saw a SET_FEATURE, so the decision reads shutdown and the
-	// plugged-into-a-dead-host re-arm still works.)
-	if (epArmed)
+	if (susp) {
+		// Countdown from the LAST suspend edge, not the episode start: a manual power-on's POST
+		// flaps continue the shutdown episode, and counting from its start would fire the re-arm
+		// in the middle of a boot the user started by hand. Every flap restarts the clock; only
+		// WAKE_AUTO_REARM_MS of CONTINUOUS suspension (and a shutdown-decided episode) re-arms.
+		if (!epArmed &&
+		    (uint32_t)(millis() - suspSince) >= WAKE_AUTO_REARM_MS)
+			modeSwitchReboot(MODE_WAKE);
 		return;
-	if (millis() - downAt >= WAKE_AUTO_REARM_MS)
+	}
+	// Dead-bus path (see WAKE_DEADBUS_REARM_MS): never enumerated => never mounted AND never
+	// suspended. A failed wake's return boot and a plug into an off host both land here; a live
+	// host mounts us long before the deadline and never enters this branch.
+	if (!USBDevice.mounted() && millis() >= WAKE_DEADBUS_REARM_MS)
 		modeSwitchReboot(MODE_WAKE);
 #endif
 }

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -1,0 +1,169 @@
+#include "mode_wake.h"
+#include "config.h"
+#include "rf_link.h" // anySlotLinkUp()
+#include "usb_mount.h" // modeSwitchReboot()
+#include "usb_tx.h" // usbTxHid()
+#include "status_led.h" // ledWakePulse()
+#include <Adafruit_TinyUSB.h>
+#include <string.h>
+
+WakeController g_wakeCtl;
+
+// Plain boot keyboard, NO report ID. Report ID 0 matters: the EC will very likely put us in boot protocol
+// (SET_PROTOCOL 0), whose report format is the fixed 8-byte [modifier][reserved][keycode x6] with no id
+// byte. TUD_HID_REPORT_DESC_KEYBOARD() with no id argument emits exactly that, so the report protocol and
+// boot protocol payloads are identical and it does not matter which one the host picks.
+//
+// Note wake_hid.cpp's comment that a boot KEYBOARD failed to enumerate on Windows where the boot mouse
+// worked -- that was a keyboard added to the puck composite as an extra wake interface. This is a
+// standalone single-interface keyboard talking to a firmware EC, which is the case a real keyboard
+// exercises. If it does not enumerate, that is the thing to bisect first.
+static const uint8_t WAKE_KBD_DESC[] = { TUD_HID_REPORT_DESC_KEYBOARD() };
+static Adafruit_USBD_HID g_kbd;
+
+enum {
+	W_WAIT_DOWN, // link must go quiet before we arm (see WAKE_ARM_DOWN_MS)
+	W_ARMED, // waiting for a controller to connect
+	W_PRESS, // send key-down
+	W_RELEASE, // hold, then send key-up
+	W_GAP, // spacing between repeats
+	W_SETTLE, // let the key-up land before we tear the device down
+	W_DONE // reboot issued (modeSwitchReboot does not return)
+};
+static uint8_t s_st = W_WAIT_DOWN;
+static uint32_t s_t = 0; // start of the current timed phase
+static uint32_t s_dl = 0; // press-sequence start, for WAKE_SEQ_DEADLINE_MS
+static uint8_t s_shots = 0;
+
+// One boot-keyboard report. Queued for the usbTx drain like every other report in this firmware -- loop()
+// never calls tud_* directly (see usb_tx.h). key==0 with mod==0 is the all-keys-up report.
+static void kbdSend(uint8_t mod, uint8_t key)
+{
+	hid_keyboard_report_t r;
+	memset(&r, 0, sizeof r);
+	r.modifier = mod;
+	r.keycode[0] = key;
+	usbTxHid(&g_kbd, 0, &r, sizeof r);
+}
+
+void WakeController::usbIdentity()
+{
+	// Distinct identity from every other personality. Hosts cache the configuration descriptor by
+	// VID:PID:bcdDevice (see the bcdDevice rule in ARCHITECTURE.md), so the wake keyboard must not share
+	// one with the puck or a host can serve the wrong cached descriptor for whichever enumerates second.
+	// The PID is arbitrary and unclaimed -- nothing matches on it; the EC keys off the HID class.
+	USBDevice.setID(0x28DE, 0x574B);
+	USBDevice.setDeviceVersion(0x0100);
+	USBDevice.setManufacturerDescriptor("OpenPuck");
+	USBDevice.setProductDescriptor("OpenPuck Wake Keyboard");
+}
+
+void WakeController::begin()
+{
+	usbIdentity();
+	g_kbd.setBootProtocol(HID_ITF_PROTOCOL_KEYBOARD);
+	g_kbd.setStringDescriptor("OpenPuck Wake Keyboard");
+	g_kbd.setReportDescriptor(WAKE_KBD_DESC, sizeof WAKE_KBD_DESC);
+	// 10 ms, a real keyboard's cadence; nothing here is latency-sensitive
+	g_kbd.setPollInterval(10);
+	g_kbd.begin();
+}
+
+// Non-blocking throughout: every wait is a millis() comparison, never a delay(). loop() has to keep feeding
+// the ~8 s watchdog and keep the RF poll running while we sit here, so nothing in this file may spin.
+void WakeController::task()
+{
+	const uint32_t now = millis();
+	const bool up = anySlotLinkUp();
+
+	switch (s_st) {
+	case W_WAIT_DOWN:
+		// Any link activity restarts the quiet timer. s_t starts at 0, so a boot with no controller
+		// already gets the full WAKE_ARM_DOWN_MS of grace before arming.
+		if (up) {
+			s_t = now;
+			break;
+		}
+		if (now - s_t >= WAKE_ARM_DOWN_MS)
+			s_st = W_ARMED;
+		break;
+
+	case W_ARMED:
+		// The wake gesture. ready() means the host has actually configured our interface -- on a machine
+		// in S5 that is the EC's minimal stack having enumerated us. If it never goes true we simply never
+		// fire, and the LED never flashes, which is the diagnostic.
+		if (up && g_kbd.ready()) {
+			s_shots = 0;
+			s_dl = now;
+			s_st = W_PRESS;
+		}
+		break;
+
+	case W_PRESS:
+		// Deadline: the EC deconfigured us mid-sequence (port reset as POST takes over the bus). Bail to
+		// settle instead of stalling here until the booted OS re-enumerates us and gets a stray Alt+P.
+		// The queued all-keys-up is harmless whenever it drains.
+		if (now - s_dl >= WAKE_SEQ_DEADLINE_MS) {
+			kbdSend(0, 0);
+			s_t = now;
+			s_st = W_SETTLE;
+			break;
+		}
+		if (!g_kbd.ready())
+			break;
+		kbdSend(WAKE_MOD, WAKE_KEY);
+		// wake-debugger convention: flash = a wake was actually sent
+		ledWakePulse();
+		s_t = now;
+		s_st = W_RELEASE;
+		break;
+
+	case W_RELEASE:
+		if (now - s_t < WAKE_HOLD_MS)
+			break;
+		kbdSend(0, 0);
+		s_t = now;
+		s_st = (++s_shots < WAKE_REPEAT) ? W_GAP : W_SETTLE;
+		break;
+
+	case W_GAP:
+		// Repeats are cheap insurance against the EC missing the first report. Extra Alt+P presses that
+		// land during POST are harmless -- Lenovo's POST hotkeys are F1/F12/Enter.
+		if (now - s_t >= WAKE_REPEAT_MS)
+			s_st = W_PRESS;
+		break;
+
+	case W_SETTLE:
+		if (now - s_t < WAKE_SETTLE_MS)
+			break;
+		s_st = W_DONE;
+		// Clean detach + reboot into the puck. Does not return.
+		modeSwitchReboot(WAKE_RETURN_MODE);
+		break;
+
+	case W_DONE:
+	default:
+		break;
+	}
+}
+
+// Auto-re-arm watcher, called from loop() in every mode (compiled to nothing unless the WAKE_AUTO_REARM
+// build option is on -- see mode_wake.h for why it is off by default). Note this deliberately bypasses the
+// "no mode switch while suspended" convention the chord + console paths follow: their rule exists so a
+// SLEEPING host never resumes to find a different device, and here a long suspend meaning "the host is
+// down" is the entire premise.
+void wakeAutoRearmTask()
+{
+#if WAKE_AUTO_REARM
+	static uint32_t downAt = 0;
+	static bool wasSusp = false;
+	const bool susp = USBDevice.suspended();
+	if (susp && !wasSusp)
+		downAt = millis();
+	wasSusp = susp;
+	if (!susp || modeIsWake(g_usbMode))
+		return;
+	if (millis() - downAt >= WAKE_AUTO_REARM_MS)
+		modeSwitchReboot(MODE_WAKE);
+#endif
+}

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -23,29 +23,30 @@ static Adafruit_USBD_HID g_kbd;
 
 // Post-fire handoff grace (see mode_wake.h). The arm is PERSISTED (Cfg.wakeHandoff, one-shot consumed by
 // loadCfg like bootMode) because this board class's bootloader wipes .noinit RAM on every reset -- a RAM
-// flag simply does not survive the return reboot. The flash write costs nothing extra: the return mode
-// switch already rewrites cfg for its own one-shot bootMode.
+// flag simply does not survive the return reboot. saveCfg() here because the return reboot goes through
+// modeSwitchReboot(0xFF) ("keep current"), which intentionally skips its own saveMode.
 void wakeHandoffMark()
 {
-	g_wakeHandoffArm =
-		1; // persisted by the modeSwitchReboot save that follows
+	g_wakeHandoffArm = 1;
+	saveCfg();
 }
 
 bool wakeHandoffActive()
 {
-	static bool checked = false, active = false;
+	// Deadline-only (mode_wake.h): a POST-time SET_CONFIGURATION reads mounted() long before the OS is
+	// up, so an early exit on mount would re-expose the suspend power-off during the BIOS->kernel gap.
+	static bool init = false;
 	static uint32_t t0 = 0;
-	if (!checked) {
-		checked = true;
-		if (g_wakeHandoffBoot) {
-			active = true;
-			t0 = millis();
-		}
+	if (!init) {
+		init = true;
+		t0 = millis();
 	}
-	if (active &&
-	    (USBDevice.mounted() || millis() - t0 >= WAKE_HANDOFF_GRACE_MS))
-		active = false;
-	return active;
+	return g_wakeHandoffBoot && millis() - t0 < WAKE_HANDOFF_GRACE_MS;
+}
+
+bool wakeHandoffExpired()
+{
+	return g_wakeHandoffBoot && !wakeHandoffActive();
 }
 
 enum {
@@ -105,11 +106,28 @@ void WakeController::task()
 	const uint32_t now = millis();
 	const bool up = anySlotLinkUp();
 
+	// The wake gesture is the connect up-EDGE, latched briefly: an EC that suspends the port between
+	// enumeration and the press only reads ready() a few ms after the connect (rf_link's remoteWakeup has
+	// to resume the bus first). The latch EXPIRES (WAKE_FIRE_LATCH_MS): a controller that connected
+	// against a dead port must not fire hours later when a manually booted OS enumerates the keyboard.
+	static bool s_wasUp = false;
+	static bool s_pend = false;
+	static uint32_t s_pendMs = 0;
+	if (up && !s_wasUp) {
+		s_pend = true;
+		s_pendMs = now;
+	}
+	if (!up || now - s_pendMs >= WAKE_FIRE_LATCH_MS)
+		s_pend = false;
+	s_wasUp = up;
+
 	switch (s_st) {
 	case W_WAIT_DOWN:
-		// Any link activity restarts the quiet timer. s_t starts at 0, so a boot with no controller
-		// already gets the full WAKE_ARM_DOWN_MS of grace before arming.
-		if (up) {
+		// Link activity restarts the quiet timer -- and so does a closed connect cooldown: before
+		// rfConnectOpen() nothing is on air, so a controller that was linked at the mode switch cannot
+		// have shown itself yet, and counting that silence would arm us just in time to type Alt+P
+		// into the live session it then relinks into.
+		if (up || !rfConnectOpen()) {
 			s_t = now;
 			break;
 		}
@@ -118,10 +136,11 @@ void WakeController::task()
 		break;
 
 	case W_ARMED:
-		// The wake gesture. ready() means the host has actually configured our interface -- on a machine
-		// in S5 that is the EC's minimal stack having enumerated us. If it never goes true we simply never
-		// fire, and the LED never flashes, which is the diagnostic.
-		if (up && g_kbd.ready()) {
+		// ready() means the host has actually configured our interface -- on a machine in S5 that is
+		// the EC's minimal stack having enumerated us. If it never goes true we simply never fire, and
+		// the LED never flashes, which is the diagnostic.
+		if (s_pend && g_kbd.ready()) {
+			s_pend = false;
 			s_shots = 0;
 			s_dl = now;
 			s_st = W_PRESS;
@@ -189,7 +208,8 @@ void WakeController::task()
 		// The machine is now powering on but will look bus-suspended until POST enumerates the reborn
 		// puck; hold the suspend policies off across that window (see mode_wake.h).
 		wakeHandoffMark();
-		// Clean detach + reboot into the puck. Does not return.
+		// Clean detach + reboot into the return personality (0xFF = the boot-policy default:
+		// the user's persisted mode, or Steam). Does not return.
 		modeSwitchReboot(WAKE_RETURN_MODE);
 		break;
 
@@ -197,6 +217,13 @@ void WakeController::task()
 	default:
 		break;
 	}
+}
+
+// True while a press sequence is in flight (haptics' suspend power-off must not kill the triggering
+// controller mid-wake; every other wake-mode state keeps the battery-saving power-off).
+bool wakeFireInFlight()
+{
+	return modeIsWake(g_usbMode) && s_st >= W_PRESS;
 }
 
 // Auto-re-arm watcher, called from loop() in every mode (compiled to nothing unless the WAKE_AUTO_REARM

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -88,9 +88,11 @@
 // EXPERIMENTAL, default OFF; build with EXTRA_FLAGS="-DWAKE_AUTO_REARM=1" to enable. While running any
 // OTHER personality, a continuous USB suspend longer than WAKE_AUTO_REARM_MS reboots into MODE_WAKE, so
 // the wake re-arms itself every time the host goes down (the smart-power-on port keeps VBUS in S5, so the
-// MCU never cold-boots -- without this, one wake per manual arm). Off by default because S3 sleep is also
-// a persistent suspend, and a device that re-attaches mid-S3 is never configured: with this on, the
-// existing wake-on-connect-from-S3 path stops working. Use it on hosts that shut down to S4/S5.
+// MCU never cold-boots -- without this, one wake per manual arm). Sleep is distinguished from shutdown by
+// the host's own hand: an OS entering S3 arms DEVICE_REMOTE_WAKEUP before suspending (tud_suspend_cb in
+// mode_wake.cpp) and such suspends never re-arm, so wake-on-connect-from-S3 keeps working. Still off by
+// default: a host with wakeup disabled for the device (sysfs) makes its sleep look like a shutdown,
+// degrading to re-arm-on-sleep -- acceptable on hosts that shut down to S4/S5, surprising elsewhere.
 #ifndef WAKE_AUTO_REARM
 #define WAKE_AUTO_REARM 0
 #endif

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -36,17 +36,27 @@
 #pragma once
 #include "controllers.h"
 
-// Where to land after the hotkey has been sent. MODE_STEAM is the normal puck; change if you live in
-// another personality.
-#define WAKE_RETURN_MODE MODE_STEAM
+// Where to land after the hotkey has been sent. 0xFF = modeSwitchReboot's "keep current" sentinel, which
+// boots by the normal policy: the persisted mode for persist-last-mode users, Steam otherwise -- so a
+// wake never overwrites the user's chosen personality. Set a concrete mode to force one instead.
+#define WAKE_RETURN_MODE 0xFF
 
 // The hotkey itself. Lenovo ThinkCentre Smart Power On = Alt+P.
 #define WAKE_MOD KEYBOARD_MODIFIER_LEFTALT
 #define WAKE_KEY HID_KEY_P
 
 // How long the RF link must be continuously down before an up-edge counts as a wake gesture. Must be
-// comfortably longer than anySlotLinkUp()'s 300 ms window so an ordinary RF hiccup can't arm us.
-#define WAKE_ARM_DOWN_MS 3000u
+// comfortably longer than anySlotLinkUp()'s 300 ms window so an ordinary RF hiccup can't arm us -- and
+// long enough that a controller briefly walking out of range while the host is LIVE can't re-arm a
+// keyboard pointed at the session. The quiet clock only runs once the RF side is on air (rfConnectOpen()),
+// so with a controller off at the mode switch, arming lands ~WAKE_ARM_DOWN_MS after the cooldown opens.
+#define WAKE_ARM_DOWN_MS 5000u
+
+// An up-EDGE seen while the keyboard is not yet ready() stays a valid gesture for this long. Long enough
+// for the EC's resume-then-configure lag after our remote wakeup (milliseconds), far shorter than a human
+// power-on: a controller that connected against a dead port must NOT fire hours later when a manually
+// booted OS finally enumerates the keyboard.
+#define WAKE_FIRE_LATCH_MS 2000u
 
 // Press shaping. A combined Alt+P report held 60 ms was read but IGNORED by the
 // ThinkCentre M90q Gen 6 EC (it drained both repeats off the endpoint, so the
@@ -92,14 +102,22 @@
 // power-off (haptics.cpp, SUSPEND_OFF_MS) shuts down the controller that just triggered the wake, and
 // WAKE_AUTO_REARM would yank the puck back into the wake personality mid-boot. wakeHandoffMark() arms a
 // PERSISTED one-shot (Cfg.wakeHandoff -- flash, because this board class's bootloader wipes .noinit RAM
-// on reset) right before the return reboot; wakeHandoffActive() then holds both policies off until a USB
-// host actually mounts us, or this deadline passes (machine never booted -> the normal power-saving
-// behavior is correct after all). The handoff boot also skips setup()'s mount wait and opens the RF
-// connect cooldown immediately, so the reborn puck answers the triggering controller ~3 s sooner --
-// before it gives up searching and powers itself off.
+// on reset) right before the return reboot; wakeHandoffActive() then holds both policies off for this
+// full window. Deadline-only ON PURPOSE -- USBDevice.mounted() is NOT "the OS is up": BIOS legacy-HID
+// support SET_CONFIGURATIONs keyboard-bearing devices during POST, and the BIOS->kernel handoff right
+// after is exactly the suspend gap the grace exists to cover. Nobody sleeps a machine within 90 s of
+// waking it, so nothing is lost by holding the two policies for the whole window; if the machine never
+// boots, haptics' expiry fallback still powers the controller off (battery saved). The handoff boot also
+// skips setup()'s mount wait and opens the RF connect cooldown immediately, so the reborn puck answers
+// the triggering controller in <0.5 s -- before it gives up searching and powers itself off.
 #define WAKE_HANDOFF_GRACE_MS 90000u
 void wakeHandoffMark();
 bool wakeHandoffActive();
+// True from this boot's grace expiry onward (false on non-handoff boots): haptics' never-booted fallback.
+bool wakeHandoffExpired();
+// True while a press sequence is in flight (first press queued .. return reboot): the only wake-mode
+// window where haptics' suspend power-off must hold its fire (it would kill the triggering controller).
+bool wakeFireInFlight();
 
 class WakeController : public IController {
     public:

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -96,7 +96,9 @@
 #ifndef WAKE_AUTO_REARM
 #define WAKE_AUTO_REARM 0
 #endif
+#ifndef WAKE_AUTO_REARM_MS
 #define WAKE_AUTO_REARM_MS 15000u
+#endif
 // A bus resume shorter than this does NOT start a new down-episode: during poweroff the smart-port EC
 // takes the bus over with a brief resume (~2.4 s captured on the M90q) and re-suspends WITH remote
 // wakeup armed -- its own listening mechanism, not the OS's sleep intent. The sleep-vs-shutdown decision
@@ -106,11 +108,12 @@
 // resume right before a genuine sleep, and inheriting an hours-old "shutdown" decision there would
 // re-arm under a sleeping host. The EC takeover flap arrives ~3 s into its episode, far under this cap.
 #define WAKE_REARM_EPISODE_MS 60000u
-// Dead-bus re-arm: TinyUSB only reports suspend on a bus that got a SETUP packet, so a failed wake's
-// return boot (EC cannot enumerate the composite) and a plug into an already-off host read neither
-// mounted nor suspended -- ever. Never-mounted this long after boot cannot be a live host (any real
-// boot's USB is up in well under this), so treat it as a shutdown and re-arm.
-#define WAKE_DEADBUS_REARM_MS 90000u
+// Dead-bus re-arm: TinyUSB only reports suspend on a bus that got a SETUP packet, so a bus that was
+// RESET at shutdown (one of the M90q EC's two takeover styles), a failed wake's return boot, and a plug
+// into an already-off host all read neither mounted nor suspended -- ever. Measured from when the bus
+// was LOST (or boot, if never mounted): long past a normal boot's re-enumeration gap and past the
+// SUSPEND_OFF_LOST_MS controller power-off, which must land first.
+#define WAKE_DEADBUS_REARM_MS 45000u
 
 // Post-fire handoff grace. After the hotkey is sent the machine spends tens of seconds in POST + OS boot
 // with the bus suspended (nothing has enumerated the reborn puck yet) -- which is indistinguishable from
@@ -127,6 +130,12 @@
 // skips setup()'s mount wait and opens the RF connect cooldown immediately, so the reborn puck answers
 // the triggering controller in <0.5 s -- before it gives up searching and powers itself off.
 #define WAKE_HANDOFF_GRACE_MS 90000u
+// Early end: once the bus has been CONTINUOUSLY mounted and active for this long, the OS is genuinely up
+// (BIOS legacy-HID mounts last a few seconds and end in the boot-handoff reset/suspend, never this) and
+// the grace's job is done. Without this, a shutdown within 90 s of a wake-boot found the suspend
+// power-off still suppressed: the controller stayed on, the re-arm swapped the puck mid-power-down, and
+// the controller reconnected to the wake keyboard it could then never arm against.
+#define WAKE_HANDOFF_MOUNTED_MS 20000u
 void wakeHandoffMark();
 bool wakeHandoffActive();
 // True from this boot's grace expiry onward (false on non-handoff boots): haptics' never-booted fallback.

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -1,0 +1,89 @@
+// mode_wake.h -- MODE_WAKE: a boot-keyboard-only personality that powers on a
+// sleeping/off desktop with its firmware hotkey, then hands the port back to the puck.
+//
+// WHY THIS EXISTS. USB remote-wakeup (wake_hid.cpp + the rf_link connect edge) only works from S3: it
+// needs a host controller that is still clocked. From a full shutdown (S5) there is no host stack to
+// resume -- the only thing listening on the port is the board's embedded controller, and on Lenovo
+// ThinkCentre (BIOS: Power > Smart Power On) it powers the machine on when it sees Alt+P from a USB
+// keyboard on the designated always-on port. Dell/others have the same feature under different names and
+// different chords; see WAKE_MOD / WAKE_KEY below.
+//
+// WHY A SEPARATE MODE RATHER THAN ONE MORE INTERFACE ON THE PUCK. Two reasons:
+//   1. The EC's S5 USB stack is minimal. A real keyboard is what it was written against, so the safest
+//      thing to show it is a single boot-protocol HID keyboard and nothing else -- no wake mouse, no
+//      WebUSB, no CDC. setup() drops all of those for this mode (see `bareHid` in OpenPuck.ino).
+//   2. Endpoints. The puck composite already uses 6 of the nRF52840's 7 data IN endpoints, so bolting a
+//      keyboard onto it would spend the last one. Two-phase costs nothing: each phase is small.
+//
+// THE FLOW.
+//   arm     -- chord / WebUSB panel / CDC console switch to MODE_WAKE (modeSwitchReboot). With the default
+//              "always boot Steam" policy this is a ONE-SHOT bootMode, which is exactly right: one wake,
+//              then back to normal.
+//   settle  -- the mode refuses to arm until the RF link has been DOWN for WAKE_ARM_DOWN_MS. This is the
+//              stand-in for "is the host off?": you arm while the controller is still on, and arming only
+//              completes once you put the controller down / power the desk off. Without it the still-
+//              connected controller would trip the wake the instant we rebooted, firing Alt+P into the
+//              running session and bouncing straight back to puck mode.
+//   fire    -- first link-up edge after arming sends Alt+P (WAKE_REPEAT times), LED pulses per the
+//              status_led wake-debugger convention: flash = we sent it, no flash = we never fired.
+//   hand off-- after WAKE_SETTLE_MS, modeSwitchReboot(WAKE_RETURN_MODE). The reboot is a real detach +
+//              re-enumerate, so the machine -- which is a couple of seconds into POST by then -- enumerates
+//              the puck normally and Steam sees it as it always does.
+//
+// RE-ARMING. The smart-power-on port keeps VBUS up in S5, so the MCU never cold-boots and nothing re-arms
+// this mode after it fires: by default it is one wake per manual arm. The WAKE_AUTO_REARM build option
+// (below) makes it repeatable: a persistent USB suspend in any other mode reboots back into MODE_WAKE.
+#pragma once
+#include "controllers.h"
+
+// Where to land after the hotkey has been sent. MODE_STEAM is the normal puck; change if you live in
+// another personality.
+#define WAKE_RETURN_MODE MODE_STEAM
+
+// The hotkey itself. Lenovo ThinkCentre Smart Power On = Alt+P.
+#define WAKE_MOD KEYBOARD_MODIFIER_LEFTALT
+#define WAKE_KEY HID_KEY_P
+
+// How long the RF link must be continuously down before an up-edge counts as a wake gesture. Must be
+// comfortably longer than anySlotLinkUp()'s 300 ms window so an ordinary RF hiccup can't arm us.
+#define WAKE_ARM_DOWN_MS 3000u
+
+#define WAKE_HOLD_MS \
+	60u // key-down duration (EC samples HID reports, not edges)
+#define WAKE_REPEAT 2 // how many Alt+P presses to send
+#define WAKE_REPEAT_MS 600u // gap between them
+// Quiet time after the last key-up before we detach and re-enumerate as the puck. The EC latches power-on
+// immediately; this only needs to outlast the key-up transfer. POST enumeration is seconds later, so
+// there is a lot of slack here in both directions.
+#define WAKE_SETTLE_MS 1200u
+
+// Give up on the press sequence this long after it starts. If the EC deconfigures us mid-way (port reset
+// as POST takes the bus over), ready() goes false and the machine would otherwise stall in W_PRESS until
+// whatever boots next re-enumerates us -- and then receive a stray Alt+P. On deadline: all-keys-up,
+// settle, reboot to the puck.
+#define WAKE_SEQ_DEADLINE_MS 10000u
+
+// EXPERIMENTAL, default OFF; build with EXTRA_FLAGS="-DWAKE_AUTO_REARM=1" to enable. While running any
+// OTHER personality, a continuous USB suspend longer than WAKE_AUTO_REARM_MS reboots into MODE_WAKE, so
+// the wake re-arms itself every time the host goes down (the smart-power-on port keeps VBUS in S5, so the
+// MCU never cold-boots -- without this, one wake per manual arm). Off by default because S3 sleep is also
+// a persistent suspend, and a device that re-attaches mid-S3 is never configured: with this on, the
+// existing wake-on-connect-from-S3 path stops working. Use it on hosts that shut down to S4/S5.
+#ifndef WAKE_AUTO_REARM
+#define WAKE_AUTO_REARM 0
+#endif
+#define WAKE_AUTO_REARM_MS 15000u
+
+class WakeController : public IController {
+    public:
+	// STATIC mount, single HID, no slot pool: this mode never forwards controller input to the host --
+	// onReport45/onAuxReport stay no-ops so a trackpad graze can't leak a keystroke into the BIOS or the
+	// just-woken desktop. All the work happens in task().
+	void begin() override;
+	void task() override;
+	void usbIdentity() override;
+};
+extern WakeController g_wakeCtl;
+
+// Called from loop() in EVERY mode. No-op unless built with WAKE_AUTO_REARM (see above).
+void wakeAutoRearmTask();

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -102,6 +102,15 @@
 // wakeup armed -- its own listening mechanism, not the OS's sleep intent. The sleep-vs-shutdown decision
 // is sampled once, at the first suspend edge of the episode, and EC flaps cannot overwrite it.
 #define WAKE_REARM_FLAP_MS 5000u
+// ...but an episode older than this always re-samples: USB selective-suspend churn can put a sub-5 s
+// resume right before a genuine sleep, and inheriting an hours-old "shutdown" decision there would
+// re-arm under a sleeping host. The EC takeover flap arrives ~3 s into its episode, far under this cap.
+#define WAKE_REARM_EPISODE_MS 60000u
+// Dead-bus re-arm: TinyUSB only reports suspend on a bus that got a SETUP packet, so a failed wake's
+// return boot (EC cannot enumerate the composite) and a plug into an already-off host read neither
+// mounted nor suspended -- ever. Never-mounted this long after boot cannot be a live host (any real
+// boot's USB is up in well under this), so treat it as a shutdown and re-arm.
+#define WAKE_DEADBUS_REARM_MS 90000u
 
 // Post-fire handoff grace. After the hotkey is sent the machine spends tens of seconds in POST + OS boot
 // with the bus suspended (nothing has enumerated the reborn puck yet) -- which is indistinguishable from

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -97,6 +97,11 @@
 #define WAKE_AUTO_REARM 0
 #endif
 #define WAKE_AUTO_REARM_MS 15000u
+// A bus resume shorter than this does NOT start a new down-episode: during poweroff the smart-port EC
+// takes the bus over with a brief resume (~2.4 s captured on the M90q) and re-suspends WITH remote
+// wakeup armed -- its own listening mechanism, not the OS's sleep intent. The sleep-vs-shutdown decision
+// is sampled once, at the first suspend edge of the episode, and EC flaps cannot overwrite it.
+#define WAKE_REARM_FLAP_MS 5000u
 
 // Post-fire handoff grace. After the hotkey is sent the machine spends tens of seconds in POST + OS boot
 // with the bus suspended (nothing has enumerated the reborn puck yet) -- which is indistinguishable from

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -48,9 +48,19 @@
 // comfortably longer than anySlotLinkUp()'s 300 ms window so an ordinary RF hiccup can't arm us.
 #define WAKE_ARM_DOWN_MS 3000u
 
+// Press shaping. A combined Alt+P report held 60 ms was read but IGNORED by the
+// ThinkCentre M90q Gen 6 EC (it drained both repeats off the endpoint, so the
+// reports arrived; a real keyboard on the same port woke the machine). Shaping
+// the press like a human types it -- modifier alone first, long hold, restate
+// the held chord -- makes the same EC fire. Which ingredient is load-bearing is
+// untested (each attempt costs an S5 power cycle); all three are what a real
+// keyboard produces anyway.
+#define WAKE_MOD_LEAD_MS \
+	150u // Alt alone before Alt+P (EC may edge-detect modifier-then-key)
+#define WAKE_RESEND_MS 100u // restate the held report (slow-sampling ECs)
 #define WAKE_HOLD_MS \
-	60u // key-down duration (EC samples HID reports, not edges)
-#define WAKE_REPEAT 2 // how many Alt+P presses to send
+	450u // key-down duration (EC samples HID reports, not edges)
+#define WAKE_REPEAT 4 // how many Alt+P presses to send
 #define WAKE_REPEAT_MS 600u // gap between them
 // Quiet time after the last key-up before we detach and re-enumerate as the puck. The EC latches power-on
 // immediately; this only needs to outlast the key-up transfer. POST enumeration is seconds later, so

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -64,8 +64,10 @@
 #define WAKE_REPEAT_MS 600u // gap between them
 // Quiet time after the last key-up before we detach and re-enumerate as the puck. The EC latches power-on
 // immediately; this only needs to outlast the key-up transfer. POST enumeration is seconds later, so
-// there is a lot of slack here in both directions.
-#define WAKE_SETTLE_MS 1200u
+// there is a lot of slack here in both directions. Kept short: every ms here extends the RF outage the
+// triggering controller must ride out before the reborn puck answers it again (M90q: the controller gives
+// up somewhere between ~2.5 s and ~5 s of silence).
+#define WAKE_SETTLE_MS 600u
 
 // Give up on the press sequence this long after it starts. If the EC deconfigures us mid-way (port reset
 // as POST takes the bus over), ready() goes false and the machine would otherwise stall in W_PRESS until
@@ -83,6 +85,21 @@
 #define WAKE_AUTO_REARM 0
 #endif
 #define WAKE_AUTO_REARM_MS 15000u
+
+// Post-fire handoff grace. After the hotkey is sent the machine spends tens of seconds in POST + OS boot
+// with the bus suspended (nothing has enumerated the reborn puck yet) -- which is indistinguishable from
+// "the host went to sleep". Two standing policies misfire on that state: the suspend-persisted controller
+// power-off (haptics.cpp, SUSPEND_OFF_MS) shuts down the controller that just triggered the wake, and
+// WAKE_AUTO_REARM would yank the puck back into the wake personality mid-boot. wakeHandoffMark() arms a
+// PERSISTED one-shot (Cfg.wakeHandoff -- flash, because this board class's bootloader wipes .noinit RAM
+// on reset) right before the return reboot; wakeHandoffActive() then holds both policies off until a USB
+// host actually mounts us, or this deadline passes (machine never booted -> the normal power-saving
+// behavior is correct after all). The handoff boot also skips setup()'s mount wait and opens the RF
+// connect cooldown immediately, so the reborn puck answers the triggering controller ~3 s sooner --
+// before it gives up searching and powers itself off.
+#define WAKE_HANDOFF_GRACE_MS 90000u
+void wakeHandoffMark();
+bool wakeHandoffActive();
 
 class WakeController : public IController {
     public:

--- a/OpenPuck/rf_link.cpp
+++ b/OpenPuck/rf_link.cpp
@@ -157,10 +157,26 @@ static unsigned long g_lastStream = 0;
 // Used for the "we're connected to at least one controller" decisions (beacon pacing, wake detect).
 bool anySlotLinkUp()
 {
+	// The != 0 guard matches the six sibling call sites (usb_mount, webusb, ps3, puck_hid, haptics): a
+	// bonded slot that has never replied since boot holds g_connReplyMs == 0, which would otherwise read
+	// "up" for 300 ms after every millis() wrap (~49.7 days) -- and MODE_WAKE turns that glitch into an
+	// unattended Alt+P power-on.
 	for (int s = 0; s < NSLOT; s++)
-		if (g_slot[s].used && millis() - g_connReplyMs[s] < 300)
+		if (g_slot[s].used && g_connReplyMs[s] != 0 &&
+		    millis() - g_connReplyMs[s] < 300)
 			return true;
 	return false;
+}
+
+bool rfConnectOpen()
+{
+	return millis() - g_connCooldown > 2500;
+}
+
+void rfConnectOpenNow()
+{
+	// Backdate instead of zeroing: wrap-safe against the same unsigned arithmetic the gate uses.
+	g_connCooldown = millis() - 2501u;
 }
 
 static void rfHostFrameOnce(int slot, bool discovery)
@@ -741,10 +757,17 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 					}
 					if (want != 0xFF &&
 					    want == chWant[g_curSlot]) {
+						// The no-switch-while-suspended rule exists so a SLEEPING
+						// host never resumes to a different device -- but a
+						// suspended bus is MODE_WAKE's normal environment (host
+						// off / wrong port), and the chord is that mode's ONLY
+						// exit (no WebUSB, no CDC). Exempt it, like
+						// wakeAutoRearmTask already does.
 						if (++chCnt[g_curSlot] >= 12 &&
 						    want != g_usbMode &&
 						    modeValid(want) &&
-						    !USBDevice.suspended()) {
+						    (!USBDevice.suspended() ||
+						     modeIsWake(g_usbMode))) {
 							// clean detach + reboot into the new mode (releases any held
 							// input on the outgoing device -- see modeSwitchReboot)
 							modeSwitchReboot(want);
@@ -966,7 +989,7 @@ void rfLinkTask()
 	// Poll before beacons: the cycle gate must fire as close to its
 	// 4 ms deadline as possible; beacon TX (up to 3.6 ms for 4 slots)
 	// runs after so it never delays the current poll.
-	if (g_connOn && millis() - g_connCooldown > 2500) {
+	if (g_connOn && rfConnectOpen()) {
 		rfConnStep();
 	} // connected-mode: poll controller, read input
 
@@ -974,7 +997,7 @@ void rfLinkTask()
 	// real puck's per-hop-cycle announce) to stay synced and keep answering polls at full rate; suppressing it
 	// drops the reply rate from ~210/s to ~38/s. Paused only during the post-disconnect cooldown so a controller
 	// that's powering off isn't immediately re-woken/reconnected.
-	if (g_rfHost && millis() - g_connCooldown > 2500) {
+	if (g_rfHost && rfConnectOpen()) {
 		bool connNow = anySlotLinkUp();
 		// session keepalive on the clean channel: every loop while connecting (fast), every 25ms once connected
 		// (every-loop beaconing also hammers the session ch and steals reply slots from the poll). The real puck
@@ -1044,7 +1067,7 @@ void rfLinkTask()
 	// connected slot being stalled, so one controller walking off (others still live) never trips it; the
 	// cooldown gate keeps it from firing while a controller is intentionally powering off; rate-limited so it
 	// cannot thrash. g_rfStallRecover is surfaced to the panel so the wedge -- and its recovery -- is observable.
-	if (g_connOn && g_curSlot >= 0 && millis() - g_connCooldown > 2500) {
+	if (g_connOn && g_curSlot >= 0 && rfConnectOpen()) {
 		static unsigned long lastRecoverMs = 0;
 		static uint8_t consecStall = 0;
 		unsigned long nowMs2 = millis();
@@ -1092,7 +1115,11 @@ void rfLinkTask()
 		bool nowRfConn = anySlotLinkUp();
 		if (nowRfConn && !wasRfConn && USBDevice.suspended()) {
 			USBDevice.remoteWakeup();
-			ledWakePulse();
+			// Wake mode reserves the LED for hotkey presses (the
+			// WAKE_MODE.md diagnostic table); the resume itself is still
+			// wanted -- a real keyboard also resumes before typing.
+			if (!modeIsWake(g_usbMode))
+				ledWakePulse();
 			// post-resume nudge (host needs real input to actually wake)
 			if (g_active)
 				g_active->wakeEvent();

--- a/OpenPuck/rf_link.cpp
+++ b/OpenPuck/rf_link.cpp
@@ -501,7 +501,10 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 									    .suspended()) {
 									USBDevice
 										.remoteWakeup();
-									ledWakePulse();
+									// wake mode: LED = presses only
+									if (!modeIsWake(
+										    g_usbMode))
+										ledWakePulse();
 									if (g_active)
 										g_active->wakeEvent();
 								}
@@ -761,13 +764,15 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 						// host never resumes to a different device -- but a
 						// suspended bus is MODE_WAKE's normal environment (host
 						// off / wrong port), and the chord is that mode's ONLY
-						// exit (no WebUSB, no CDC). Exempt it, like
-						// wakeAutoRearmTask already does.
+						// exit (no WebUSB, no CDC) AND its only panel-less entry
+						// once the machine is already off. Exempt both
+						// directions, like wakeAutoRearmTask already does.
 						if (++chCnt[g_curSlot] >= 12 &&
 						    want != g_usbMode &&
 						    modeValid(want) &&
 						    (!USBDevice.suspended() ||
-						     modeIsWake(g_usbMode))) {
+						     modeIsWake(g_usbMode) ||
+						     modeIsWake(want))) {
 							// clean detach + reboot into the new mode (releases any held
 							// input on the outgoing device -- see modeSwitchReboot)
 							modeSwitchReboot(want);

--- a/OpenPuck/rf_link.h
+++ b/OpenPuck/rf_link.h
@@ -50,6 +50,11 @@ extern const uint32_t g_rxWin;
 
 // set on 0xF2 disconnect; pauses beacon+poll so a powering-off controller can sleep
 extern unsigned long g_connCooldown;
+// True once the post-boot / post-disconnect connect cooldown has passed, i.e. beacons + polls are on air.
+// Nothing can (re)link before this, so a "link quiet" observation made earlier proves nothing.
+bool rfConnectOpen();
+// Open the cooldown immediately (the post-wake-fire boot: the triggering controller is searching NOW).
+void rfConnectOpenNow();
 
 // connected-mode state (reset by the 'k' console toggle)
 extern uint8_t g_connSt, g_connStep;

--- a/OpenPuck/serial_console.cpp
+++ b/OpenPuck/serial_console.cpp
@@ -175,7 +175,7 @@ void serialConsolePoll()
 					g_lizKeep ? "ON" : "off");
 			}
 
-			// switch USB mode: 0=steam 1=xbox 2=hori 3=lizard 4=swpro 5=ps5 6=hidgyro 7=ps5-game/clean 8=ds4-game/clean 9=ps3(dualshock3)
+			// switch USB mode: 0=steam 1=xbox 2=hori 3=lizard 4=swpro 5=ps5 6=hidgyro 7=ps5-game/clean 8=ds4-game/clean 9=ps3(dualshock3) 10=wake(alt+p)
 			else if (line[0] == 'x') {
 				uint8_t m = strtoul(line + 1, 0, 10);
 				if (modeValid(m)) {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Similarly you can hold all 4 back buttons and press Y to switch (teehee) over to
 | WebUSB panel → mode 5 | DualSense + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 6 | DS4/HIDGYRO + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 9 | PS3 DualShock 3 / Sixaxis | Enumerates on a real PS3 (+ gyro/haptics) |
-| WebUSB panel → mode 10 | Wake (Alt+P power-on) | Boot keyboard that powers on a smart-power-on PC (Lenovo Alt+P) when the controller connects, then returns to Steam mode |
+| WebUSB panel → mode 10 | Wake (Alt+P power-on) | Boot keyboard that powers on a smart-power-on PC (Lenovo Alt+P) when the controller connects, then returns to Steam mode — setup guide: [docs/WAKE_MODE.md](./docs/WAKE_MODE.md) |
 
 I'm also adding various QOL items as I go as well. For example having to hold the Steam button for like 6 seconds feels like an eternity. If Steam is open you can do Steam + Y for a shutdown. I'm adding Steam + Y for 2 seconds as a shutdown chort in ALL modes now.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Similarly you can hold all 4 back buttons and press Y to switch (teehee) over to
 | WebUSB panel → mode 5 | DualSense + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 6 | DS4/HIDGYRO + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 9 | PS3 DualShock 3 / Sixaxis | Enumerates on a real PS3 (+ gyro/haptics) |
-| WebUSB panel → mode 10 | Wake (Alt+P power-on) | Boot keyboard that powers on a smart-power-on PC (Lenovo Alt+P) when the controller connects, then returns to Steam mode — setup guide: [docs/WAKE_MODE.md](./docs/WAKE_MODE.md) |
+| WebUSB panel → mode 10 | Wake (Alt+P power-on) | Boot keyboard that powers on a smart-power-on PC (Lenovo Alt+P) when the controller connects, then returns to the normal puck (your persisted mode, or Steam) — setup guide: [docs/WAKE_MODE.md](./docs/WAKE_MODE.md) |
 
 I'm also adding various QOL items as I go as well. For example having to hold the Steam button for like 6 seconds feels like an eternity. If Steam is open you can do Steam + Y for a shutdown. I'm adding Steam + Y for 2 seconds as a shutdown chort in ALL modes now.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Similarly you can hold all 4 back buttons and press Y to switch (teehee) over to
 | WebUSB panel → mode 5 | DualSense + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 6 | DS4/HIDGYRO + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 9 | PS3 DualShock 3 / Sixaxis | Enumerates on a real PS3 (+ gyro/haptics) |
+| WebUSB panel → mode 10 | Wake (Alt+P power-on) | Boot keyboard that powers on a smart-power-on PC (Lenovo Alt+P) when the controller connects, then returns to Steam mode |
 
 I'm also adding various QOL items as I go as well. For example having to hold the Steam button for like 6 seconds feels like an eternity. If Steam is open you can do Steam + Y for a shutdown. I'm adding Steam + Y for 2 seconds as a shutdown chort in ALL modes now.
 

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -85,10 +85,16 @@ Then a persistent USB suspend (≥15 s) in any other mode reboots the puck into
 wake mode by itself: shut the machine down, and the next controller power-on
 wakes it — no interaction with the puck ever again.
 
-**Trade-off, read before enabling:** S3 sleep is *also* a persistent suspend.
-With this flag the puck re-attaches as a keyboard mid-sleep, which breaks the
-existing wake-from-S3 (controller-connect remote wakeup) path. Use it only on
-hosts that fully shut down. Validated end-to-end on the M90q Gen 6.
+**Sleep vs shutdown:** the firmware tells them apart by the host's own hand —
+an OS going to sleep arms USB remote wakeup on the puck first (that's what
+makes the existing wake-from-S3 feature work), and such suspends never
+re-arm, so sleeping the machine leaves the puck a normal puck and
+controller-wake-from-sleep keeps working. A shutdown never arms remote
+wakeup, so it re-arms as intended. Caveat: if your OS has wakeup *disabled*
+for the device (Linux: `power/wakeup` in sysfs), its sleep looks like a
+shutdown and the puck will re-arm mid-sleep — recover with the escape chord
+or a replug, or enable device wakeup. Validated end-to-end on the M90q
+Gen 6.
 
 ## 6. Other vendors / tuning the press
 

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -100,14 +100,19 @@ controller-wake-from-sleep keeps working. A shutdown never arms remote
 wakeup, so it re-arms as intended — even though some ECs (the M90q's
 included) re-arm the feature themselves when they take the port over in S5;
 the decision is sampled from the OS's own suspend, so that doesn't confuse
-it. A wake that *fails* (machine never boots) re-arms again 90 s later, so
-the next press still works. Two caveats: if your OS has wakeup *disabled*
-for the device (Linux: `power/wakeup` in sysfs), its sleep looks like a
-shutdown and the puck will re-arm mid-sleep — recover with the escape chord
-or a replug, or enable device wakeup. And a host that arms remote wakeup
-once but never clears it (Linux clears on resume; other OSes untested) would
-make shutdowns look like sleeps — if auto-rearm silently stops re-arming on
-your machine, that's the signature. Validated end-to-end on the M90q Gen 6.
+it. A wake that *fails* (machine never boots) re-arms again when the 90 s
+handoff grace runs out (~90–105 s after the fire), so a later press still
+works. Three caveats: if your OS has wakeup *disabled* for the device
+(Linux: `power/wakeup` in sysfs), its sleep looks like a shutdown and the
+puck will re-arm mid-sleep — recover with the escape chord or a replug, or
+enable device wakeup. A host that arms remote wakeup once but never clears
+it (Linux clears on resume; other OSes untested) would make shutdowns look
+like sleeps — if auto-rearm silently stops re-arming on your machine, that's
+the signature. And if the *puck itself* restarts while the host is asleep
+(replug, firmware flash, watchdog reset), a sleeping host is indistinguishable
+from an off one — the puck re-arms ~45 s later and the resumed session finds
+the wake keyboard instead of a controller; escape-chord or replug recovers.
+Validated end-to-end on the M90q Gen 6.
 
 ## 6. Other vendors / tuning the press
 
@@ -132,8 +137,9 @@ controller still connected can't type into a live session) → fire on the
 first controller connect → settle → reboot into the return mode with a
 persisted one-shot **handoff grace**. During the grace (up to 90 s; it ends
 early once the OS has been stably up for 20 s — a bar BIOS POST enumeration
-never clears — so a quick shutdown after a wake behaves normally), two
-standing behaviors that would otherwise
+never clears, so a quick shutdown after a wake behaves normally; the one
+exception is parking in BIOS setup for 20 s+ right after a wake, which also
+ends the grace early), two standing behaviors that would otherwise
 misread a POSTing machine as "host went to sleep" hold their fire: the
 suspend-triggered controller power-off, and `WAKE_AUTO_REARM` itself. If the
 machine never boots, the grace expires and the controller is powered off

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -51,12 +51,19 @@ still on can't type into your live session.
    normal puck again and the controller has reconnected by itself —
    single press, end to end.
 
-The escape hatch from wake mode without firing is the **all-four-back-paddles
-+ A** chord on a connected controller: it reboots straight back to Steam
-mode, and works whether the machine is on or off (wake mode is exempt from
-the usual no-mode-switch-while-suspended rule — it has no other exit). Note
-the wake trigger is *any* bonded controller connecting; with two controllers,
-one left powered on prevents arming until it, too, goes quiet.
+**Leaving wake mode.** The **all-four-back-paddles + A** chord on a connected
+controller reboots straight back to Steam mode, and works whether the machine
+is on or off (wake mode is exempt from the usual
+no-mode-switch-while-suspended rule in both directions — the chord is also
+how you *enter* mode 10 with the machine already off). Timing matters,
+though: the chord only escapes **without firing** while the controller that
+was connected at the mode switch stays connected (the mode never arms with a
+link up). Once armed, a *fresh* controller connect is the wake gesture and
+fires immediately — on a running machine that types the hotkey once into the
+session and bounces back to the normal puck by itself, which is the other,
+cruder way out. Note the trigger is *any* bonded controller connecting; with
+two controllers, one left powered on prevents arming until it, too, goes
+quiet.
 
 ## 4. The LED tells you what happened
 
@@ -68,7 +75,7 @@ diagnostic story:
 
 | You see | It means |
 | --- | --- |
-| No pulses when the controller connects | The EC never enumerated/configured the keyboard: wrong port, BIOS feature off, or the machine's EC doesn't service USB in S5. |
+| No pulses when the controller connects | First rule out timing: the mode arms ~8 s after the link goes quiet (2.5 s radio bring-up + 5 s observed quiet), so a power-press within ~8 s of shutdown, or a second bonded controller still powered on, means it simply was not armed yet — power the controller off, wait ~10 s, try again. If timing is ruled out: the EC never enumerated/configured the keyboard — wrong port, BIOS feature off, or the machine's EC doesn't service USB in S5. |
 | Pulses, machine stays off | Reports were delivered but the hotkey parser rejected them: wrong hotkey for your vendor (§6), or the EC wants different press shaping (`WAKE_*` timings in `mode_wake.h`). |
 | Pulses, machine powers on | Working as intended. |
 
@@ -90,11 +97,17 @@ an OS going to sleep arms USB remote wakeup on the puck first (that's what
 makes the existing wake-from-S3 feature work), and such suspends never
 re-arm, so sleeping the machine leaves the puck a normal puck and
 controller-wake-from-sleep keeps working. A shutdown never arms remote
-wakeup, so it re-arms as intended. Caveat: if your OS has wakeup *disabled*
+wakeup, so it re-arms as intended — even though some ECs (the M90q's
+included) re-arm the feature themselves when they take the port over in S5;
+the decision is sampled from the OS's own suspend, so that doesn't confuse
+it. A wake that *fails* (machine never boots) re-arms again 90 s later, so
+the next press still works. Two caveats: if your OS has wakeup *disabled*
 for the device (Linux: `power/wakeup` in sysfs), its sleep looks like a
 shutdown and the puck will re-arm mid-sleep — recover with the escape chord
-or a replug, or enable device wakeup. Validated end-to-end on the M90q
-Gen 6.
+or a replug, or enable device wakeup. And a host that arms remote wakeup
+once but never clears it (Linux clears on resume; other OSes untested) would
+make shutdowns look like sleeps — if auto-rearm silently stops re-arming on
+your machine, that's the signature. Validated end-to-end on the M90q Gen 6.
 
 ## 6. Other vendors / tuning the press
 

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -1,0 +1,110 @@
+# Wake Mode (MODE_WAKE): powering on a shut-down PC from the controller
+
+Wake mode turns the puck into a bare USB boot keyboard that types the firmware
+"smart power on" hotkey (Lenovo: **Alt+P**) the moment your controller
+connects, powering on a **fully shut down (S5)** machine — then reboots itself
+back into the normal puck so the booted OS sees the controller as usual. USB
+remote wakeup only covers sleep (S3); this covers real power-on.
+
+**Nothing about this mode is active by default.** If you never enter mode 10,
+the puck behaves exactly as before on every machine, Lenovo or not.
+
+## 1. Requirements
+
+- A PC whose firmware can power on from a USB keyboard hotkey. Developed and
+  validated on a **Lenovo ThinkCentre M90q Gen 6** ("Smart Power On", Alt+P).
+  Other vendors have equivalents under different names and different key
+  chords — see §6.
+- The puck plugged into the machine's **designated always-on USB port** (on
+  ThinkCentres the Smart Power On port; the EC only services that port in S5).
+- BIOS setting enabled: **Setup → Power → Smart Power On → Enabled**.
+
+Sanity check before involving the puck at all: plug a real USB keyboard into
+that port, shut the machine down, press Alt+P. If the machine doesn't power
+on, fix the BIOS/port first — the puck can't succeed where a real keyboard
+fails.
+
+## 2. Entering wake mode
+
+Any of the usual mode-switch paths, to mode **10**:
+
+- **WebUSB panel**: the *Wake (Alt+P)* mode button. Note the panel cannot
+  connect while the puck **is** in wake mode (a bare keyboard has no WebUSB);
+  it returns to the puck automatically after firing, or via the escape chord.
+- **CDC serial console**: `x10`.
+- **A configurable chord**: assign mode 10 to one of the back-4 + D-pad
+  chords from the panel.
+
+With the default "always boot Steam" policy this is a **one-shot**: one wake,
+then the puck is back to normal. See §5 for making it automatic.
+
+## 3. Using it
+
+1. Enter wake mode (the controller can still be on — arming waits for it).
+2. Power the controller off and shut the machine down.
+3. To wake: **press the controller's power button.** The puck types the
+   hotkey, the machine powers on, and by the time the OS is up the puck is a
+   normal puck again and the controller has reconnected by itself —
+   single press, end to end.
+
+The escape hatch from wake mode without firing is the **all-four-back-paddles
++ A** chord: reboots straight back to Steam mode.
+
+## 4. The LED tells you what happened
+
+The wake-mode LED is **dark in every steady state** and pulses ~½ s per
+hotkey report actually sent (default: 4 pulses over ~5 s). That makes it the
+whole diagnostic story:
+
+| You see | It means |
+| --- | --- |
+| No pulses when the controller connects | The EC never enumerated/configured the keyboard: wrong port, BIOS feature off, or the machine's EC doesn't service USB in S5. |
+| Pulses, machine stays off | Reports were delivered but the hotkey parser rejected them: wrong hotkey for your vendor (§6), or the EC wants different press shaping (`WAKE_*` timings in `mode_wake.h`). |
+| Pulses, machine powers on | Working as intended. |
+
+## 5. Automatic re-arming (`WAKE_AUTO_REARM`)
+
+By default one wake requires one manual mode-10 switch. For a machine that
+always **shuts down** (S4/S5) rather than sleeping, build with:
+
+```bash
+make build EXTRA_FLAGS="-DWAKE_AUTO_REARM=1"
+```
+
+Then a persistent USB suspend (≥15 s) in any other mode reboots the puck into
+wake mode by itself: shut the machine down, and the next controller power-on
+wakes it — no interaction with the puck ever again.
+
+**Trade-off, read before enabling:** S3 sleep is *also* a persistent suspend.
+With this flag the puck re-attaches as a keyboard mid-sleep, which breaks the
+existing wake-from-S3 (controller-connect remote wakeup) path. Use it only on
+hosts that fully shut down. Validated end-to-end on the M90q Gen 6.
+
+## 6. Other vendors / tuning the press
+
+Everything the EC sees is a `#define` at the top of `mode_wake.h`:
+
+- `WAKE_MOD` / `WAKE_KEY` — the hotkey (default `LEFTALT` + `P`, Lenovo).
+  Change these for Dell/HP/etc. equivalents.
+- `WAKE_MOD_LEAD_MS`, `WAKE_HOLD_MS`, `WAKE_RESEND_MS`, `WAKE_REPEAT`,
+  `WAKE_REPEAT_MS` — press shaping. The defaults imitate a human keystroke
+  (modifier first, long held chord, restated while held) because the M90q's
+  EC **ignores** a minimal combined report even though it reads it; other ECs
+  are likely no less picky.
+- `WAKE_RETURN_MODE` — which personality to return to after firing (default
+  Steam).
+
+## 7. What happens behind the scenes (and what was hard)
+
+Full flow: arm (3 s of RF-link silence, so switching modes with the
+controller still connected can't type into a live session) → fire on the
+first controller connect → settle → reboot into the return mode with a
+persisted one-shot **handoff grace**. During the grace (until the OS actually
+enumerates the puck, or 90 s), two standing behaviors that would otherwise
+misread a POSTing machine as "host went to sleep" hold their fire: the
+suspend-triggered controller power-off, and `WAKE_AUTO_REARM` itself. The
+post-fire boot also skips the USB mount wait and starts RF beacons
+immediately, so the controller that triggered the wake reconnects in well
+under a second instead of giving up during POST. Design details and the
+hardware findings behind each decision are in `mode_wake.h` / `mode_wake.cpp`
+comments.

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -130,9 +130,10 @@ Everything the EC sees is a `#define` at the top of `mode_wake.h`:
 Full flow: arm (~5 s of observed RF-link silence, so switching modes with the
 controller still connected can't type into a live session) → fire on the
 first controller connect → settle → reboot into the return mode with a
-persisted one-shot **handoff grace**. During the grace (a fixed 90 s window —
-deliberately *not* ended by USB enumeration, which BIOSes perform during POST
-long before the OS is up), two standing behaviors that would otherwise
+persisted one-shot **handoff grace**. During the grace (up to 90 s; it ends
+early once the OS has been stably up for 20 s — a bar BIOS POST enumeration
+never clears — so a quick shutdown after a wake behaves normally), two
+standing behaviors that would otherwise
 misread a POSTing machine as "host went to sleep" hold their fire: the
 suspend-triggered controller power-off, and `WAKE_AUTO_REARM` itself. If the
 machine never boots, the grace expires and the controller is powered off

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -35,8 +35,12 @@ Any of the usual mode-switch paths, to mode **10**:
 - **A configurable chord**: assign mode 10 to one of the back-4 + D-pad
   chords from the panel.
 
-With the default "always boot Steam" policy this is a **one-shot**: one wake,
-then the puck is back to normal. See §5 for making it automatic.
+Entering wake mode is always a **one-shot**: one wake, then the puck returns
+to your normal personality (the persisted mode if you use *persist last
+mode*, Steam otherwise). See §5 for making it automatic. Arming takes a few
+seconds — the mode requires ~5 s of observed controller-radio silence before
+a connect counts as a wake gesture, so switching modes with the controller
+still on can't type into your live session.
 
 ## 3. Using it
 
@@ -48,13 +52,19 @@ then the puck is back to normal. See §5 for making it automatic.
    single press, end to end.
 
 The escape hatch from wake mode without firing is the **all-four-back-paddles
-+ A** chord: reboots straight back to Steam mode.
++ A** chord on a connected controller: it reboots straight back to Steam
+mode, and works whether the machine is on or off (wake mode is exempt from
+the usual no-mode-switch-while-suspended rule — it has no other exit). Note
+the wake trigger is *any* bonded controller connecting; with two controllers,
+one left powered on prevents arming until it, too, goes quiet.
 
 ## 4. The LED tells you what happened
 
 The wake-mode LED is **dark in every steady state** and pulses ~½ s per
-hotkey report actually sent (default: 4 pulses over ~5 s). That makes it the
-whole diagnostic story:
+hotkey press (default: 4 pulses over ~5 s). In wake mode the LED is reserved
+for presses — the connect-time remote-wakeup pulse other modes show is
+suppressed so it can't be mistaken for a fire. That makes it the whole
+diagnostic story:
 
 | You see | It means |
 | --- | --- |
@@ -91,18 +101,23 @@ Everything the EC sees is a `#define` at the top of `mode_wake.h`:
   (modifier first, long held chord, restated while held) because the M90q's
   EC **ignores** a minimal combined report even though it reads it; other ECs
   are likely no less picky.
-- `WAKE_RETURN_MODE` — which personality to return to after firing (default
-  Steam).
+- `WAKE_RETURN_MODE` — which personality to return to after firing. The
+  default (`0xFF`) means "the normal boot policy": your persisted mode if
+  *persist last mode* is on, Steam otherwise. Set a concrete mode to force
+  one.
 
 ## 7. What happens behind the scenes (and what was hard)
 
-Full flow: arm (3 s of RF-link silence, so switching modes with the
+Full flow: arm (~5 s of observed RF-link silence, so switching modes with the
 controller still connected can't type into a live session) → fire on the
 first controller connect → settle → reboot into the return mode with a
-persisted one-shot **handoff grace**. During the grace (until the OS actually
-enumerates the puck, or 90 s), two standing behaviors that would otherwise
+persisted one-shot **handoff grace**. During the grace (a fixed 90 s window —
+deliberately *not* ended by USB enumeration, which BIOSes perform during POST
+long before the OS is up), two standing behaviors that would otherwise
 misread a POSTing machine as "host went to sleep" hold their fire: the
-suspend-triggered controller power-off, and `WAKE_AUTO_REARM` itself. The
+suspend-triggered controller power-off, and `WAKE_AUTO_REARM` itself. If the
+machine never boots, the grace expires and the controller is powered off
+after all — the battery is still saved. The
 post-fire boot also skips the USB mount wait and starts RF beacons
 immediately, so the controller that triggered the wake reconnects in well
 under a second instead of giving up during POST. Design details and the

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,7 +165,7 @@
         <button data-mode="9" class="modebtn">PS3 (DualShock 3)</button>
         <button data-mode="10" class="modebtn">Wake (Alt+P power-on)</button>
       </div>
-      <p class="note">Switching reboots the copycat and re-enumerates USB (~2 s). WebUSB works in every mode, including Steam/Lizard with Steam running (Chrome claims the vendor interface; Steam keeps the HID slots). Switch HORIPAD + WebUSB is PC-only. Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): the panel cannot connect to it; it fires once when a controller connects and reboots back to Steam mode (or chord back-4 + A to leave it).</p>
+      <p class="note">Switching reboots the copycat and re-enumerates USB (~2 s). WebUSB works in every mode, including Steam/Lizard with Steam running (Chrome claims the vendor interface; Steam keeps the HID slots). Switch HORIPAD + WebUSB is PC-only. Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): the panel cannot connect to it; it fires once when a controller connects and returns to the normal puck (chord back-4 + A on a still-connected controller to leave it before it arms).</p>
       <div class="row"><label>Persist last mode</label>
         <button id="persistMode">off</button>
         <span class="note" style="flex:1">Off (default): every restart / fresh reconnect boots into Steam mode. On: remembers the last mode you selected.</span>
@@ -2227,7 +2227,7 @@ for(const b of document.querySelectorAll(".modebtn")){
   b.onclick=()=>{ const m=+b.dataset.mode;
     const clean=(m===7||m===8||m===9||m===10);
     const why=(m===10)
-      ? "Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): it has no WebUSB, so THIS PANEL WILL DISCONNECT. It fires once when a controller connects after the machine is shut down, then returns to the normal puck by itself. To leave it WITHOUT firing, chord all four back paddles (L4+R4+L5+R5) + A on a connected controller. Setup guide: docs/WAKE_MODE.md."
+      ? "Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): it has no WebUSB, so THIS PANEL WILL DISCONNECT. It fires once when a controller connects after the machine is shut down, then returns to the normal puck by itself. To leave it WITHOUT firing, chord all four back paddles (L4+R4+L5+R5) + A on a STILL-CONNECTED controller before it arms (~8 s); once armed, a fresh controller connect fires immediately. Setup guide: docs/WAKE_MODE.md."
       : "the game/clean PlayStation modes (and PS3) drop WebUSB + host-wake, so THIS PANEL WILL DISCONNECT and can't reach the device while it's in this mode. To get back, chord on the controller: hold all four back paddles (L4+R4+L5+R5) + A to return to Steam mode. The back4+D-pad chords are how you get back INTO these modes without the panel — check their assignments in the chords card first.";
     const msg="Switch to "+MODE_NAMES[m]+"? The copycat will reboot."+(clean?"\n\nNOTE: "+why:"");
     if(confirm(msg)){ send([0x03, m]); log("mode switch requested — device will reboot"); } };

--- a/docs/index.html
+++ b/docs/index.html
@@ -163,8 +163,9 @@
         <button data-mode="5" class="modebtn">PS5 DualSense</button>
         <button data-mode="6" class="modebtn">HID gyro (DS4)</button>
         <button data-mode="9" class="modebtn">PS3 (DualShock 3)</button>
+        <button data-mode="10" class="modebtn">Wake (Alt+P power-on)</button>
       </div>
-      <p class="note">Switching reboots the copycat and re-enumerates USB (~2 s). WebUSB works in every mode, including Steam/Lizard with Steam running (Chrome claims the vendor interface; Steam keeps the HID slots). Switch HORIPAD + WebUSB is PC-only.</p>
+      <p class="note">Switching reboots the copycat and re-enumerates USB (~2 s). WebUSB works in every mode, including Steam/Lizard with Steam running (Chrome claims the vendor interface; Steam keeps the HID slots). Switch HORIPAD + WebUSB is PC-only. Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): the panel cannot connect to it; it fires once when a controller connects and reboots back to Steam mode (or chord back-4 + A to leave it).</p>
       <div class="row"><label>Persist last mode</label>
         <button id="persistMode">off</button>
         <span class="note" style="flex:1">Off (default): every restart / fresh reconnect boots into Steam mode. On: remembers the last mode you selected.</span>
@@ -388,7 +389,7 @@
 </div>
 
 <script>
-const MODE_NAMES = ["Steam (puck)","Xbox 360","Switch (HORIPAD)","Lizard (always)","Switch Pro + gyro","PS5 DualSense","HID gyro (DS4)","PS5 (game/clean)","DS4 (game/clean)","PS3 (DualShock 3)"];
+const MODE_NAMES = ["Steam (puck)","Xbox 360","Switch (HORIPAD)","Lizard (always)","Switch Pro + gyro","PS5 DualSense","HID gyro (DS4)","PS5 (game/clean)","DS4 (game/clean)","PS3 (DualShock 3)","Wake (Alt+P power-on)"];
 const CHORD_FIELD = [17, 18, 19];          // back4 + B/X/Y
 const CHORD_DPAD_FIELD = [34, 35, 36, 37]; // back4 + D-pad left/up/right/down (firmware protocol >= 18)
 const CHORD_DPAD_DEF = [9, 8, 7, 2];       // firmware defaults: PS3, DS4 game, PS5 game, Switch HORIPAD
@@ -678,7 +679,7 @@ function setTab(et){
   setTab(0);
 })();
 for(const sel of document.querySelectorAll("select.chord")){
-  MODE_NAMES.forEach((n,i)=>{ if(i===7||i===8) return;
+  MODE_NAMES.forEach((n,i)=>{ if(i===7||i===8||i===10) return;
     const o=document.createElement("option"); o.value=i; o.textContent=n; sel.appendChild(o); });
 }
 // D-pad chords offer EVERY mode, including the game/clean ones the face selects skip: those modes drop WebUSB,

--- a/docs/index.html
+++ b/docs/index.html
@@ -2225,8 +2225,11 @@ for(const sel of document.querySelectorAll("select.chordD")){
 }
 for(const b of document.querySelectorAll(".modebtn")){
   b.onclick=()=>{ const m=+b.dataset.mode;
-    const clean=(m===7||m===8||m===9);
-    const msg="Switch to "+MODE_NAMES[m]+"? The copycat will reboot."+(clean?"\n\nNOTE: the game/clean PlayStation modes (and PS3) drop WebUSB + host-wake, so THIS PANEL WILL DISCONNECT and can't reach the device while it's in this mode. To get back, chord on the controller: hold all four back paddles (L4+R4+L5+R5) + A to return to Steam mode. The back4+D-pad chords are how you get back INTO these modes without the panel — check their assignments in the chords card first.":"");
+    const clean=(m===7||m===8||m===9||m===10);
+    const why=(m===10)
+      ? "Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): it has no WebUSB, so THIS PANEL WILL DISCONNECT. It fires once when a controller connects after the machine is shut down, then returns to the normal puck by itself. To leave it WITHOUT firing, chord all four back paddles (L4+R4+L5+R5) + A on a connected controller. Setup guide: docs/WAKE_MODE.md."
+      : "the game/clean PlayStation modes (and PS3) drop WebUSB + host-wake, so THIS PANEL WILL DISCONNECT and can't reach the device while it's in this mode. To get back, chord on the controller: hold all four back paddles (L4+R4+L5+R5) + A to return to Steam mode. The back4+D-pad chords are how you get back INTO these modes without the panel — check their assignments in the chords card first.";
+    const msg="Switch to "+MODE_NAMES[m]+"? The copycat will reboot."+(clean?"\n\nNOTE: "+why:"");
     if(confirm(msg)){ send([0x03, m]); log("mode switch requested — device will reboot"); } };
 }
 updateUf2UI();


### PR DESCRIPTION
## Summary
Adds **MODE_WAKE** (mode 10): a bare boot-protocol keyboard personality that powers on a fully shut-down (S5) host through firmware "smart power on" (Lenovo: Alt+P from the always-on USB port). On the first controller connect after a 3 s link-quiet arming period it types the hotkey and reboots back into the puck — by the time the OS is up, the puck is a normal puck and the controller has reconnected by itself. USB remote wakeup only covers S3; this covers real power-on.

**Hardware-validated on SteamOS** (Lenovo ThinkCentre M90q Gen 6), including the optional `WAKE_AUTO_REARM=1` build: shut down → puck re-arms itself → one controller power-button press → machine boots → controller is connected and working in SteamOS. Not yet exercised on a Windows host. A subsequent adversarial-review hardening pass (`46ac644`) tightened the arming/trigger/grace paths and was re-validated end-to-end on the same hardware. Should apply to any Lenovo/Dell-class box with a keyboard-hotkey power-on feature — hotkey/press-shaping/return mode are `#define`s at the top of `mode_wake.h`.

**Default behavior is unchanged for everyone who doesn't use it.** Mode 10 is only entered explicitly (panel / console `x10` / assignable chord); `WAKE_AUTO_REARM` is compile-time off; the new suspend-policy gates are inert unless the puck is in wake mode or booting off a wake fire; the cfg layout is byte-identical (a dead reserved byte is repurposed, old `cfg.bin` files load unchanged).

**User docs:** [docs/WAKE_MODE.md](https://github.com/Saffsanity/openpuck/blob/mode-wake/docs/WAKE_MODE.md) — BIOS setup, the designated port, LED diagnostics, auto-rearm trade-offs, adapting to other vendors.

## Design notes
- **Dedicated personality, not an extra puck interface.** The S5 embedded controller runs a minimal host stack written against real keyboards, so it sees exactly one boot keyboard and nothing else (reuses the clean-PS `bareHid` gating in `setup()`; keeps remote-wakeup in bmAttributes like a real keyboard). Also endpoint budget — the puck uses 6 of 7 IN.
- **Trigger** = the `anySlotLinkUp()` connect up-edge (F-type replies only, so a neighbor puck's shared-address beacon can't false-fire), latched 2 s so an EC that suspends the port between enumeration and the press still fires — but a controller that connected against a dead port can't fire hours later into a manually booted OS. Arming requires ~5 s of *observed* link silence (the quiet clock runs only while RF is on air) so chording in with a connected controller doesn't type Alt+P into the live session.
- **Press shaping** (hardware finding): the M90q EC reads but *ignores* a minimal combined Alt+P report; it accepts a human-shaped press — modifier alone first, long held chord restated while held, repeated. A real keyboard on the same port works either way, so the shaping is just "what a real keyboard produces".
- **Post-fire handoff grace** (hardware finding): after the hotkey lands, the EC hands the port to the chipset and the bus suspends — during the press sequence *and* through POST. Without a grace, the suspend-persisted controller power-off kills the controller that just triggered the wake, and `WAKE_AUTO_REARM` re-enters wake mode mid-boot. The grace is a one-shot **persisted in cfg** (`Cfg.wakeHandoff`, the dead `rsvd1` byte — this board class's bootloader wipes `.noinit` RAM every reset, and the return mode-switch already rewrites cfg, so persistence is free); it is deadline-only (90 s — a POST-time BIOS SET_CONFIGURATION reads `mounted()` long before the OS is up, so ending on mount would re-expose the kill during the BIOS→kernel gap), and a machine that never boots still gets the battery-saving power-off via an expiry fallback. The grace boot also skips `setup()`'s 3 s mount wait and opens the RF connect cooldown, putting beacons on air on the first `loop()` pass — the triggering controller relinks in 0.424 s (measured) instead of giving up during POST.
- **`WAKE_SEQ_DEADLINE_MS`** (10 s) bails to settle-and-reboot if the EC deconfigures us mid-sequence, so a booted OS never receives a stray Alt+P.
- **`WAKE_AUTO_REARM`** — compile-time, **off by default**. Persistent suspend in any other mode reboots into MODE_WAKE so it re-arms itself (the smart-power-on port keeps VBUS in S5, so the MCU never cold-boots). **Sleep-aware**: the OS arms `DEVICE_REMOTE_WAKEUP` before S3 (that's what makes wake-from-S3 work), a shutdown never does — sampled once at the first suspend edge of a down-episode, so the Smart Power On EC re-arming the feature during its S5 port takeover (a real M90q behavior caught by black-box tracing) can't masquerade as a sleeping OS. Sleeping leaves the puck a puck and controller-wake-from-S3 keeps working; shutdown re-arms. Still off by default: a host with device wakeup disabled in sysfs reads sleep as shutdown (degrades to re-arm-on-sleep). It intentionally bypasses the "no mode switch while suspended" rule the chord/console paths follow — rationale in `mode_wake.cpp`.

## Commits
1. `mode_wake.{h,cpp}` + plumbing (`config.h`, `controllers.cpp`, `OpenPuck.ino`, `serial_console.cpp`); also fixes a hardcoded `<= 9` bound in the `MODE_SUFFIX` lookup that the `MODE_MAX` bump would otherwise have desynced.
2. Surfacing: panel mode button + `MODE_NAMES`, README row, CODE_MAP section.
3. Press shaping (from S5 hardware testing — see PR comments for the full campaign).
4. Handoff grace + fast post-fire RF bring-up (ditto).
5. `docs/WAKE_MODE.md` user guide.
6. Review hardening: two independent adversarial review passes over the branch, all nine confirmed findings fixed (arming race, edge-latched trigger, escape-chord suspend exemption, persist-mode preservation, deadline-only grace, narrowed suspend power-off gate + never-booted fallback, LED contract, panel dialog, `anySlotLinkUp` millis-wrap guard).

## Open question for maintainer
Identity is `28DE:574B` — Valve VID with an invented PID, following the ReversePuck `28DE:1302` precedent. Happy to change if you'd prefer something else.

## Status
- [x] clang-format-18 clean; trailing-comment lint adds zero new violations (a handful pre-exist upstream in touched files)
- [x] Both `WAKE_AUTO_REARM` variants compile clean (arduino-cli, adafruit:nrf52 1.7.0)
- [x] Hardware-validated end-to-end on the M90q Gen 6, including re-validation of the review-hardening commit `46ac644` (full S5 auto-rearm cycle + arming-race negative test — see the hardware comments)
- [ ] CI has not run on this PR yet (first-time contributor) — maintainer: the Format/Build workflow runs need approval


