### PR TITLE
Add MODE_WAKE: smart-power-on wake personality (Lenovo Alt+P)

### DIFF
--- a/CODE_MAP.md
+++ b/CODE_MAP.md
@@ -76,8 +76,9 @@ re-add wake mouse + `g_active->mountSlots(k)` + WebUSB in locked instance order,
   (`g_swGyroLegacy` is declared here but lives in `mode_switch_pro.cpp`/`swprocfg.bin`.)
 - `struct Cfg` is serialized to `/cfg.bin` (LittleFS), magic `0xCF`. `rxWin10`,
   `lizKeep`, `landAll87` and the per-type table travel with it; `rsvd0` is the
-  one-shot debug-CDC arm and `rsvd1` the ex-rumble-strength slot (both kept so the
-  on-flash layout is unchanged). New fields are **appended to the tail** (`chordDpad[4]`) —
+  one-shot debug-CDC arm and `wakeHandoff` (ex `rsvd1`, the old rumble-strength slot)
+  the one-shot post-wake-fire handoff arm (0xA5 sentinel; see mode_wake) -- both offsets
+  kept so the on-flash layout is unchanged. New fields are **appended to the tail** (`chordDpad[4]`) —
   `loadCfg()` prefills `0xFF` and accepts a file short by only the tail (`CFG_LEN_MIN`),
   so an upgrade keeps every existing setting and unwritten tail bytes fall back to defaults.
 - `loadCfg()` resolves the boot mode policy: one-shot `bootMode` wins once then clears;
@@ -422,6 +423,33 @@ Reads `g_qamMap`/`g_abSwap`/`g_back[]`. Pure transforms, no buffers beyond calle
   `wakeHidReady`, `wakeHidMove(dx,dy)` → `g_wakeHid.mouseReport(0,0,dx,dy,0,0)`
   (buttons always 0). Poll interval 10 ms. No buffers/delays/loops; only shared state is
   the one flag set once at begin.
+
+### `mode_wake.cpp` / `mode_wake.h`  (`g_wakeCtl`, MODE_WAKE)
+Boot-keyboard-only wake personality (28DE:574B): powers on a shut-down (S5) host whose
+firmware watches the port for a keyboard hotkey (Lenovo Smart Power On = Alt+P).
+- **loop task only**: `task()` state machine -- OBSERVED RF link quiet >= `WAKE_ARM_DOWN_MS`
+  arms it (the quiet clock runs only while `rfConnectOpen()`, so unobservable boot time
+  never counts); the gesture is an `anySlotLinkUp()` up-EDGE latched `WAKE_FIRE_LATCH_MS`
+  until `g_kbd.ready()`, which sends the shaped press sequence (`WAKE_MOD_LEAD_MS` Alt
+  alone, `WAKE_HOLD_MS` held chord restated every `WAKE_RESEND_MS`, x `WAKE_REPEAT`) then
+  `modeSwitchReboot(WAKE_RETURN_MODE)` (0xFF = boot-policy default). Registers no report
+  callbacks and forwards no controller input. `WAKE_SEQ_DEADLINE_MS` bails the sequence if
+  the EC deconfigures us.
+- **Post-fire handoff grace**: `wakeHandoffMark()` persists a one-shot 0xA5 sentinel in
+  `Cfg.wakeHandoff` (flash -- this board class's bootloader wipes .noinit) consumed by
+  `loadCfg`; `wakeHandoffActive()` (deadline-only, `WAKE_HANDOFF_GRACE_MS`) holds the
+  suspend controller power-off + auto-rearm through POST, and the grace boot skips the
+  mount wait + opens the RF connect cooldown (`rfConnectOpenNow`). `wakeFireInFlight()` /
+  `wakeHandoffExpired()` are the haptics-side gates.
+- `wakeAutoRearmTask()` (called from `loop()` in every mode): `WAKE_AUTO_REARM` opt-in --
+  sleep-aware re-arm. Samples the host's `DEVICE_REMOTE_WAKEUP` arming (`tud_suspend_cb`)
+  once per down-episode (flap filter `WAKE_REARM_FLAP_MS` vs the EC's S5 port-takeover
+  re-arm, age cap `WAKE_REARM_EPISODE_MS`); armed = sleeping host, never re-arm. The
+  countdown runs from the last suspend edge (`WAKE_AUTO_REARM_MS` continuous), plus a
+  dead-bus path (`WAKE_DEADBUS_REARM_MS` from the moment the bus was lost) covering
+  reset-style EC takeovers, failed wakes, and plugs into an off host.
+- Enumerates bare -- single boot-protocol keyboard, no wake mouse / WebUSB / CDC (`bareHid`
+  in `setup()`) -- because the S5 embedded controller runs a minimal USB host stack.
 
 ### `webusb_config.cpp` / `webusb_config.h` — browser config channel (loop task)
 - `Adafruit_USBD_WebUSB usb_web`. **No vendor callbacks** — fully **polled from

--- a/OpenPuck/OpenPuck.ino
+++ b/OpenPuck/OpenPuck.ino
@@ -36,6 +36,7 @@ using namespace Adafruit_LittleFS_Namespace;
 #include "lizard_map.h"
 #include "serial_console.h"
 #include "wake_hid.h"
+#include "mode_wake.h" // wakeAutoRearmTask()
 #include "status_led.h"
 #include "usb_mount.h"
 #include "identity.h"
@@ -65,10 +66,11 @@ using namespace Adafruit_LittleFS_Namespace;
 // puck composite (4 HID + WebUSB) exceeds the default 256 B config buffer
 static uint8_t g_usbCfgDesc[512];
 
-// Per-mode USB serial suffix (modes 1..9: X=xbox N=hori L=lizard P=swpro S=ps5 G=hidgyro Q=ps5game D=ds4game 3=ps3).
-static const char MODE_SUFFIX[] = {
-	'X', 'N', 'L', 'P', 'S', 'G', 'Q', 'D', '3'
-};
+// Per-mode USB serial suffix (modes 1..10: X=xbox N=hori L=lizard P=swpro S=ps5 G=hidgyro Q=ps5game D=ds4game 3=ps3 W=wake).
+static const char MODE_SUFFIX[] = { 'X', 'N', 'L', 'P', 'S',
+				    'G', 'Q', 'D', '3', 'W' };
+static_assert(sizeof MODE_SUFFIX == MODE_MAX,
+	      "MODE_SUFFIX must have one entry per mode 1..MODE_MAX");
 // Fixed-interface flags captured at boot so usbReenumerate (dynamic mount, no reboot) replays them.
 static bool s_dynWantWebusb = false, s_dynWantWakeMouse = false;
 
@@ -84,11 +86,11 @@ void usbReenumerate(uint8_t k)
 	USBDevice.setConfigurationBuffer(g_usbCfgDesc, sizeof g_usbCfgDesc);
 	g_active->usbIdentity(); // clearConfiguration reset VID/PID/strings -- restore them
 	// serial carries the mounted count so the host invalidates its cached config descriptor on a change
-	snprintf(
-		g_usbSerial, sizeof g_usbSerial, "%s%c%u", g_unit,
-		MODE_SUFFIX[(g_usbMode >= 1 && g_usbMode <= 9) ? g_usbMode - 1 :
-								 0],
-		(unsigned)k);
+	snprintf(g_usbSerial, sizeof g_usbSerial, "%s%c%u", g_unit,
+		 MODE_SUFFIX[(g_usbMode >= 1 && g_usbMode <= MODE_MAX) ?
+				     g_usbMode - 1 :
+				     0],
+		 (unsigned)k);
 	USBDevice.setSerialDescriptor(g_usbSerial);
 	if (s_dynWantWakeMouse)
 		wakeHidAddInterface(); // HID instance 0
@@ -179,6 +181,12 @@ void setup()
 	// clean-PS modes skip BOTH the wake mouse and WebUSB -- no config panel / host-wake; chord back to Steam
 	// (back-paddle 4 + A) to reach the panel. Normal MODE_PS5 / MODE_HIDGYRO keep wake + panel.
 	const bool psClean = modeIsCleanPS(g_usbMode);
+	// MODE_WAKE shows the same bare single-HID shape as the clean-PS modes, for a different reason: the
+	// embedded controller watching this port in S5 (Lenovo Smart Power On) enumerates with a minimal USB
+	// stack written against real keyboards, so we give it exactly one boot-protocol keyboard interface and
+	// nothing else. It keeps remote-wakeup in bmAttributes (a real keyboard advertises it) -- only the
+	// clean-PS modes drop that, to match a genuine Sony pad.
+	const bool bareHid = psClean || modeIsWake(g_usbMode);
 	const bool dynamic = g_active->dynamicMount();
 
 	if (dynamic) {
@@ -240,12 +248,12 @@ void setup()
 		// Boot-mouse wake interface for clean (non-puck) modes, and for puck on the one-shot debug boot (CDC on,
 		// no endpoint room for wake mouse on a normal puck boot -- wake is registered above instead). Skipped for PS
 		// modes so the device stays a single clean HID gamepad (see psClean above).
-		if (!puckMode && !keepCdc && !psClean)
+		if (!puckMode && !keepCdc && !bareHid)
 			wakeHidBegin();
 
 		// WebUSB config panel -- every mode EXCEPT the PlayStation modes. Puck: registered above (IF 0) before wake +
 		// slots; other clean modes after controller. PS modes omit it to present a genuine single-HID PS controller.
-		if (!puckMode && !psClean)
+		if (!puckMode && !bareHid)
 			usb_web.begin();
 		// bmAttributes: required(0x80) | remote_wakeup(0x20). Remote Wakeup lets us signal wake-from-sleep.
 		// The PS3/Sixaxis (the only clean-PS mode on this static path) advertises 0x80 only -- match it so a
@@ -257,11 +265,20 @@ void setup()
 		USBDevice.attach();
 	}
 	Serial.begin(115200);
-	for (int i = 0; i < 300 && !USBDevice.mounted(); i++)
-		delay(10); // wait up to 3s for USB mount, but NEVER hang
+	// Post-wake-fire boot: the machine is POSTing and will not mount us for many seconds -- waiting here
+	// just extends the RF outage for the controller that triggered the wake (it gives up and powers off).
+	// Skip straight to bringing the RF side up; opening the connect cooldown makes the first beacons go
+	// out on the first loop() pass instead of at t=2.5 s.
+	if (wakeHandoffActive())
+		rfConnectOpenNow();
+	else
+		for (int i = 0; i < 300 && !USBDevice.mounted(); i++)
+			delay(10); // up to 3s for USB mount, NEVER hang
 	if (USBDevice.suspended()) {
 		USBDevice.remoteWakeup();
-		ledWakePulse();
+		// wake mode reserves the LED for hotkey presses (WAKE_MODE.md diagnostic table)
+		if (!modeIsWake(g_usbMode))
+			ledWakePulse();
 	} // wake host if bus was sleeping when we (re-)attached
 	// Route all device->host HID sends through the usbd task (SOF drain) so loop() never calls tud_* directly
 	// -> the cross-task blocking-defer that deadlocked the loop under comms load can no longer happen.
@@ -273,7 +290,8 @@ void setup()
 		"SWITCH(horipad)",     "LIZARD(puck kb/mouse)",
 		"SWITCH(pro+gyro)",    "PS5(dualsense)",
 		"HIDGYRO(ds4+motion)", "PS5(dualsense,game/clean)",
-		"DS4(ds4,game/clean)", "PS3(dualshock3/sixaxis)"
+		"DS4(ds4,game/clean)", "PS3(dualshock3/sixaxis)",
+		"WAKE(alt+p keyboard)"
 	};
 	Serial.printf("# copycat up: unit=%s board=%s, mode=%s\n", g_unit,
 		      g_board,
@@ -341,6 +359,8 @@ void loop()
 	hapticStabTask(); // stability-test keepalive buzz (no-op unless armed via WebUSB)
 	// cross-check HFCLK(micros) vs LFCLK(millis) once a second -- cheap, both builds (clone clock diagnostic)
 	clockDiagTick();
+	// opt-in auto re-arm of the smart-power-on wake mode (no-op unless built with WAKE_AUTO_REARM)
+	wakeAutoRearmTask();
 	if (g_dirty) {
 		g_dirty = false;
 		// A bond flash write erases+programs a page with interrupts effectively stalled for ms -- a known

--- a/OpenPuck/OpenPuck.ino
+++ b/OpenPuck/OpenPuck.ino
@@ -268,8 +268,10 @@ void setup()
 	// Post-wake-fire boot: the machine is POSTing and will not mount us for many seconds -- waiting here
 	// just extends the RF outage for the controller that triggered the wake (it gives up and powers off).
 	// Skip straight to bringing the RF side up; opening the connect cooldown makes the first beacons go
-	// out on the first loop() pass instead of at t=2.5 s.
-	if (wakeHandoffActive())
+	// out on the first loop() pass instead of at t=2.5 s. Auto-rearm boots take the same fast path for
+	// the mirror-image reason: the host is proven DOWN and will never mount us, and a rearm-on-connect
+	// boot has a controller mid-search that must be answered before it gives up (~4-5 s of silence).
+	if (wakeHandoffActive() || g_wakeRearmBoot)
 		rfConnectOpenNow();
 	else
 		for (int i = 0; i < 300 && !USBDevice.mounted(); i++)

--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -1,6 +1,8 @@
 #include "config.h"
 #include "rf_link.h" // g_rxWin (poll RX window persisted here)
 #include "haptics.h" // g_hapticBlockOn, g_hapticBlockMs
+#include "mode_wake.h" // WAKE_MOD_DEFAULT/WAKE_KEY_DEFAULT (g_wakeMod/g_wakeKey factory values)
+#include <Adafruit_TinyUSB.h> // KEYBOARD_MODIFIER_*/HID_KEY_* (wake-hotkey defaults + validation)
 #include <Adafruit_LittleFS.h>
 #include <InternalFileSystem.h>
 #include <string.h>
@@ -23,6 +25,9 @@ uint8_t g_bootMode = 0xFF;
 // this boot came from a wake fire (consumed like bootMode/debugCdc so the next boot is normal).
 uint8_t g_wakeHandoffArm = 0;
 bool g_wakeHandoffBoot = false;
+// MODE_WAKE hotkey (modifier bitmask + HID key usage), panel-settable per vendor; default Lenovo Alt+P.
+uint8_t g_wakeMod = WAKE_MOD_DEFAULT;
+uint8_t g_wakeKey = WAKE_KEY_DEFAULT;
 // The mode saveCfg persists as Cfg.mode. Tracks the last REAL (non-wake) personality: while the live mode
 // is MODE_WAKE, any saveCfg (the loadCfg consume-save included) must not leak 10 into the persisted mode,
 // or persist-last-mode users would boot into the panel-less keyboard on every replug.
@@ -116,6 +121,9 @@ struct Cfg {
 	uint8_t chordDpad[4];
 	// per-type trackpad->stick mapping: [et][0] = left pad, [et][1] = right pad (PS_*)
 	uint8_t padStick[ET_COUNT][2];
+	// MODE_WAKE hotkey (tail): modifier bitmask + HID key usage. 0xFF (short pre-tail file) = unset ->
+	// compiled defaults (Alt+P).
+	uint8_t wakeMod, wakeKey;
 }; // rsvd0 = ex-padSmooth, now the one-shot debug-CDC arm
 
 // Shortest cfg.bin we still accept: the layout as of CFG_MAGIC 0xCF, i.e. everything before the appended tail.
@@ -141,7 +149,9 @@ void saveCfg()
 		  {},
 		  { g_chordDpad[0], g_chordDpad[1], g_chordDpad[2],
 		    g_chordDpad[3] },
-		  {} };
+		  {},
+		  g_wakeMod,
+		  g_wakeKey };
 	for (int i = 0; i < ET_COUNT; i++) {
 		c.type[i] = g_type[i];
 		c.padStick[i][0] = g_padStickCfg[i][0];
@@ -224,6 +234,15 @@ void loadCfg()
 					if (c.padStick[i][k] <= PS_MAX)
 						g_padStickCfg[i][k] =
 							c.padStick[i][k];
+			// MODE_WAKE hotkey. Modifier: any bitmask incl. 0 (a bare key is a legal chord);
+			// only 0xFF (pre-tail file) means unset. Key: must be a defined keyboard usage
+			// (HID_KEY_A..GUI_RIGHT) so a stray byte can never make the wake press type garbage
+			// -- anything else keeps the compiled Alt+P default.
+			if (c.wakeMod != 0xFF)
+				g_wakeMod = c.wakeMod;
+			if (c.wakeKey >= HID_KEY_A &&
+			    c.wakeKey <= HID_KEY_GUI_RIGHT)
+				g_wakeKey = c.wakeKey;
 			// grow a short file to the current layout on the next save
 			if (got < (int)sizeof c)
 				consume = true;

--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -19,6 +19,14 @@ uint8_t g_chordDpad[4] = { MODE_PS3, MODE_DS4_GAME, MODE_PS5_GAME,
 			   MODE_SW_HORI };
 bool g_persistMode = false;
 uint8_t g_bootMode = 0xFF;
+// One-shot post-wake-fire handoff (Cfg.wakeHandoff): arm = persisted by wakeHandoffMark's saveCfg; boot =
+// this boot came from a wake fire (consumed like bootMode/debugCdc so the next boot is normal).
+uint8_t g_wakeHandoffArm = 0;
+bool g_wakeHandoffBoot = false;
+// The mode saveCfg persists as Cfg.mode. Tracks the last REAL (non-wake) personality: while the live mode
+// is MODE_WAKE, any saveCfg (the loadCfg consume-save included) must not leak 10 into the persisted mode,
+// or persist-last-mode users would boot into the panel-less keyboard on every replug.
+static uint8_t g_modePersist = 0;
 
 bool g_debugCdcThisBoot = false;
 
@@ -91,9 +99,14 @@ uint32_t g_pollUs = POLL_US_DEFAULT;
 #define CFG_MAGIC 0xCF
 struct Cfg {
 	uint8_t magic, mode, mDiv, mFric, rsvd0, pollU100, persistMode,
-		bootMode, chordBtn[3], rsvd1;
-	// rsvd1: legacy rumble-strength slot (strength now fixed at RUMBLE_SCALE_PCT; ignored -- kept so the
-	// on-flash layout is unchanged and an existing cfg.bin still loads).
+		bootMode, chordBtn[3], wakeHandoff;
+	// wakeHandoff: ex rumble-strength slot (same offset and magic, so an existing cfg.bin still loads --
+	// which also means a pre-rework file can hold a live rumble VALUE here, 0..100). Now the one-shot
+	// post-wake-fire handoff arm: MODE_WAKE writes the 0xA5 sentinel (outside the legacy range) right
+	// before its return reboot; loadCfg honors ==0xA5 for that boot and consumes ANY nonzero (so a
+	// legacy value, or a sentinel stranded by flashing an old firmware between the fire and the consume,
+	// is scrubbed rather than read as an arm later). In FLASH, not .noinit, because this board class's
+	// bootloader wipes .noinit RAM on every reset.
 	// rxWin10: legacy RF tunable slot (window now fixed; ignored). lizKeep: the id9=0 hold enable (see
 	// haptics.h LIZKEEP_MS). landAll87: the verbatim-0x87-relay experiment toggle (haptics.h g_landAll87).
 	uint8_t rxWin10, lizKeep, landAll87;
@@ -113,7 +126,7 @@ struct Cfg {
 void saveCfg()
 {
 	Cfg c = { CFG_MAGIC,
-		  g_usbMode,
+		  modeIsWake(g_usbMode) ? g_modePersist : g_usbMode,
 		  (uint8_t)g_mDiv,
 		  (uint8_t)g_mFric,
 		  g_debugCdc,
@@ -121,7 +134,7 @@ void saveCfg()
 		  (uint8_t)(g_persistMode ? 1 : 0),
 		  g_bootMode,
 		  { g_chordBtn[0], g_chordBtn[1], g_chordBtn[2] },
-		  0, // rsvd1 (ex rumble strength)
+		  g_wakeHandoffArm,
 		  (uint8_t)(g_rxWin / 10),
 		  g_lizKeep,
 		  g_landAll87,
@@ -167,6 +180,15 @@ void loadCfg()
 				g_debugCdc = 0;
 				consume = true;
 			}
+			// one-shot wake handoff: this boot follows a MODE_WAKE fire; honored (grace + fast RF
+			// bring-up) then consumed. Honor the 0xA5 sentinel exactly -- this byte is the legacy
+			// rumble-strength slot (0..100), so a real legacy value can never fake an arm -- and
+			// consume any nonzero so stale values are scrubbed, not resurrected.
+			if (c.wakeHandoff != 0) {
+				g_wakeHandoffBoot = (c.wakeHandoff == 0xA5);
+				g_wakeHandoffArm = 0;
+				consume = true;
+			}
 			// poll rate is fixed; rewrite cfg so the persisted byte matches the new default.
 			if (c.pollU100 != (uint8_t)(POLL_US_DEFAULT / 100))
 				consume = true;
@@ -181,6 +203,9 @@ void loadCfg()
 								     c.mode :
 								     0) :
 							    0;
+			// the persisted-mode slot must survive a trip through MODE_WAKE (see g_modePersist)
+			if (modeValid(c.mode) && !modeIsWake(c.mode))
+				g_modePersist = c.mode;
 			static const uint8_t CHORD_DEF[3] = { MODE_LIZARD,
 							      MODE_XBOX,
 							      MODE_SW_PRO };
@@ -225,8 +250,12 @@ void loadCfg()
 
 void saveMode(uint8_t m)
 {
-	if (g_persistMode) {
+	// MODE_WAKE is inherently transient (one wake, then back) -- it is ALWAYS a one-shot bootMode, even
+	// for persist-last-mode users, so the persisted personality is never overwritten by a wake trip and
+	// the fire's modeSwitchReboot(0xFF) return lands back in the user's own mode.
+	if (g_persistMode && !modeIsWake(m)) {
 		g_usbMode = m;
+		g_modePersist = m;
 		g_bootMode = 0xFF;
 	} else {
 		g_bootMode = m;

--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -239,12 +239,11 @@ void loadCfg()
 							c.padStick[i][k];
 			// MODE_WAKE hotkey. Modifier: any bitmask incl. 0 (a bare key is a legal chord);
 			// only 0xFF (pre-tail file) means unset. Key: must be a defined keyboard usage
-			// (HID_KEY_A..GUI_RIGHT) so a stray byte can never make the wake press type garbage
-			// -- anything else keeps the compiled Alt+P default.
+			// (wakeKeyValid, shared with the WebUSB setter) so a stray byte can never make
+			// the wake press type garbage -- anything else keeps the compiled Alt+P default.
 			if (c.wakeMod != 0xFF)
 				g_wakeMod = c.wakeMod;
-			if (c.wakeKey >= HID_KEY_A &&
-			    c.wakeKey <= HID_KEY_GUI_RIGHT)
+			if (wakeKeyValid(c.wakeKey))
 				g_wakeKey = c.wakeKey;
 			// grow a short file to the current layout on the next save
 			if (got < (int)sizeof c)

--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -25,6 +25,7 @@ uint8_t g_bootMode = 0xFF;
 // this boot came from a wake fire (consumed like bootMode/debugCdc so the next boot is normal).
 uint8_t g_wakeHandoffArm = 0;
 bool g_wakeHandoffBoot = false;
+bool g_wakeRearmBoot = false;
 // MODE_WAKE hotkey (modifier bitmask + HID key usage), panel-settable per vendor; default Lenovo Alt+P.
 uint8_t g_wakeMod = WAKE_MOD_DEFAULT;
 uint8_t g_wakeKey = WAKE_KEY_DEFAULT;
@@ -191,11 +192,13 @@ void loadCfg()
 				consume = true;
 			}
 			// one-shot wake handoff: this boot follows a MODE_WAKE fire; honored (grace + fast RF
-			// bring-up) then consumed. Honor the 0xA5 sentinel exactly -- this byte is the legacy
+			// bring-up) then consumed. Honor the sentinels exactly -- this byte is the legacy
 			// rumble-strength slot (0..100), so a real legacy value can never fake an arm -- and
-			// consume any nonzero so stale values are scrubbed, not resurrected.
+			// consume any nonzero so stale values are scrubbed, not resurrected. 0xA5 = post-fire
+			// handoff; 0xC3 = auto-rearm boot (host proven down -> MODE_WAKE arms instantly).
 			if (c.wakeHandoff != 0) {
 				g_wakeHandoffBoot = (c.wakeHandoff == 0xA5);
+				g_wakeRearmBoot = (c.wakeHandoff == 0xC3);
 				g_wakeHandoffArm = 0;
 				consume = true;
 			}

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -41,7 +41,12 @@
 // console wants a bare Sixaxis HID, not a composite). Answers the PS3's GET_REPORT(0xF2/0xF5/0xEF/0x01)
 // enable handshake. + gyro/accel + rumble.
 #define MODE_PS3 9
-#define MODE_MAX 9
+// Boot-keyboard-only wake personality: sends the firmware smart-power-on hotkey (Alt+P on Lenovo
+// ThinkCentre) when a controller connects, then reboots into WAKE_RETURN_MODE. Presents a single clean HID
+// keyboard -- no wake mouse, no WebUSB, no CDC -- because the EC that watches this port while the machine
+// is in S5 runs a minimal USB stack. See mode_wake.h.
+#define MODE_WAKE 10
+#define MODE_MAX 10
 
 // The two "game" personalities drop the wake-mouse + WebUSB interfaces so the device is a genuine single-HID PS
 // controller (some PC games -- e.g. Fortnite/UE GameInput -- refuse PS classification when extra interfaces are
@@ -49,6 +54,13 @@
 static inline bool modeIsCleanPS(uint8_t m)
 {
 	return m == MODE_PS5_GAME || m == MODE_DS4_GAME || m == MODE_PS3;
+}
+
+// Wake mode is a one-shot utility personality, not a controller: it forwards no input and enumerates as a
+// bare keyboard, so setup() gates it out of the wake-mouse / WebUSB interfaces like the clean-PS modes.
+static inline bool modeIsWake(uint8_t m)
+{
+	return m == MODE_WAKE;
 }
 
 static inline bool modeIsPuck(uint8_t m)
@@ -109,6 +121,9 @@ extern uint8_t g_chordDpad[4];
 // instead remembers the last selected mode across reboots.
 // false (default) = always boot Steam; true = boot into last mode
 extern bool g_persistMode;
+// one-shot post-wake-fire handoff flag (see Cfg.wakeHandoff in config.cpp)
+extern uint8_t g_wakeHandoffArm;
+extern bool g_wakeHandoffBoot;
 // one-shot: boot into this mode once then clear (!persistMode + explicit switch)
 extern uint8_t g_bootMode;
 
@@ -189,6 +204,18 @@ void swProSaveCfg();
 // (host idle power-management) resumes in <1s and must not trigger a self-inflicted power-off -> the
 // resulting disconnect/reconnect churn looked like random controller drops. Real host sleep persists.
 #define SUSPEND_OFF_MS 4000u
+// The suspend power-off relay is NO-ACK RF; a controller still CONTINUOUSLY linked (no 0xF2 disconnect
+// seen) this long after the send missed the burst -- resend, at most SUSPEND_OFF_RETRIES times. Long
+// enough to clear the dying controller's ~1 s F1 tail plus the 2.5 s post-disconnect cooldown, so a
+// retry can never transmit into the power-down window and re-wake it.
+#define SUSPEND_OFF_RETRY_MS 4000u
+// Reset-style shutdowns: some ECs RESET the bus when taking the port for S5 (observed on the M90q,
+// intermixed with suspend-style takeovers). A reset clears TinyUSB's connected state, so suspended()
+// never reads true again and the suspend-edge power-off above can never fire. "Was mounted, then the bus
+// died and stayed dead this long" is the equivalent signal -- long past any normal boot's ~10-20 s
+// re-enumeration gap, so it can never kill the controller during a reboot.
+#define SUSPEND_OFF_LOST_MS 30000u
+#define SUSPEND_OFF_RETRIES 2u
 // RF poll cadence (us). Defaults to POLL_US_DEFAULT; live-adjustable via the console "PR<hz>" command
 // (session-only -- NOT persisted; loadCfg always forces the default on boot) so the sweet spot can be
 // swept on hardware while watching the delivered report rate.

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -124,6 +124,10 @@ extern bool g_persistMode;
 // one-shot post-wake-fire handoff flag (see Cfg.wakeHandoff in config.cpp)
 extern uint8_t g_wakeHandoffArm;
 extern bool g_wakeHandoffBoot;
+// one-shot auto-rearm-boot flag (same Cfg.wakeHandoff byte, 0xC3 sentinel): this MODE_WAKE boot was
+// triggered by wakeAutoRearmTask against a host already proven down, so the mode arms instantly
+// instead of waiting out the link-quiet clock (see mode_wake.cpp W_WAIT_DOWN).
+extern bool g_wakeRearmBoot;
 // MODE_WAKE hotkey: modifier bitmask (KEYBOARD_MODIFIER_*) + HID key usage the wake keyboard types.
 // Defaults to Alt+P (mode_wake.h WAKE_*_DEFAULT, Lenovo Smart Power On); settable from the WebUSB
 // panel (op 0x02 fields 30/31) for vendors whose EC wants a different chord. Persisted in Cfg.

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -124,6 +124,10 @@ extern bool g_persistMode;
 // one-shot post-wake-fire handoff flag (see Cfg.wakeHandoff in config.cpp)
 extern uint8_t g_wakeHandoffArm;
 extern bool g_wakeHandoffBoot;
+// MODE_WAKE hotkey: modifier bitmask (KEYBOARD_MODIFIER_*) + HID key usage the wake keyboard types.
+// Defaults to Alt+P (mode_wake.h WAKE_*_DEFAULT, Lenovo Smart Power On); settable from the WebUSB
+// panel (op 0x02 fields 30/31) for vendors whose EC wants a different chord. Persisted in Cfg.
+extern uint8_t g_wakeMod, g_wakeKey;
 // one-shot: boot into this mode once then clear (!persistMode + explicit switch)
 extern uint8_t g_bootMode;
 

--- a/OpenPuck/controllers.cpp
+++ b/OpenPuck/controllers.cpp
@@ -7,6 +7,7 @@
 #include "mode_ps5.h"
 #include "mode_hidgyro.h"
 #include "mode_ps3.h"
+#include "mode_wake.h"
 
 IController *g_active = nullptr;
 
@@ -39,6 +40,8 @@ IController *controllerFor(uint8_t mode)
 		return &g_hidGyroCtl;
 	case MODE_PS3:
 		return &g_ps3Ctl;
+	case MODE_WAKE:
+		return &g_wakeCtl;
 	default:
 		return &g_steamPuck;
 	}

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -790,9 +790,12 @@ void hapticTask()
 		g_offMask &= (uint8_t) ~(prevLinked &
 					 ~linked); // down edges leave the mask
 		prevLinked = linked;
-		// Suspend-edge off (host went to sleep / suspend-style shutdown).
+		// Suspend-edge off (host went to sleep / suspend-style shutdown). wakeRearmWaitActive:
+		// on a connect-triggered rearm boot the EC's enumerate flap (resume then re-suspend)
+		// re-arms this one-shot, and firing it while the wake mode waits for ready() would
+		// power off the very controller whose press triggered the rearm.
 		if (suspArmed && vbus && !wakeFireInFlight() &&
-		    !wakeHandoffActive() &&
+		    !wakeHandoffActive() && !wakeRearmWaitActive() &&
 		    (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
 			hapticSendShutdown();
 			suspArmed = false; // fire once per suspend
@@ -827,7 +830,8 @@ void hapticTask()
 				    (unsigned long)(millis() - lostMs) >=
 					    SUSPEND_OFF_LOST_MS &&
 				    !wakeFireInFlight() &&
-				    !wakeHandoffActive()) {
+				    !wakeHandoffActive() &&
+				    !wakeRearmWaitActive()) {
 					if (!lostOpenMs)
 						lostOpenMs = millis();
 					if (vbus && linked) {
@@ -878,7 +882,8 @@ void hapticTask()
 			// subset of `linked`; the & is kept as cheap armor, not a filter.
 			uint8_t targets = (uint8_t)(g_offMask & linked);
 			if (hostDown && vbus && !wakeFireInFlight() &&
-			    !wakeHandoffActive() && targets) {
+			    !wakeHandoffActive() && !wakeRearmWaitActive() &&
+			    targets) {
 				for (int rs = 0; rs < NSLOT; rs++)
 					if (targets & (1u << rs))
 						hapticSendShutdown((uint8_t)rs);

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -6,6 +6,7 @@
 #include "puck_hid.h" // puckLizardActive() -- gate the lizard-suppression keepalive
 
 #include "fault_diag.h" // faultDiagTrace() -- flight recorder
+#include "mode_wake.h" // wakeHandoffActive() -- post-fire boot grace
 // USBDevice.suspended() -> autonomous controller power-off on host sleep
 #include <Adafruit_TinyUSB.h>
 #include <Arduino.h>
@@ -69,6 +70,21 @@ void hapticSendShutdown(uint8_t slot)
 	// the connection state (phantom reconnect / never-removed). Covers every power-off path (Steam 0x9F, the
 	// Steam+Y chord, the panel button, host suspend) since they all funnel through here.
 	puckNotePowerOff(slot);
+}
+
+// ---- suspend/lost-bus power-off retry state (see the off region in hapticTask) -----------------------
+// Every off send snapshots the currently-linked slots; a down edge removes a slot (delivered); retries
+// target exactly mask-and-still-linked. Centralized in offArm() so a future off path CANNOT forget the
+// snapshot -- per-site ad-hoc copies of this state are precisely how earlier review rounds' bugs arose.
+static unsigned long g_offSentMs = 0;
+static uint8_t g_offRetries = 0;
+static uint8_t g_offMask =
+	0; // slots linked at the last off send, minus down edges since
+static void offArm(uint8_t linkedMask)
+{
+	g_offMask = linkedMask;
+	g_offSentMs = millis();
+	g_offRetries = SUSPEND_OFF_RETRIES;
 }
 
 // millis of last 0x82 haptic OUTPUT relayed (Steam mode)
@@ -744,9 +760,137 @@ void hapticTask()
 			faultDiagTrace(FR_RESUME, 0);
 		suspArmed = false;
 	}
-	if (suspArmed && vbus && (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
-		hapticSendShutdown();
-		suspArmed = false; // fire once per suspend
+	// Two wake-flow windows where "suspend persisted" does NOT mean "host went to sleep" and firing here
+	// kills the controller that just triggered the wake (the double-power-on symptom):
+	//   - a press sequence in flight (wakeFireInFlight): the EC hands the port to the chipset the moment
+	//     the hotkey lands, so the bus suspends WHILE the sequence is still running. Only the in-flight
+	//     window is exempt -- in W_WAIT_DOWN/W_ARMED this power-off is still wanted: it is both the
+	//     battery saver AND what quiets the link so a controller left on across a shutdown lets the
+	//     mode arm at all.
+	//   - the post-fire return boot: POST has not enumerated the reborn puck yet; hold through the
+	//     handoff grace (deadline-only -- see mode_wake.h).
+	// ---- suspend/lost-bus power-off + per-slot retry bookkeeping ---------------------------------
+	// Every off send SNAPSHOTS which slots were linked at that moment (g_offMask). A slot leaves the
+	// mask the moment its link drops (the off was delivered -- or the slot vanished, in which case a
+	// resend is moot); a retry may only target a slot that was linked at the send AND has been linked
+	// continuously since. A controller that connects LATER -- the wake gesture, or one the user just
+	// re-powered after the off -- was never in the mask and can never be targeted; a slot that drops
+	// and relinks left the mask at the drop. Interference that drops a link without delivery reads as
+	// delivered and the controller stays on: the safe failure (battery) over the harmful one.
+	{
+		static uint8_t prevLinked = 0;
+		uint8_t linked = 0;
+		// Deliberately NOT hapticLinkUp(): that helper lacks the != 0 guard, and a used-but-never-
+		// replied slot must not read linked in the first 300 ms of uptime (it would seed the mask
+		// with phantom slots). Same 300 ms recency window as anySlotLinkUp().
+		for (int ls = 0; ls < NSLOT; ls++)
+			if (g_slot[ls].used && g_connReplyMs[ls] != 0 &&
+			    millis() - g_connReplyMs[ls] < 300)
+				linked |= (uint8_t)(1u << ls);
+		g_offMask &= (uint8_t) ~(prevLinked &
+					 ~linked); // down edges leave the mask
+		prevLinked = linked;
+		// Suspend-edge off (host went to sleep / suspend-style shutdown).
+		if (suspArmed && vbus && !wakeFireInFlight() &&
+		    !wakeHandoffActive() &&
+		    (millis() - suspSinceMs) >= SUSPEND_OFF_MS) {
+			hapticSendShutdown();
+			suspArmed = false; // fire once per suspend
+			offArm(linked);
+		}
+		// Reset-style shutdown off (SUSPEND_OFF_LOST_MS): some EC takeovers RESET the bus instead
+		// of suspending; connected clears, so suspended() never reads true and the edge path above
+		// cannot fire. "Was mounted, then the bus stayed dead" is the equivalent signal. The
+		// decision holds a RE-CHECK WINDOW (deadline .. +SUSPEND_OFF_RETRY_MS) rather than one
+		// sample instant, and the one-shot is only consumed once the decision was actually
+		// takeable -- a deadline spent inside the handoff grace or a fire sequence, or a transient
+		// reply gap at one instant, must not forfeit the episode's only off.
+		{
+			static bool everMounted = false;
+			static unsigned long lostMs = 0;
+			static unsigned long lostOpenMs = 0;
+			static bool lostDone = false;
+			if (USBDevice.mounted()) {
+				everMounted = true;
+				lostMs = 0;
+				lostOpenMs = 0;
+				lostDone = false;
+			} else if (everMounted && !susp) {
+				if (!lostMs)
+					lostMs = millis();
+				// The re-check window is anchored at the first pass where the
+				// gates are actually OPEN (like the fallback's fbExpiredMs),
+				// not at lostMs: a deadline that elapses while the handoff
+				// grace holds the gates shut must still get its full window
+				// at gate-open, not a degenerate single-instant sample.
+				if (!lostDone &&
+				    (unsigned long)(millis() - lostMs) >=
+					    SUSPEND_OFF_LOST_MS &&
+				    !wakeFireInFlight() &&
+				    !wakeHandoffActive()) {
+					if (!lostOpenMs)
+						lostOpenMs = millis();
+					if (vbus && linked) {
+						hapticSendShutdown();
+						lostDone = true;
+						offArm(linked);
+					} else if ((unsigned long)(millis() -
+								   lostOpenMs) >=
+						   SUSPEND_OFF_RETRY_MS) {
+						lostDone =
+							true; // window closed
+					}
+				}
+			}
+		}
+		// Never-booted fallback: a failed wake's return boot never gets a SETUP packet, so neither
+		// mounted() nor suspended() can ever read true and both paths above are dead. Fires in a
+		// re-check window after the grace expires, only if the bus never mounted THIS boot -- on a
+		// successful wake a later transient unmount must not detonate a stale broadcast.
+		{
+			static bool fbEverMounted = false;
+			static bool fbDone = false;
+			static unsigned long fbExpiredMs = 0;
+			if (USBDevice.mounted())
+				fbEverMounted = true;
+			if (!fbDone && !fbEverMounted && wakeHandoffExpired()) {
+				if (!fbExpiredMs)
+					fbExpiredMs = millis();
+				if (vbus && linked) {
+					hapticSendShutdown();
+					fbDone = true;
+					offArm(linked);
+				} else if ((unsigned long)(millis() -
+							   fbExpiredMs) >=
+					   SUSPEND_OFF_RETRY_MS) {
+					fbDone = true; // window closed
+				}
+			}
+		}
+		// Per-slot retries: at SUSPEND_OFF_RETRY_MS after a send the post-off F1 tail (<1 s) is
+		// long over, so a mask slot still continuously linked missed its burst -- resend to exactly
+		// those slots. Wake-flow exemptions match the fire paths.
+		if (g_offRetries && g_offMask &&
+		    (unsigned long)(millis() - g_offSentMs) >=
+			    SUSPEND_OFF_RETRY_MS) {
+			bool hostDown = susp || !USBDevice.mounted();
+			// After the top-of-pass down-edge clear, g_offMask is provably a
+			// subset of `linked`; the & is kept as cheap armor, not a filter.
+			uint8_t targets = (uint8_t)(g_offMask & linked);
+			if (hostDown && vbus && !wakeFireInFlight() &&
+			    !wakeHandoffActive() && targets) {
+				for (int rs = 0; rs < NSLOT; rs++)
+					if (targets & (1u << rs))
+						hapticSendShutdown((uint8_t)rs);
+				g_offSentMs = millis();
+				g_offRetries--;
+			} else {
+				// host came back, vbus dropped, or the wake flow owns the
+				// bus (an emptied mask cannot reach here: the outer gate
+				// requires it nonzero)
+				g_offRetries = 0;
+			}
+		}
 	}
 	wasSusp = susp;
 	// Steam-mode quiet timeout: mark 0x82 stream inactive. No synthesized stop -- Steam forwards its own.

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -1,0 +1,339 @@
+#include "mode_wake.h"
+#include "config.h"
+#include "rf_link.h" // anySlotLinkUp()
+#include "usb_mount.h" // modeSwitchReboot()
+#include "usb_tx.h" // usbTxHid()
+#include "status_led.h" // ledWakePulse()
+#include <Adafruit_TinyUSB.h>
+#include <string.h>
+
+WakeController g_wakeCtl;
+
+// Plain boot keyboard, NO report ID. Report ID 0 matters: the EC will very likely put us in boot protocol
+// (SET_PROTOCOL 0), whose report format is the fixed 8-byte [modifier][reserved][keycode x6] with no id
+// byte. TUD_HID_REPORT_DESC_KEYBOARD() with no id argument emits exactly that, so the report protocol and
+// boot protocol payloads are identical and it does not matter which one the host picks.
+//
+// Note wake_hid.cpp's comment that a boot KEYBOARD failed to enumerate on Windows where the boot mouse
+// worked -- that was a keyboard added to the puck composite as an extra wake interface. This is a
+// standalone single-interface keyboard talking to a firmware EC, which is the case a real keyboard
+// exercises. If it does not enumerate, that is the thing to bisect first.
+static const uint8_t WAKE_KBD_DESC[] = { TUD_HID_REPORT_DESC_KEYBOARD() };
+static Adafruit_USBD_HID g_kbd;
+
+// Post-fire handoff grace (see mode_wake.h). The arm is PERSISTED (Cfg.wakeHandoff, one-shot consumed by
+// loadCfg like bootMode) because this board class's bootloader wipes .noinit RAM on every reset -- a RAM
+// flag simply does not survive the return reboot. saveCfg() here because the return reboot goes through
+// modeSwitchReboot(0xFF) ("keep current"), which intentionally skips its own saveMode.
+void wakeHandoffMark()
+{
+	// 0xA5, not 1: this byte is the repurposed legacy rumble-strength slot (0..100), so a plausible
+	// legacy value must not read as an arm after a firmware upgrade. 0xA5 is outside that range.
+	g_wakeHandoffArm = 0xA5;
+	saveCfg();
+}
+
+bool wakeHandoffActive()
+{
+	// Deadline-based (mode_wake.h): a POST-time SET_CONFIGURATION reads mounted() long before the OS
+	// is up, so a bare mounted() exit would re-expose the suspend power-off during the BIOS->kernel
+	// gap. The early end below instead requires a SUSTAINED mounted+active session -- something POST
+	// never produces -- so a shutdown shortly after a wake-boot gets normal power-off behavior back.
+	static bool init = false, done = false;
+	static uint32_t t0 = 0, upSince = 0;
+	if (!g_wakeHandoffBoot)
+		return false;
+	if (!init) {
+		init = true;
+		t0 = millis();
+	}
+	if (done)
+		return false;
+	if (USBDevice.mounted() && !USBDevice.suspended()) {
+		if (!upSince)
+			upSince = millis();
+		else if (millis() - upSince >= WAKE_HANDOFF_MOUNTED_MS)
+			done = true;
+	} else {
+		upSince = 0;
+	}
+	if (millis() - t0 >= WAKE_HANDOFF_GRACE_MS)
+		done = true;
+	return !done;
+}
+
+bool wakeHandoffExpired()
+{
+	return g_wakeHandoffBoot && !wakeHandoffActive();
+}
+
+enum {
+	W_WAIT_DOWN, // link must go quiet before we arm (see WAKE_ARM_DOWN_MS)
+	W_ARMED, // waiting for a controller to connect
+	W_PRESS, // send modifier-down
+	W_MODLEAD, // modifier alone, then add the key
+	W_RELEASE, // hold (re-sending), then send key-up
+	W_GAP, // spacing between repeats
+	W_SETTLE, // let the key-up land before we tear the device down
+	W_DONE // reboot issued (modeSwitchReboot does not return)
+};
+static uint8_t s_st = W_WAIT_DOWN;
+static uint32_t s_t = 0; // start of the current timed phase
+static uint32_t s_dl = 0; // press-sequence start, for WAKE_SEQ_DEADLINE_MS
+static uint32_t s_resend = 0; // last held-report re-send (WAKE_RESEND_MS)
+static uint8_t s_shots = 0;
+
+// One boot-keyboard report. Queued for the usbTx drain like every other report in this firmware -- loop()
+// never calls tud_* directly (see usb_tx.h). key==0 with mod==0 is the all-keys-up report.
+static void kbdSend(uint8_t mod, uint8_t key)
+{
+	hid_keyboard_report_t r;
+	memset(&r, 0, sizeof r);
+	r.modifier = mod;
+	r.keycode[0] = key;
+	usbTxHid(&g_kbd, 0, &r, sizeof r);
+}
+
+void WakeController::usbIdentity()
+{
+	// Distinct identity from every other personality. Hosts cache the configuration descriptor by
+	// VID:PID:bcdDevice (see the bcdDevice rule in ARCHITECTURE.md), so the wake keyboard must not share
+	// one with the puck or a host can serve the wrong cached descriptor for whichever enumerates second.
+	// The PID is arbitrary and unclaimed -- nothing matches on it; the EC keys off the HID class.
+	USBDevice.setID(0x28DE, 0x574B);
+	USBDevice.setDeviceVersion(0x0100);
+	USBDevice.setManufacturerDescriptor("OpenPuck");
+	USBDevice.setProductDescriptor("OpenPuck Wake Keyboard");
+}
+
+void WakeController::begin()
+{
+	usbIdentity();
+	g_kbd.setBootProtocol(HID_ITF_PROTOCOL_KEYBOARD);
+	g_kbd.setStringDescriptor("OpenPuck Wake Keyboard");
+	g_kbd.setReportDescriptor(WAKE_KBD_DESC, sizeof WAKE_KBD_DESC);
+	// 10 ms, a real keyboard's cadence; nothing here is latency-sensitive
+	g_kbd.setPollInterval(10);
+	g_kbd.begin();
+}
+
+// Non-blocking throughout: every wait is a millis() comparison, never a delay(). loop() has to keep feeding
+// the ~8 s watchdog and keep the RF poll running while we sit here, so nothing in this file may spin.
+void WakeController::task()
+{
+	const uint32_t now = millis();
+	const bool up = anySlotLinkUp();
+
+	// The wake gesture is the connect up-EDGE, latched briefly: an EC that suspends the port between
+	// enumeration and the press only reads ready() a few ms after the connect (rf_link's remoteWakeup has
+	// to resume the bus first). The latch EXPIRES (WAKE_FIRE_LATCH_MS): a controller that connected
+	// against a dead port must not fire hours later when a manually booted OS enumerates the keyboard.
+	static bool s_wasUp = false;
+	static bool s_pend = false;
+	static uint32_t s_pendMs = 0;
+	if (up && !s_wasUp) {
+		s_pend = true;
+		s_pendMs = now;
+	}
+	if (!up || now - s_pendMs >= WAKE_FIRE_LATCH_MS)
+		s_pend = false;
+	s_wasUp = up;
+
+	switch (s_st) {
+	case W_WAIT_DOWN:
+		// Link activity restarts the quiet timer -- and so does a closed connect cooldown: before
+		// rfConnectOpen() nothing is on air, so a controller that was linked at the mode switch cannot
+		// have shown itself yet, and counting that silence would arm us just in time to type Alt+P
+		// into the live session it then relinks into.
+		if (up || !rfConnectOpen()) {
+			s_t = now;
+			break;
+		}
+		if (now - s_t >= WAKE_ARM_DOWN_MS)
+			s_st = W_ARMED;
+		break;
+
+	case W_ARMED:
+		// ready() means the host has actually configured our interface -- on a machine in S5 that is
+		// the EC's minimal stack having enumerated us. If it never goes true we simply never fire, and
+		// the LED never flashes, which is the diagnostic.
+		if (s_pend && g_kbd.ready()) {
+			s_pend = false;
+			s_shots = 0;
+			s_dl = now;
+			s_st = W_PRESS;
+		}
+		break;
+
+	case W_PRESS:
+		// Deadline: the EC deconfigured us mid-sequence (port reset as POST takes over the bus). Bail to
+		// settle instead of stalling here until the booted OS re-enumerates us and gets a stray Alt+P.
+		// The queued all-keys-up is harmless whenever it drains.
+		if (now - s_dl >= WAKE_SEQ_DEADLINE_MS) {
+			kbdSend(0, 0);
+			s_t = now;
+			s_st = W_SETTLE;
+			break;
+		}
+		if (!g_kbd.ready())
+			break;
+		// Stage the press like a human types it: Alt down alone first. A
+		// minimal EC hotkey parser may track modifier-then-key transitions
+		// rather than accepting a combined report out of nowhere.
+		kbdSend(WAKE_MOD, 0);
+		s_t = now;
+		s_st = W_MODLEAD;
+		break;
+
+	case W_MODLEAD:
+		if (now - s_t < WAKE_MOD_LEAD_MS)
+			break;
+		kbdSend(WAKE_MOD, WAKE_KEY);
+		// wake-debugger convention: flash = a wake was actually sent
+		ledWakePulse();
+		s_resend = now;
+		s_t = now;
+		s_st = W_RELEASE;
+		break;
+
+	case W_RELEASE:
+		if (now - s_t < WAKE_HOLD_MS) {
+			// Keep restating the held chord: an EC that samples the
+			// current report (rather than edge-detecting) can miss a
+			// single transfer.
+			if (now - s_resend >= WAKE_RESEND_MS && g_kbd.ready()) {
+				kbdSend(WAKE_MOD, WAKE_KEY);
+				s_resend = now;
+			}
+			break;
+		}
+		kbdSend(0, 0);
+		s_t = now;
+		s_st = (++s_shots < WAKE_REPEAT) ? W_GAP : W_SETTLE;
+		break;
+
+	case W_GAP:
+		// Repeats are cheap insurance against the EC missing the first report. Extra Alt+P presses that
+		// land during POST are harmless -- Lenovo's POST hotkeys are F1/F12/Enter.
+		if (now - s_t >= WAKE_REPEAT_MS)
+			s_st = W_PRESS;
+		break;
+
+	case W_SETTLE:
+		if (now - s_t < WAKE_SETTLE_MS)
+			break;
+		s_st = W_DONE;
+		// The machine is now powering on but will look bus-suspended until POST enumerates the reborn
+		// puck; hold the suspend policies off across that window (see mode_wake.h).
+		wakeHandoffMark();
+		// Clean detach + reboot into the return personality (0xFF = the boot-policy default:
+		// the user's persisted mode, or Steam). Does not return.
+		modeSwitchReboot(WAKE_RETURN_MODE);
+		break;
+
+	case W_DONE:
+	default:
+		break;
+	}
+}
+
+// True while a press sequence is in flight (haptics' suspend power-off must not kill the triggering
+// controller mid-wake; every other wake-mode state keeps the battery-saving power-off).
+bool wakeFireInFlight()
+{
+	return modeIsWake(g_usbMode) && s_st >= W_PRESS;
+}
+
+// Auto-re-arm watcher, called from loop() in every mode (compiled to nothing unless the WAKE_AUTO_REARM
+// build option is on -- see mode_wake.h for why it is off by default). Note this deliberately bypasses the
+// "no mode switch while suspended" convention the chord + console paths follow: their rule exists so a
+// SLEEPING host never resumes to find a different device, and here a long suspend meaning "the host is
+// down" is the entire premise.
+#if WAKE_AUTO_REARM
+// The one device-visible difference between "asleep" and "off": an OS entering S3/s2idle arms
+// DEVICE_REMOTE_WAKEUP on wakeup-enabled devices BEFORE suspending (the existing wake-from-S3 path only
+// works because it does), while a shutdown never sets the feature. TinyUSB samples the flag at each
+// suspend edge and hands it to this weak callback (nothing else in the core claims it). A host that has
+// wakeup disabled for the device sends no SET_FEATURE, so its sleep reads as a shutdown -- that just
+// degrades to the old always-re-arm behavior, documented in WAKE_MODE.md.
+static volatile bool s_suspWkArmed = false;
+extern "C" void tud_suspend_cb(bool remote_wakeup_en)
+{
+	s_suspWkArmed = remote_wakeup_en;
+}
+#endif
+
+void wakeAutoRearmTask()
+{
+#if WAKE_AUTO_REARM
+	static uint32_t suspSince = 0; // last suspend EDGE (flaps included)
+	static uint32_t downAt = 0; // episode start (0 = none yet)
+	static uint32_t lastResumeMs = 0;
+	static bool wasSusp = false;
+	static bool epArmed = false; // episode's sleep-vs-shutdown decision
+	const bool susp = USBDevice.suspended();
+	// Track episodes UNCONDITIONALLY -- only the reboot action is gated below. Skipping the tracking
+	// during the handoff grace left a shutdown-inside-the-grace unrecorded, so the first post-grace
+	// edge sampled the EC's stale remote-wakeup arming as if it were the OS sleeping.
+	if (susp && !wasSusp) {
+		suspSince = millis();
+		// Fresh episode: bus was up >= WAKE_REARM_FLAP_MS (a real host session, however brief), no
+		// episode yet, or the current one aged past WAKE_REARM_EPISODE_MS. Otherwise this edge is
+		// a flap continuing the current episode: keep its decision.
+		if (downAt == 0 ||
+		    (uint32_t)(millis() - lastResumeMs) >= WAKE_REARM_FLAP_MS ||
+		    (uint32_t)(millis() - downAt) >= WAKE_REARM_EPISODE_MS) {
+			// The arming only counts as the OS's sleep intent if a real host is actually
+			// CONFIGURED on the bus: a reset-then-suspend EC takeover clears the config and
+			// then SET_FEATUREs remote wakeup itself before suspending -- with no resume edge
+			// since the reset, that reads as a fresh episode, and sampling the bare flag there
+			// classified every such shutdown as a sleeping host and vetoed the re-arm. An OS
+			// entering S3 is always mounted at its suspend edge.
+			epArmed = s_suspWkArmed && USBDevice.mounted();
+			downAt = millis();
+		}
+	}
+	if (!susp && wasSusp)
+		lastResumeMs = millis();
+	wasSusp = susp;
+	// Track the bus-lost clock UNCONDITIONALLY (like the episode tracking above): latching it below
+	// the grace gate made a failed wake's 45 s dead-bus countdown start only after the 90 s grace,
+	// re-arming at ~140 s instead of the documented ~grace-end.
+	static uint32_t busLostMs = 0;
+	if (USBDevice.mounted())
+		busLostMs = 0;
+	else if (!busLostMs)
+		busLostMs = millis() ? millis() : 1;
+	// A machine POSTing after our own wake fire looks suspended (or dead); re-arming now would swap
+	// the puck out from under the boot. Track above, act only past the grace -- and give haptics'
+	// suspend power-off AND its full retry schedule (ripe through send + RETRIES x RETRY_MS = 12 s)
+	// a head start when the grace ends with the bus already down, so the re-arm reboot can never
+	// destroy a pending resend.
+	if (wakeHandoffActive() || modeIsWake(g_usbMode))
+		return;
+	static uint32_t graceClearMs = 0;
+	if (g_wakeHandoffBoot) {
+		if (!graceClearMs)
+			graceClearMs = millis();
+		if ((uint32_t)(millis() - graceClearMs) < 15000u)
+			return;
+	}
+	if (susp) {
+		// Countdown from the LAST suspend edge, not the episode start: a manual power-on's POST
+		// flaps continue the shutdown episode, and counting from its start would fire the re-arm
+		// in the middle of a boot the user started by hand. Every flap restarts the clock; only
+		// WAKE_AUTO_REARM_MS of CONTINUOUS suspension (and a shutdown-decided episode) re-arms.
+		if (!epArmed &&
+		    (uint32_t)(millis() - suspSince) >= WAKE_AUTO_REARM_MS)
+			modeSwitchReboot(MODE_WAKE);
+		return;
+	}
+	// Dead-bus path (see WAKE_DEADBUS_REARM_MS): the bus is neither mounted nor suspended -- a
+	// reset-style shutdown, a failed wake's return boot, or a plug into an off host. The clock runs
+	// from the moment the bus was lost (tracked above, through the grace), NOT puck uptime: an
+	// uptime clock fired mid-shutdown and rebooted the puck out from under the pending power-off.
+	if (busLostMs &&
+	    (uint32_t)(millis() - busLostMs) >= WAKE_DEADBUS_REARM_MS)
+		modeSwitchReboot(MODE_WAKE);
+#endif
+}

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -119,12 +119,12 @@ void WakeController::begin()
 	// 10 ms, a real keyboard's cadence; nothing here is latency-sensitive
 	g_kbd.setPollInterval(10);
 	g_kbd.begin();
-	// Connect-triggered rearm boot (0xC3, the ONLY marked rearm -- see WAKE_REARM_FIRE_WINDOW_MS):
-	// the user's press already happened and the host was proven down, so the link-quiet clock's job
-	// -- keeping a mode switch from typing into a live session -- is already done. Arm immediately:
-	// the connect that triggered the rearm must be answerable the moment it relinks. Timer/dead-bus
-	// rearm boots are unmarked and go through W_WAIT_DOWN like a manual entry, so a controller that
-	// survived its power-off can never fire the hotkey without a human gesture.
+	// Marked rearm boot (0xC3 -- see WAKE_REARM_FIRE_WINDOW_MS): the host was proven down and
+	// nothing was on the air at the reboot, so the link-quiet clock's job -- keeping a mode switch
+	// from typing into a live session -- is already done, and any prompt connect is a fresh human
+	// press. Arm immediately so that press is answerable the moment it (re)links. Rearm boots that
+	// had a link up (or only freshly down) are unmarked and go through W_WAIT_DOWN like a manual
+	// entry, so a controller that survived its power-off can never fire without a human gesture.
 	s_bootMs = millis();
 	if (g_wakeRearmBoot)
 		s_st = W_ARMED;
@@ -303,11 +303,12 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en)
 	s_suspWkArmed = remote_wakeup_en;
 }
 
-// CONNECT-TRIGGERED rearm reboot only: carries the persisted one-shot gesture marker (Cfg.wakeHandoff
-// 0xC3, flash for the same reason as the fire handoff: this board class's bootloader wipes .noinit
-// RAM). saveCfg runs inside modeSwitchReboot's saveMode, so the marker rides the same flash write.
-// Timer/dead-bus rearms call modeSwitchReboot(MODE_WAKE) bare -- no gesture, no marker, normal
-// quiet-clock arming. Does not return.
+// Marked rearm reboot: carries the persisted one-shot marker (Cfg.wakeHandoff 0xC3, flash for the
+// same reason as the fire handoff: this board class's bootloader wipes .noinit RAM) attesting that
+// nothing was on the air (see WAKE_REARM_FIRE_WINDOW_MS in mode_wake.h). saveCfg runs inside
+// modeSwitchReboot's saveMode, so the marker rides the same flash write. Callers with a link up (or
+// only freshly down) call modeSwitchReboot(MODE_WAKE) bare instead -- no marker, normal quiet-clock
+// arming. Does not return.
 static void wakeRearmReboot()
 {
 	g_wakeHandoffArm = 0xC3;
@@ -399,8 +400,7 @@ void wakeAutoRearmTask()
 		// and making the user wait out the timer. Runs before rfLinkTask/hapticTask in loop(), and
 		// the power-off frame only leaves on rfLinkTask's poll replies, so this reboot always
 		// preempts a same-pass power-off. A sleep episode (epArmed) never lands here: its connect
-		// edge did the S3 remote wakeup in rf_link instead. This is the ONLY marked (0xC3) rearm:
-		// the marker attests a user gesture.
+		// edge did the S3 remote wakeup in rf_link instead.
 		if (!epArmed && connGesture &&
 		    (uint32_t)(millis() - suspSince) >= WAKE_REARM_FLAP_MS)
 			wakeRearmReboot();
@@ -408,12 +408,21 @@ void wakeAutoRearmTask()
 		// flaps continue the shutdown episode, and counting from its start would fire the re-arm
 		// in the middle of a boot the user started by hand. Every flap restarts the clock; only
 		// WAKE_AUTO_REARM_MS of CONTINUOUS suspension (and a shutdown-decided episode) re-arms.
-		// UNMARKED reboot: with no gesture behind it, the wake mode must take the normal quiet-
-		// clock arming, or a controller that survived its power-off would relink into a pre-armed
-		// no-edge window and power the machine back on by itself.
+		// Marked (instant-arm) only when nothing is on the air and hasn't been for
+		// WAKE_REARM_CONN_DOWN_MS -- then a prompt connect on the wake boot must be a fresh human
+		// press, and a press RACING this timer fires first try instead of connecting into an
+		// unarmed quiet wait. With a link up (or only just dropped, i.e. possibly a fade of a
+		// controller that survived its power-off), boot UNMARKED: quiet-clock arming, so the
+		// survivor can never power the machine back on by itself.
 		if (!epArmed &&
-		    (uint32_t)(millis() - suspSince) >= WAKE_AUTO_REARM_MS)
-			modeSwitchReboot(MODE_WAKE);
+		    (uint32_t)(millis() - suspSince) >= WAKE_AUTO_REARM_MS) {
+			if (!linkUp && linkDownMs &&
+			    (uint32_t)(millis() - linkDownMs) >=
+				    WAKE_REARM_CONN_DOWN_MS)
+				wakeRearmReboot();
+			else
+				modeSwitchReboot(MODE_WAKE);
+		}
 		return;
 	}
 	// Dead-bus path (see WAKE_DEADBUS_REARM_MS): the bus is neither mounted nor suspended -- a
@@ -422,10 +431,19 @@ void wakeAutoRearmTask()
 	// uptime clock fired mid-shutdown and rebooted the puck out from under the pending power-off.
 	// No connect fast path here ON PURPOSE: a dead bus is also what a manually-rebooting PC looks
 	// like during POST, and a controller powered on during a normal boot must not swap the puck for
-	// the wake keyboard -- only the (deliberately long) timer may act on a dead bus. UNMARKED
-	// reboot for the same reason as the suspend timer above: no gesture, so no pre-armed window.
+	// the wake keyboard -- only the (deliberately long) timer may act on a dead bus. Marked
+	// (instant-arm) under the same nothing-on-the-air condition as the suspend timer above; with a
+	// link up the boot stays unmarked and quiet-clock arming keeps a standing link from ever
+	// firing without a human gesture (a controller off for 3 s+ arms via the quiet clock ~8 s
+	// later anyway, so the marker changes timing, not exposure).
 	if (busLostMs &&
-	    (uint32_t)(millis() - busLostMs) >= WAKE_DEADBUS_REARM_MS)
-		modeSwitchReboot(MODE_WAKE);
+	    (uint32_t)(millis() - busLostMs) >= WAKE_DEADBUS_REARM_MS) {
+		if (!linkUp && linkDownMs &&
+		    (uint32_t)(millis() - linkDownMs) >=
+			    WAKE_REARM_CONN_DOWN_MS)
+			wakeRearmReboot();
+		else
+			modeSwitchReboot(MODE_WAKE);
+	}
 #endif
 }

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -180,7 +180,7 @@ void WakeController::task()
 		// Stage the press like a human types it: Alt down alone first. A
 		// minimal EC hotkey parser may track modifier-then-key transitions
 		// rather than accepting a combined report out of nowhere.
-		kbdSend(WAKE_MOD, 0);
+		kbdSend(g_wakeMod, 0);
 		s_t = now;
 		s_st = W_MODLEAD;
 		break;
@@ -188,7 +188,7 @@ void WakeController::task()
 	case W_MODLEAD:
 		if (now - s_t < WAKE_MOD_LEAD_MS)
 			break;
-		kbdSend(WAKE_MOD, WAKE_KEY);
+		kbdSend(g_wakeMod, g_wakeKey);
 		// wake-debugger convention: flash = a wake was actually sent
 		ledWakePulse();
 		s_resend = now;
@@ -202,7 +202,7 @@ void WakeController::task()
 			// current report (rather than edge-detecting) can miss a
 			// single transfer.
 			if (now - s_resend >= WAKE_RESEND_MS && g_kbd.ready()) {
-				kbdSend(WAKE_MOD, WAKE_KEY);
+				kbdSend(g_wakeMod, g_wakeKey);
 				s_resend = now;
 			}
 			break;

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -82,6 +82,10 @@ static uint32_t s_t = 0; // start of the current timed phase
 static uint32_t s_dl = 0; // press-sequence start, for WAKE_SEQ_DEADLINE_MS
 static uint32_t s_resend = 0; // last held-report re-send (WAKE_RESEND_MS)
 static uint8_t s_shots = 0;
+// begin() timestamp, anchor for the rearm-boot fire window. Wrap-safe subtraction against this --
+// never a raw millis() comparison -- so a puck parked in W_ARMED on always-on VBUS for 49.7 days
+// cannot see the no-edge window reopen at the millis() wrap.
+static uint32_t s_bootMs = 0;
 
 // One boot-keyboard report. Queued for the usbTx drain like every other report in this firmware -- loop()
 // never calls tud_* directly (see usb_tx.h). key==0 with mod==0 is the all-keys-up report.
@@ -115,10 +119,13 @@ void WakeController::begin()
 	// 10 ms, a real keyboard's cadence; nothing here is latency-sensitive
 	g_kbd.setPollInterval(10);
 	g_kbd.begin();
-	// Auto-rearm boot: the host was proven down before the reboot (>= WAKE_AUTO_REARM_MS of
-	// shutdown-decided suspend, a settled connect, or a long-dead bus), so the link-quiet clock's job
+	// Connect-triggered rearm boot (0xC3, the ONLY marked rearm -- see WAKE_REARM_FIRE_WINDOW_MS):
+	// the user's press already happened and the host was proven down, so the link-quiet clock's job
 	// -- keeping a mode switch from typing into a live session -- is already done. Arm immediately:
-	// the connect that triggered a rearm-on-connect boot must be answerable the moment it relinks.
+	// the connect that triggered the rearm must be answerable the moment it relinks. Timer/dead-bus
+	// rearm boots are unmarked and go through W_WAIT_DOWN like a manual entry, so a controller that
+	// survived its power-off can never fire the hotkey without a human gesture.
+	s_bootMs = millis();
 	if (g_wakeRearmBoot)
 		s_st = W_ARMED;
 }
@@ -164,15 +171,17 @@ void WakeController::task()
 		// the EC's minimal stack having enumerated us. If it never goes true we simply never fire, and
 		// the LED never flashes, which is the diagnostic.
 		//
-		// Rearm-boot fire window: on a g_wakeRearmBoot boot the gesture already happened -- the
-		// connect that triggered the rearm (or a press racing the timer) -- and the controller
-		// relinks within ~1 s of boot, but the EC's enumeration of the reborn keyboard can take
-		// longer than WAKE_FIRE_LATCH_MS after that edge. For the first WAKE_REARM_FIRE_WINDOW_MS
-		// of the boot a link that is simply UP when ready() lands fires without a fresh edge; past
-		// the window the strict edge-latch rules return (a controller connected against a dead port
-		// must not fire when a manually booted OS finally enumerates us).
+		// Rearm-boot fire window: on a g_wakeRearmBoot (connect-triggered) boot the gesture already
+		// happened -- the connect that caused the rearm -- and the controller relinks within ~1 s
+		// of boot, but the EC's enumeration of the reborn keyboard can take longer than
+		// WAKE_FIRE_LATCH_MS after that edge. For the first WAKE_REARM_FIRE_WINDOW_MS of the boot a
+		// link that is simply UP when ready() lands fires without a fresh edge; past the window the
+		// strict edge-latch rules return (a controller connected against a dead port must not fire
+		// when a manually booted OS finally enumerates us). Wrap-safe subtraction against s_bootMs
+		// on purpose (see its comment).
 		if ((s_pend || (g_wakeRearmBoot && up &&
-				now <= WAKE_REARM_FIRE_WINDOW_MS)) &&
+				(uint32_t)(now - s_bootMs) <=
+					WAKE_REARM_FIRE_WINDOW_MS)) &&
 		    g_kbd.ready()) {
 			s_pend = false;
 			s_shots = 0;
@@ -260,6 +269,22 @@ bool wakeFireInFlight()
 	return modeIsWake(g_usbMode) && s_st >= W_PRESS;
 }
 
+// True while a connect-triggered rearm boot is still inside its fire window (see mode_wake.h): the
+// W_ARMED wait for g_kbd.ready() is part of answering the user's press, and haptics' suspend
+// power-off must not shoot the triggering controller down during it.
+bool wakeRearmWaitActive()
+{
+	return modeIsWake(g_usbMode) && g_wakeRearmBoot &&
+	       (uint32_t)(millis() - s_bootMs) <= WAKE_REARM_FIRE_WINDOW_MS;
+}
+
+// The one definition of "a byte the wake press may type": the defined HID keyboard usage range.
+// Shared by loadCfg and the WebUSB field-31 setter so the accept policies can never drift apart.
+bool wakeKeyValid(uint8_t k)
+{
+	return k >= HID_KEY_A && k <= HID_KEY_GUI_RIGHT;
+}
+
 // Auto-re-arm watcher, called from loop() in every mode (compiled to nothing unless the WAKE_AUTO_REARM
 // build option is on -- see mode_wake.h for why it is off by default). Note this deliberately bypasses the
 // "no mode switch while suspended" convention the chord + console paths follow: their rule exists so a
@@ -278,9 +303,11 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en)
 	s_suspWkArmed = remote_wakeup_en;
 }
 
-// Every auto-rearm reboot carries the persisted one-shot rearm marker (Cfg.wakeHandoff 0xC3, flash for
-// the same reason as the fire handoff: this board class's bootloader wipes .noinit RAM). saveCfg runs
-// inside modeSwitchReboot's saveMode, so the marker rides the same flash write. Does not return.
+// CONNECT-TRIGGERED rearm reboot only: carries the persisted one-shot gesture marker (Cfg.wakeHandoff
+// 0xC3, flash for the same reason as the fire handoff: this board class's bootloader wipes .noinit
+// RAM). saveCfg runs inside modeSwitchReboot's saveMode, so the marker rides the same flash write.
+// Timer/dead-bus rearms call modeSwitchReboot(MODE_WAKE) bare -- no gesture, no marker, normal
+// quiet-clock arming. Does not return.
 static void wakeRearmReboot()
 {
 	g_wakeHandoffArm = 0xC3;
@@ -323,10 +350,24 @@ void wakeAutoRearmTask()
 	wasSusp = susp;
 	// Connect-edge tracking for the rearm-on-connect fast path. Tracked UNCONDITIONALLY like the
 	// episode state above -- updating it only past the gates would leave a stale "down" across the
-	// grace and misread the first post-grace pass as a connect edge.
+	// grace and misread the first post-grace pass as a connect edge. An edge only counts as a
+	// GESTURE if the link was continuously down >= WAKE_REARM_CONN_DOWN_MS first: a real press
+	// follows a long controller-off, while an RF fade of a controller that survived its power-off
+	// blips down for well under a second (see mode_wake.h).
 	static bool wasUp = false;
+	static uint32_t linkDownMs =
+		0; // when the link last went down (0 = currently up)
 	const bool linkUp = anySlotLinkUp();
-	const bool connEdge = linkUp && !wasUp;
+	bool connGesture = false;
+	if (linkUp && !wasUp)
+		connGesture = linkDownMs && (uint32_t)(millis() - linkDownMs) >=
+						    WAKE_REARM_CONN_DOWN_MS;
+	if (!linkUp && wasUp)
+		linkDownMs = millis() ? millis() : 1;
+	else if (!linkUp && !linkDownMs)
+		linkDownMs = millis() ? millis() : 1; // down since boot
+	if (linkUp)
+		linkDownMs = 0;
 	wasUp = linkUp;
 	// Track the bus-lost clock UNCONDITIONALLY (like the episode tracking above): latching it below
 	// the grace gate made a failed wake's 45 s dead-bus countdown start only after the 90 s grace,
@@ -353,22 +394,26 @@ void wakeAutoRearmTask()
 	if (susp) {
 		// Rearm-on-connect (see WAKE_REARM_FIRE_WINDOW_MS in mode_wake.h): with a shutdown-decided
 		// episode and the suspension settled past the EC-takeover flap window, a controller connect
-		// IS the user pressing power for a wake -- reboot into MODE_WAKE right now instead of
-		// letting the suspend power-off shoot the controller down and making the user wait out the
-		// timer. Runs before rfLinkTask/hapticTask in loop(), and the power-off frame only leaves
-		// on rfLinkTask's poll replies, so this reboot always preempts a same-pass power-off. A
-		// sleep episode (epArmed) never lands here: its connect edge did the S3 remote wakeup in
-		// rf_link instead.
-		if (!epArmed && connEdge &&
+		// after a real controller-off IS the user pressing power for a wake -- reboot into
+		// MODE_WAKE right now instead of letting the suspend power-off shoot the controller down
+		// and making the user wait out the timer. Runs before rfLinkTask/hapticTask in loop(), and
+		// the power-off frame only leaves on rfLinkTask's poll replies, so this reboot always
+		// preempts a same-pass power-off. A sleep episode (epArmed) never lands here: its connect
+		// edge did the S3 remote wakeup in rf_link instead. This is the ONLY marked (0xC3) rearm:
+		// the marker attests a user gesture.
+		if (!epArmed && connGesture &&
 		    (uint32_t)(millis() - suspSince) >= WAKE_REARM_FLAP_MS)
 			wakeRearmReboot();
 		// Countdown from the LAST suspend edge, not the episode start: a manual power-on's POST
 		// flaps continue the shutdown episode, and counting from its start would fire the re-arm
 		// in the middle of a boot the user started by hand. Every flap restarts the clock; only
 		// WAKE_AUTO_REARM_MS of CONTINUOUS suspension (and a shutdown-decided episode) re-arms.
+		// UNMARKED reboot: with no gesture behind it, the wake mode must take the normal quiet-
+		// clock arming, or a controller that survived its power-off would relink into a pre-armed
+		// no-edge window and power the machine back on by itself.
 		if (!epArmed &&
 		    (uint32_t)(millis() - suspSince) >= WAKE_AUTO_REARM_MS)
-			wakeRearmReboot();
+			modeSwitchReboot(MODE_WAKE);
 		return;
 	}
 	// Dead-bus path (see WAKE_DEADBUS_REARM_MS): the bus is neither mounted nor suspended -- a
@@ -377,9 +422,10 @@ void wakeAutoRearmTask()
 	// uptime clock fired mid-shutdown and rebooted the puck out from under the pending power-off.
 	// No connect fast path here ON PURPOSE: a dead bus is also what a manually-rebooting PC looks
 	// like during POST, and a controller powered on during a normal boot must not swap the puck for
-	// the wake keyboard -- only the (deliberately long) timer may act on a dead bus.
+	// the wake keyboard -- only the (deliberately long) timer may act on a dead bus. UNMARKED
+	// reboot for the same reason as the suspend timer above: no gesture, so no pre-armed window.
 	if (busLostMs &&
 	    (uint32_t)(millis() - busLostMs) >= WAKE_DEADBUS_REARM_MS)
-		wakeRearmReboot();
+		modeSwitchReboot(MODE_WAKE);
 #endif
 }

--- a/OpenPuck/mode_wake.cpp
+++ b/OpenPuck/mode_wake.cpp
@@ -115,6 +115,12 @@ void WakeController::begin()
 	// 10 ms, a real keyboard's cadence; nothing here is latency-sensitive
 	g_kbd.setPollInterval(10);
 	g_kbd.begin();
+	// Auto-rearm boot: the host was proven down before the reboot (>= WAKE_AUTO_REARM_MS of
+	// shutdown-decided suspend, a settled connect, or a long-dead bus), so the link-quiet clock's job
+	// -- keeping a mode switch from typing into a live session -- is already done. Arm immediately:
+	// the connect that triggered a rearm-on-connect boot must be answerable the moment it relinks.
+	if (g_wakeRearmBoot)
+		s_st = W_ARMED;
 }
 
 // Non-blocking throughout: every wait is a millis() comparison, never a delay(). loop() has to keep feeding
@@ -157,7 +163,17 @@ void WakeController::task()
 		// ready() means the host has actually configured our interface -- on a machine in S5 that is
 		// the EC's minimal stack having enumerated us. If it never goes true we simply never fire, and
 		// the LED never flashes, which is the diagnostic.
-		if (s_pend && g_kbd.ready()) {
+		//
+		// Rearm-boot fire window: on a g_wakeRearmBoot boot the gesture already happened -- the
+		// connect that triggered the rearm (or a press racing the timer) -- and the controller
+		// relinks within ~1 s of boot, but the EC's enumeration of the reborn keyboard can take
+		// longer than WAKE_FIRE_LATCH_MS after that edge. For the first WAKE_REARM_FIRE_WINDOW_MS
+		// of the boot a link that is simply UP when ready() lands fires without a fresh edge; past
+		// the window the strict edge-latch rules return (a controller connected against a dead port
+		// must not fire when a manually booted OS finally enumerates us).
+		if ((s_pend || (g_wakeRearmBoot && up &&
+				now <= WAKE_REARM_FIRE_WINDOW_MS)) &&
+		    g_kbd.ready()) {
 			s_pend = false;
 			s_shots = 0;
 			s_dl = now;
@@ -261,6 +277,15 @@ extern "C" void tud_suspend_cb(bool remote_wakeup_en)
 {
 	s_suspWkArmed = remote_wakeup_en;
 }
+
+// Every auto-rearm reboot carries the persisted one-shot rearm marker (Cfg.wakeHandoff 0xC3, flash for
+// the same reason as the fire handoff: this board class's bootloader wipes .noinit RAM). saveCfg runs
+// inside modeSwitchReboot's saveMode, so the marker rides the same flash write. Does not return.
+static void wakeRearmReboot()
+{
+	g_wakeHandoffArm = 0xC3;
+	modeSwitchReboot(MODE_WAKE);
+}
 #endif
 
 void wakeAutoRearmTask()
@@ -296,6 +321,13 @@ void wakeAutoRearmTask()
 	if (!susp && wasSusp)
 		lastResumeMs = millis();
 	wasSusp = susp;
+	// Connect-edge tracking for the rearm-on-connect fast path. Tracked UNCONDITIONALLY like the
+	// episode state above -- updating it only past the gates would leave a stale "down" across the
+	// grace and misread the first post-grace pass as a connect edge.
+	static bool wasUp = false;
+	const bool linkUp = anySlotLinkUp();
+	const bool connEdge = linkUp && !wasUp;
+	wasUp = linkUp;
 	// Track the bus-lost clock UNCONDITIONALLY (like the episode tracking above): latching it below
 	// the grace gate made a failed wake's 45 s dead-bus countdown start only after the 90 s grace,
 	// re-arming at ~140 s instead of the documented ~grace-end.
@@ -319,21 +351,35 @@ void wakeAutoRearmTask()
 			return;
 	}
 	if (susp) {
+		// Rearm-on-connect (see WAKE_REARM_FIRE_WINDOW_MS in mode_wake.h): with a shutdown-decided
+		// episode and the suspension settled past the EC-takeover flap window, a controller connect
+		// IS the user pressing power for a wake -- reboot into MODE_WAKE right now instead of
+		// letting the suspend power-off shoot the controller down and making the user wait out the
+		// timer. Runs before rfLinkTask/hapticTask in loop(), and the power-off frame only leaves
+		// on rfLinkTask's poll replies, so this reboot always preempts a same-pass power-off. A
+		// sleep episode (epArmed) never lands here: its connect edge did the S3 remote wakeup in
+		// rf_link instead.
+		if (!epArmed && connEdge &&
+		    (uint32_t)(millis() - suspSince) >= WAKE_REARM_FLAP_MS)
+			wakeRearmReboot();
 		// Countdown from the LAST suspend edge, not the episode start: a manual power-on's POST
 		// flaps continue the shutdown episode, and counting from its start would fire the re-arm
 		// in the middle of a boot the user started by hand. Every flap restarts the clock; only
 		// WAKE_AUTO_REARM_MS of CONTINUOUS suspension (and a shutdown-decided episode) re-arms.
 		if (!epArmed &&
 		    (uint32_t)(millis() - suspSince) >= WAKE_AUTO_REARM_MS)
-			modeSwitchReboot(MODE_WAKE);
+			wakeRearmReboot();
 		return;
 	}
 	// Dead-bus path (see WAKE_DEADBUS_REARM_MS): the bus is neither mounted nor suspended -- a
 	// reset-style shutdown, a failed wake's return boot, or a plug into an off host. The clock runs
 	// from the moment the bus was lost (tracked above, through the grace), NOT puck uptime: an
 	// uptime clock fired mid-shutdown and rebooted the puck out from under the pending power-off.
+	// No connect fast path here ON PURPOSE: a dead bus is also what a manually-rebooting PC looks
+	// like during POST, and a controller powered on during a normal boot must not swap the puck for
+	// the wake keyboard -- only the (deliberately long) timer may act on a dead bus.
 	if (busLostMs &&
 	    (uint32_t)(millis() - busLostMs) >= WAKE_DEADBUS_REARM_MS)
-		modeSwitchReboot(MODE_WAKE);
+		wakeRearmReboot();
 #endif
 }

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -117,16 +117,18 @@
 // ~15 s after shutdown connected to a Steam-mode puck on a suspended bus and was (correctly, for the
 // S3 case) powered straight back off by the suspend policy -- a press-timing trap users hit in
 // practice. A sleep episode (remote wakeup armed) never takes this path: its connect edge does the
-// normal S3 remote wakeup instead. CONNECT-TRIGGERED rearm boots -- and only those -- carry a
-// persisted one-shot marker (Cfg.wakeHandoff 0xC3 sentinel -> g_wakeRearmBoot): the marker attests a
-// USER GESTURE, so MODE_WAKE arms instantly (no link-quiet wait, RF cooldown pre-opened), and for
-// this long after the boot a link that is simply UP when the keyboard turns ready() fires without a
-// fresh up-edge -- the EC's enumeration of the reborn keyboard can outlast WAKE_FIRE_LATCH_MS, and
-// the connect that caused the boot IS the gesture. Past the window the strict edge-latch rules
-// return. Timer and dead-bus rearms deliberately boot UNMARKED into the normal quiet-clock arming: a
-// controller that survived its power-off (best-effort delivery) relinks right after any rearm
-// reboot, and against a pre-armed no-edge window that standing link would power the machine back on
-// with nobody at the button.
+// normal S3 remote wakeup instead. The persisted one-shot marker (Cfg.wakeHandoff 0xC3 sentinel ->
+// g_wakeRearmBoot) attests "NO CONTROLLER WAS ON THE AIR -- any prompt connect is a fresh human
+// press": connect-triggered rearms always carry it (the gesture already happened), and timer/
+// dead-bus rearms carry it only when the link has been continuously down >= WAKE_REARM_CONN_DOWN_MS
+// at the reboot. A marked boot arms instantly (no link-quiet wait, RF cooldown pre-opened), and for
+// this long after it a link that is simply UP when the keyboard turns ready() fires without a fresh
+// up-edge -- the EC's enumeration of the reborn keyboard can outlast WAKE_FIRE_LATCH_MS. This is
+// what makes a press RACING the timer (landing in the reboot's first seconds) fire first try
+// instead of connecting into an unarmed quiet wait. Past the window the strict edge-latch rules
+// return. A timer/dead-bus rearm with a link UP (or only just dropped -- an RF fade of a controller
+// that survived its best-effort power-off) boots UNMARKED into the normal quiet-clock arming, so a
+// standing or fade-flapping link can never power the machine back on with nobody at the button.
 #define WAKE_REARM_FIRE_WINDOW_MS 15000u
 // A connect edge only counts as a wake gesture if the link was continuously DOWN this long first: a
 // real press follows seconds-to-hours of controller-off, while an RF fade of a still-on controller

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -6,7 +6,7 @@
 // resume -- the only thing listening on the port is the board's embedded controller, and on Lenovo
 // ThinkCentre (BIOS: Power > Smart Power On) it powers the machine on when it sees Alt+P from a USB
 // keyboard on the designated always-on port. Dell/others have the same feature under different names and
-// different chords; see WAKE_MOD / WAKE_KEY below.
+// different chords; the hotkey is configurable from the WebUSB panel (see WAKE_MOD_DEFAULT below).
 //
 // WHY A SEPARATE MODE RATHER THAN ONE MORE INTERFACE ON THE PUCK. Two reasons:
 //   1. The EC's S5 USB stack is minimal. A real keyboard is what it was written against, so the safest
@@ -41,9 +41,11 @@
 // wake never overwrites the user's chosen personality. Set a concrete mode to force one instead.
 #define WAKE_RETURN_MODE 0xFF
 
-// The hotkey itself. Lenovo ThinkCentre Smart Power On = Alt+P.
-#define WAKE_MOD KEYBOARD_MODIFIER_LEFTALT
-#define WAKE_KEY HID_KEY_P
+// The hotkey DEFAULTS. Lenovo ThinkCentre Smart Power On = Alt+P. The live hotkey is runtime config
+// (g_wakeMod / g_wakeKey, config.h): settable from the WebUSB panel (fields 30/31) for vendors whose
+// EC wants a different chord, persisted in cfg.bin, falling back to these when unset.
+#define WAKE_MOD_DEFAULT KEYBOARD_MODIFIER_LEFTALT
+#define WAKE_KEY_DEFAULT HID_KEY_P
 
 // How long the RF link must be continuously down before an up-edge counts as a wake gesture. Must be
 // comfortably longer than anySlotLinkUp()'s 300 ms window so an ordinary RF hiccup can't arm us -- and

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -88,7 +88,8 @@
 #define WAKE_SEQ_DEADLINE_MS 10000u
 
 // EXPERIMENTAL, default OFF; build with EXTRA_FLAGS="-DWAKE_AUTO_REARM=1" to enable. While running any
-// OTHER personality, a continuous USB suspend longer than WAKE_AUTO_REARM_MS reboots into MODE_WAKE, so
+// OTHER personality, a continuous USB suspend longer than WAKE_AUTO_REARM_MS reboots into MODE_WAKE (or
+// immediately on a controller connect once the episode is settled -- see WAKE_REARM_FIRE_WINDOW_MS), so
 // the wake re-arms itself every time the host goes down (the smart-power-on port keeps VBUS in S5, so the
 // MCU never cold-boots -- without this, one wake per manual arm). Sleep is distinguished from shutdown by
 // the host's own hand: an OS entering S3 arms DEVICE_REMOTE_WAKEUP before suspending (tud_suspend_cb in
@@ -104,8 +105,23 @@
 // A bus resume shorter than this does NOT start a new down-episode: during poweroff the smart-port EC
 // takes the bus over with a brief resume (~2.4 s captured on the M90q) and re-suspends WITH remote
 // wakeup armed -- its own listening mechanism, not the OS's sleep intent. The sleep-vs-shutdown decision
-// is sampled once, at the first suspend edge of the episode, and EC flaps cannot overwrite it.
+// is sampled once, at the first suspend edge of the episode, and EC flaps cannot overwrite it. Doubles
+// as the settle time for the rearm-on-connect fast path below: a connect is only honored once the bus
+// has been CONTINUOUSLY suspended this long, so the EC takeover flap can never race the decision.
 #define WAKE_REARM_FLAP_MS 5000u
+// Rearm-on-connect: while suspended with a shutdown-decided episode (settled per the flap filter), a
+// controller CONNECT is unambiguous -- the user pressing power for a wake -- so the re-arm reboots
+// immediately instead of waiting out WAKE_AUTO_REARM_MS. Without it, a press in the puck's first
+// ~15 s after shutdown connected to a Steam-mode puck on a suspended bus and was (correctly, for the
+// S3 case) powered straight back off by the suspend policy -- a press-timing trap users hit in
+// practice. A sleep episode (remote wakeup armed) never takes this path: its connect edge does the
+// normal S3 remote wakeup instead. Rearm boots carry a persisted one-shot marker (Cfg.wakeHandoff
+// 0xC3 sentinel -> g_wakeRearmBoot): the host was already proven down, so MODE_WAKE arms instantly
+// (no link-quiet wait, RF cooldown pre-opened), and for this long after the rearm boot a link that is
+// simply UP when the keyboard turns ready() fires without a fresh up-edge -- the EC's enumeration of
+// the reborn keyboard can outlast WAKE_FIRE_LATCH_MS, and the connect that caused the boot IS the
+// gesture. Past the window the strict edge-latch rules return.
+#define WAKE_REARM_FIRE_WINDOW_MS 15000u
 // ...but an episode older than this always re-samples: USB selective-suspend churn can put a sub-5 s
 // resume right before a genuine sleep, and inheriting an hours-old "shutdown" decision there would
 // re-arm under a sleeping host. The EC takeover flap arrives ~3 s into its episode, far under this cap.

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -96,6 +96,8 @@
 // mode_wake.cpp) and such suspends never re-arm, so wake-on-connect-from-S3 keeps working. Still off by
 // default: a host with wakeup disabled for the device (sysfs) makes its sleep look like a shutdown,
 // degrading to re-arm-on-sleep -- acceptable on hosts that shut down to S4/S5, surprising elsewhere.
+// The game/clean PS personalities never advertise remote wakeup at all (OpenPuck.ino psClean), so in
+// those modes EVERY sleep classifies as a shutdown -- the same degradation class.
 #ifndef WAKE_AUTO_REARM
 #define WAKE_AUTO_REARM 0
 #endif
@@ -115,13 +117,22 @@
 // ~15 s after shutdown connected to a Steam-mode puck on a suspended bus and was (correctly, for the
 // S3 case) powered straight back off by the suspend policy -- a press-timing trap users hit in
 // practice. A sleep episode (remote wakeup armed) never takes this path: its connect edge does the
-// normal S3 remote wakeup instead. Rearm boots carry a persisted one-shot marker (Cfg.wakeHandoff
-// 0xC3 sentinel -> g_wakeRearmBoot): the host was already proven down, so MODE_WAKE arms instantly
-// (no link-quiet wait, RF cooldown pre-opened), and for this long after the rearm boot a link that is
-// simply UP when the keyboard turns ready() fires without a fresh up-edge -- the EC's enumeration of
-// the reborn keyboard can outlast WAKE_FIRE_LATCH_MS, and the connect that caused the boot IS the
-// gesture. Past the window the strict edge-latch rules return.
+// normal S3 remote wakeup instead. CONNECT-TRIGGERED rearm boots -- and only those -- carry a
+// persisted one-shot marker (Cfg.wakeHandoff 0xC3 sentinel -> g_wakeRearmBoot): the marker attests a
+// USER GESTURE, so MODE_WAKE arms instantly (no link-quiet wait, RF cooldown pre-opened), and for
+// this long after the boot a link that is simply UP when the keyboard turns ready() fires without a
+// fresh up-edge -- the EC's enumeration of the reborn keyboard can outlast WAKE_FIRE_LATCH_MS, and
+// the connect that caused the boot IS the gesture. Past the window the strict edge-latch rules
+// return. Timer and dead-bus rearms deliberately boot UNMARKED into the normal quiet-clock arming: a
+// controller that survived its power-off (best-effort delivery) relinks right after any rearm
+// reboot, and against a pre-armed no-edge window that standing link would power the machine back on
+// with nobody at the button.
 #define WAKE_REARM_FIRE_WINDOW_MS 15000u
+// A connect edge only counts as a wake gesture if the link was continuously DOWN this long first: a
+// real press follows seconds-to-hours of controller-off, while an RF fade of a still-on controller
+// (the same best-effort-delivery survivor) blips down for well under a second -- without this, a
+// deep fade + relink while shutdown-suspended would read as a press and power the machine back on.
+#define WAKE_REARM_CONN_DOWN_MS 3000u
 // ...but an episode older than this always re-samples: USB selective-suspend churn can put a sub-5 s
 // resume right before a genuine sleep, and inheriting an hours-old "shutdown" decision there would
 // re-arm under a sleeping host. The EC takeover flap arrives ~3 s into its episode, far under this cap.
@@ -161,6 +172,14 @@ bool wakeHandoffExpired();
 // True while a press sequence is in flight (first press queued .. return reboot): the only wake-mode
 // window where haptics' suspend power-off must hold its fire (it would kill the triggering controller).
 bool wakeFireInFlight();
+// True while a connect-triggered rearm boot is still inside WAKE_REARM_FIRE_WINDOW_MS: haptics'
+// suspend power-off must also hold fire here -- the EC's enumerate flap (resume then re-suspend, a
+// captured M90q behavior) re-arms the suspend one-shot, and if ready() takes longer than
+// SUSPEND_OFF_MS from that edge the power-off would swallow the very press that triggered the rearm.
+bool wakeRearmWaitActive();
+// Valid HID keyboard usage for the wake hotkey (shared by loadCfg and the WebUSB setter, so the two
+// sites can never drift apart and silently un-persist a key one of them accepted).
+bool wakeKeyValid(uint8_t k);
 
 class WakeController : public IController {
     public:

--- a/OpenPuck/mode_wake.h
+++ b/OpenPuck/mode_wake.h
@@ -1,0 +1,159 @@
+// mode_wake.h -- MODE_WAKE: a boot-keyboard-only personality that powers on a
+// sleeping/off desktop with its firmware hotkey, then hands the port back to the puck.
+//
+// WHY THIS EXISTS. USB remote-wakeup (wake_hid.cpp + the rf_link connect edge) only works from S3: it
+// needs a host controller that is still clocked. From a full shutdown (S5) there is no host stack to
+// resume -- the only thing listening on the port is the board's embedded controller, and on Lenovo
+// ThinkCentre (BIOS: Power > Smart Power On) it powers the machine on when it sees Alt+P from a USB
+// keyboard on the designated always-on port. Dell/others have the same feature under different names and
+// different chords; see WAKE_MOD / WAKE_KEY below.
+//
+// WHY A SEPARATE MODE RATHER THAN ONE MORE INTERFACE ON THE PUCK. Two reasons:
+//   1. The EC's S5 USB stack is minimal. A real keyboard is what it was written against, so the safest
+//      thing to show it is a single boot-protocol HID keyboard and nothing else -- no wake mouse, no
+//      WebUSB, no CDC. setup() drops all of those for this mode (see `bareHid` in OpenPuck.ino).
+//   2. Endpoints. The puck composite already uses 6 of the nRF52840's 7 data IN endpoints, so bolting a
+//      keyboard onto it would spend the last one. Two-phase costs nothing: each phase is small.
+//
+// THE FLOW.
+//   arm     -- chord / WebUSB panel / CDC console switch to MODE_WAKE (modeSwitchReboot). With the default
+//              "always boot Steam" policy this is a ONE-SHOT bootMode, which is exactly right: one wake,
+//              then back to normal.
+//   settle  -- the mode refuses to arm until the RF link has been DOWN for WAKE_ARM_DOWN_MS. This is the
+//              stand-in for "is the host off?": you arm while the controller is still on, and arming only
+//              completes once you put the controller down / power the desk off. Without it the still-
+//              connected controller would trip the wake the instant we rebooted, firing Alt+P into the
+//              running session and bouncing straight back to puck mode.
+//   fire    -- first link-up edge after arming sends Alt+P (WAKE_REPEAT times), LED pulses per the
+//              status_led wake-debugger convention: flash = we sent it, no flash = we never fired.
+//   hand off-- after WAKE_SETTLE_MS, modeSwitchReboot(WAKE_RETURN_MODE). The reboot is a real detach +
+//              re-enumerate, so the machine -- which is a couple of seconds into POST by then -- enumerates
+//              the puck normally and Steam sees it as it always does.
+//
+// RE-ARMING. The smart-power-on port keeps VBUS up in S5, so the MCU never cold-boots and nothing re-arms
+// this mode after it fires: by default it is one wake per manual arm. The WAKE_AUTO_REARM build option
+// (below) makes it repeatable: a persistent USB suspend in any other mode reboots back into MODE_WAKE.
+#pragma once
+#include "controllers.h"
+
+// Where to land after the hotkey has been sent. 0xFF = modeSwitchReboot's "keep current" sentinel, which
+// boots by the normal policy: the persisted mode for persist-last-mode users, Steam otherwise -- so a
+// wake never overwrites the user's chosen personality. Set a concrete mode to force one instead.
+#define WAKE_RETURN_MODE 0xFF
+
+// The hotkey itself. Lenovo ThinkCentre Smart Power On = Alt+P.
+#define WAKE_MOD KEYBOARD_MODIFIER_LEFTALT
+#define WAKE_KEY HID_KEY_P
+
+// How long the RF link must be continuously down before an up-edge counts as a wake gesture. Must be
+// comfortably longer than anySlotLinkUp()'s 300 ms window so an ordinary RF hiccup can't arm us -- and
+// long enough that a controller briefly walking out of range while the host is LIVE can't re-arm a
+// keyboard pointed at the session. The quiet clock only runs once the RF side is on air (rfConnectOpen()),
+// so with a controller off at the mode switch, arming lands ~WAKE_ARM_DOWN_MS after the cooldown opens.
+#define WAKE_ARM_DOWN_MS 5000u
+
+// An up-EDGE seen while the keyboard is not yet ready() stays a valid gesture for this long. Long enough
+// for the EC's resume-then-configure lag after our remote wakeup (milliseconds), far shorter than a human
+// power-on: a controller that connected against a dead port must NOT fire hours later when a manually
+// booted OS finally enumerates the keyboard.
+#define WAKE_FIRE_LATCH_MS 2000u
+
+// Press shaping. A combined Alt+P report held 60 ms was read but IGNORED by the
+// ThinkCentre M90q Gen 6 EC (it drained both repeats off the endpoint, so the
+// reports arrived; a real keyboard on the same port woke the machine). Shaping
+// the press like a human types it -- modifier alone first, long hold, restate
+// the held chord -- makes the same EC fire. Which ingredient is load-bearing is
+// untested (each attempt costs an S5 power cycle); all three are what a real
+// keyboard produces anyway.
+#define WAKE_MOD_LEAD_MS \
+	150u // Alt alone before Alt+P (EC may edge-detect modifier-then-key)
+#define WAKE_RESEND_MS 100u // restate the held report (slow-sampling ECs)
+#define WAKE_HOLD_MS \
+	450u // key-down duration (EC samples HID reports, not edges)
+#define WAKE_REPEAT 4 // how many Alt+P presses to send
+#define WAKE_REPEAT_MS 600u // gap between them
+// Quiet time after the last key-up before we detach and re-enumerate as the puck. The EC latches power-on
+// immediately; this only needs to outlast the key-up transfer. POST enumeration is seconds later, so
+// there is a lot of slack here in both directions. Kept short: every ms here extends the RF outage the
+// triggering controller must ride out before the reborn puck answers it again (M90q: the controller gives
+// up somewhere between ~2.5 s and ~5 s of silence).
+#define WAKE_SETTLE_MS 600u
+
+// Give up on the press sequence this long after it starts. If the EC deconfigures us mid-way (port reset
+// as POST takes the bus over), ready() goes false and the machine would otherwise stall in W_PRESS until
+// whatever boots next re-enumerates us -- and then receive a stray Alt+P. On deadline: all-keys-up,
+// settle, reboot to the puck.
+#define WAKE_SEQ_DEADLINE_MS 10000u
+
+// EXPERIMENTAL, default OFF; build with EXTRA_FLAGS="-DWAKE_AUTO_REARM=1" to enable. While running any
+// OTHER personality, a continuous USB suspend longer than WAKE_AUTO_REARM_MS reboots into MODE_WAKE, so
+// the wake re-arms itself every time the host goes down (the smart-power-on port keeps VBUS in S5, so the
+// MCU never cold-boots -- without this, one wake per manual arm). Sleep is distinguished from shutdown by
+// the host's own hand: an OS entering S3 arms DEVICE_REMOTE_WAKEUP before suspending (tud_suspend_cb in
+// mode_wake.cpp) and such suspends never re-arm, so wake-on-connect-from-S3 keeps working. Still off by
+// default: a host with wakeup disabled for the device (sysfs) makes its sleep look like a shutdown,
+// degrading to re-arm-on-sleep -- acceptable on hosts that shut down to S4/S5, surprising elsewhere.
+#ifndef WAKE_AUTO_REARM
+#define WAKE_AUTO_REARM 0
+#endif
+#ifndef WAKE_AUTO_REARM_MS
+#define WAKE_AUTO_REARM_MS 15000u
+#endif
+// A bus resume shorter than this does NOT start a new down-episode: during poweroff the smart-port EC
+// takes the bus over with a brief resume (~2.4 s captured on the M90q) and re-suspends WITH remote
+// wakeup armed -- its own listening mechanism, not the OS's sleep intent. The sleep-vs-shutdown decision
+// is sampled once, at the first suspend edge of the episode, and EC flaps cannot overwrite it.
+#define WAKE_REARM_FLAP_MS 5000u
+// ...but an episode older than this always re-samples: USB selective-suspend churn can put a sub-5 s
+// resume right before a genuine sleep, and inheriting an hours-old "shutdown" decision there would
+// re-arm under a sleeping host. The EC takeover flap arrives ~3 s into its episode, far under this cap.
+#define WAKE_REARM_EPISODE_MS 60000u
+// Dead-bus re-arm: TinyUSB only reports suspend on a bus that got a SETUP packet, so a bus that was
+// RESET at shutdown (one of the M90q EC's two takeover styles), a failed wake's return boot, and a plug
+// into an already-off host all read neither mounted nor suspended -- ever. Measured from when the bus
+// was LOST (or boot, if never mounted): long past a normal boot's re-enumeration gap and past the
+// SUSPEND_OFF_LOST_MS controller power-off, which must land first.
+#define WAKE_DEADBUS_REARM_MS 45000u
+
+// Post-fire handoff grace. After the hotkey is sent the machine spends tens of seconds in POST + OS boot
+// with the bus suspended (nothing has enumerated the reborn puck yet) -- which is indistinguishable from
+// "the host went to sleep". Two standing policies misfire on that state: the suspend-persisted controller
+// power-off (haptics.cpp, SUSPEND_OFF_MS) shuts down the controller that just triggered the wake, and
+// WAKE_AUTO_REARM would yank the puck back into the wake personality mid-boot. wakeHandoffMark() arms a
+// PERSISTED one-shot (Cfg.wakeHandoff -- flash, because this board class's bootloader wipes .noinit RAM
+// on reset) right before the return reboot; wakeHandoffActive() then holds both policies off for this
+// full window. Deadline-only ON PURPOSE -- USBDevice.mounted() is NOT "the OS is up": BIOS legacy-HID
+// support SET_CONFIGURATIONs keyboard-bearing devices during POST, and the BIOS->kernel handoff right
+// after is exactly the suspend gap the grace exists to cover. Nobody sleeps a machine within 90 s of
+// waking it, so nothing is lost by holding the two policies for the whole window; if the machine never
+// boots, haptics' expiry fallback still powers the controller off (battery saved). The handoff boot also
+// skips setup()'s mount wait and opens the RF connect cooldown immediately, so the reborn puck answers
+// the triggering controller in <0.5 s -- before it gives up searching and powers itself off.
+#define WAKE_HANDOFF_GRACE_MS 90000u
+// Early end: once the bus has been CONTINUOUSLY mounted and active for this long, the OS is genuinely up
+// (BIOS legacy-HID mounts last a few seconds and end in the boot-handoff reset/suspend, never this) and
+// the grace's job is done. Without this, a shutdown within 90 s of a wake-boot found the suspend
+// power-off still suppressed: the controller stayed on, the re-arm swapped the puck mid-power-down, and
+// the controller reconnected to the wake keyboard it could then never arm against.
+#define WAKE_HANDOFF_MOUNTED_MS 20000u
+void wakeHandoffMark();
+bool wakeHandoffActive();
+// True from this boot's grace expiry onward (false on non-handoff boots): haptics' never-booted fallback.
+bool wakeHandoffExpired();
+// True while a press sequence is in flight (first press queued .. return reboot): the only wake-mode
+// window where haptics' suspend power-off must hold its fire (it would kill the triggering controller).
+bool wakeFireInFlight();
+
+class WakeController : public IController {
+    public:
+	// STATIC mount, single HID, no slot pool: this mode never forwards controller input to the host --
+	// onReport45/onAuxReport stay no-ops so a trackpad graze can't leak a keystroke into the BIOS or the
+	// just-woken desktop. All the work happens in task().
+	void begin() override;
+	void task() override;
+	void usbIdentity() override;
+};
+extern WakeController g_wakeCtl;
+
+// Called from loop() in EVERY mode. No-op unless built with WAKE_AUTO_REARM (see above).
+void wakeAutoRearmTask();

--- a/OpenPuck/rf_link.cpp
+++ b/OpenPuck/rf_link.cpp
@@ -157,10 +157,26 @@ static unsigned long g_lastStream = 0;
 // Used for the "we're connected to at least one controller" decisions (beacon pacing, wake detect).
 bool anySlotLinkUp()
 {
+	// The != 0 guard matches the six sibling call sites (usb_mount, webusb, ps3, puck_hid, haptics): a
+	// bonded slot that has never replied since boot holds g_connReplyMs == 0, which would otherwise read
+	// "up" for 300 ms after every millis() wrap (~49.7 days) -- and MODE_WAKE turns that glitch into an
+	// unattended Alt+P power-on.
 	for (int s = 0; s < NSLOT; s++)
-		if (g_slot[s].used && millis() - g_connReplyMs[s] < 300)
+		if (g_slot[s].used && g_connReplyMs[s] != 0 &&
+		    millis() - g_connReplyMs[s] < 300)
 			return true;
 	return false;
+}
+
+bool rfConnectOpen()
+{
+	return millis() - g_connCooldown > 2500;
+}
+
+void rfConnectOpenNow()
+{
+	// Backdate instead of zeroing: wrap-safe against the same unsigned arithmetic the gate uses.
+	g_connCooldown = millis() - 2501u;
 }
 
 static void rfHostFrameOnce(int slot, bool discovery)
@@ -485,7 +501,10 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 									    .suspended()) {
 									USBDevice
 										.remoteWakeup();
-									ledWakePulse();
+									// wake mode: LED = presses only
+									if (!modeIsWake(
+										    g_usbMode))
+										ledWakePulse();
 									if (g_active)
 										g_active->wakeEvent();
 								}
@@ -741,10 +760,19 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 					}
 					if (want != 0xFF &&
 					    want == chWant[g_curSlot]) {
+						// The no-switch-while-suspended rule exists so a SLEEPING
+						// host never resumes to a different device -- but a
+						// suspended bus is MODE_WAKE's normal environment (host
+						// off / wrong port), and the chord is that mode's ONLY
+						// exit (no WebUSB, no CDC) AND its only panel-less entry
+						// once the machine is already off. Exempt both
+						// directions, like wakeAutoRearmTask already does.
 						if (++chCnt[g_curSlot] >= 12 &&
 						    want != g_usbMode &&
 						    modeValid(want) &&
-						    !USBDevice.suspended()) {
+						    (!USBDevice.suspended() ||
+						     modeIsWake(g_usbMode) ||
+						     modeIsWake(want))) {
 							// clean detach + reboot into the new mode (releases any held
 							// input on the outgoing device -- see modeSwitchReboot)
 							modeSwitchReboot(want);
@@ -966,7 +994,7 @@ void rfLinkTask()
 	// Poll before beacons: the cycle gate must fire as close to its
 	// 4 ms deadline as possible; beacon TX (up to 3.6 ms for 4 slots)
 	// runs after so it never delays the current poll.
-	if (g_connOn && millis() - g_connCooldown > 2500) {
+	if (g_connOn && rfConnectOpen()) {
 		rfConnStep();
 	} // connected-mode: poll controller, read input
 
@@ -974,7 +1002,7 @@ void rfLinkTask()
 	// real puck's per-hop-cycle announce) to stay synced and keep answering polls at full rate; suppressing it
 	// drops the reply rate from ~210/s to ~38/s. Paused only during the post-disconnect cooldown so a controller
 	// that's powering off isn't immediately re-woken/reconnected.
-	if (g_rfHost && millis() - g_connCooldown > 2500) {
+	if (g_rfHost && rfConnectOpen()) {
 		bool connNow = anySlotLinkUp();
 		// session keepalive on the clean channel: every loop while connecting (fast), every 25ms once connected
 		// (every-loop beaconing also hammers the session ch and steals reply slots from the poll). The real puck
@@ -1044,7 +1072,7 @@ void rfLinkTask()
 	// connected slot being stalled, so one controller walking off (others still live) never trips it; the
 	// cooldown gate keeps it from firing while a controller is intentionally powering off; rate-limited so it
 	// cannot thrash. g_rfStallRecover is surfaced to the panel so the wedge -- and its recovery -- is observable.
-	if (g_connOn && g_curSlot >= 0 && millis() - g_connCooldown > 2500) {
+	if (g_connOn && g_curSlot >= 0 && rfConnectOpen()) {
 		static unsigned long lastRecoverMs = 0;
 		static uint8_t consecStall = 0;
 		unsigned long nowMs2 = millis();
@@ -1092,7 +1120,11 @@ void rfLinkTask()
 		bool nowRfConn = anySlotLinkUp();
 		if (nowRfConn && !wasRfConn && USBDevice.suspended()) {
 			USBDevice.remoteWakeup();
-			ledWakePulse();
+			// Wake mode reserves the LED for hotkey presses (the
+			// WAKE_MODE.md diagnostic table); the resume itself is still
+			// wanted -- a real keyboard also resumes before typing.
+			if (!modeIsWake(g_usbMode))
+				ledWakePulse();
 			// post-resume nudge (host needs real input to actually wake)
 			if (g_active)
 				g_active->wakeEvent();

--- a/OpenPuck/rf_link.h
+++ b/OpenPuck/rf_link.h
@@ -50,6 +50,11 @@ extern const uint32_t g_rxWin;
 
 // set on 0xF2 disconnect; pauses beacon+poll so a powering-off controller can sleep
 extern unsigned long g_connCooldown;
+// True once the post-boot / post-disconnect connect cooldown has passed, i.e. beacons + polls are on air.
+// Nothing can (re)link before this, so a "link quiet" observation made earlier proves nothing.
+bool rfConnectOpen();
+// Open the cooldown immediately (the post-wake-fire boot: the triggering controller is searching NOW).
+void rfConnectOpenNow();
 
 // connected-mode state (reset by the 'k' console toggle)
 extern uint8_t g_connSt, g_connStep;

--- a/OpenPuck/serial_console.cpp
+++ b/OpenPuck/serial_console.cpp
@@ -175,7 +175,7 @@ void serialConsolePoll()
 					g_lizKeep ? "ON" : "off");
 			}
 
-			// switch USB mode: 0=steam 1=xbox 2=hori 3=lizard 4=swpro 5=ps5 6=hidgyro 7=ps5-game/clean 8=ds4-game/clean 9=ps3(dualshock3)
+			// switch USB mode: 0=steam 1=xbox 2=hori 3=lizard 4=swpro 5=ps5 6=hidgyro 7=ps5-game/clean 8=ds4-game/clean 9=ps3(dualshock3) 10=wake(alt+p)
 			else if (line[0] == 'x') {
 				uint8_t m = strtoul(line + 1, 0, 10);
 				if (modeValid(m)) {

--- a/OpenPuck/webusb_config.cpp
+++ b/OpenPuck/webusb_config.cpp
@@ -78,7 +78,8 @@ static bool boardCommand(uint8_t op)
 //                [v18: p[182..185] chordDpad left/up/right/down (back4+D-pad mode assignments)]
 //                [v19: p[186] swGyroLegacy (Switch Pro gyro mapping: 0 = corrected, 1 = legacy/pre-#189)]
 //                [v20: p[187..194] per-type trackpad->stick map, 4x2B {left pad, right pad} (PS_OFF/LEFT/RIGHT)]
-#define WB_PAYLEN 193
+//                [v21: p[195] wakeMod (modifier bitmask), p[196] wakeKey (HID usage) -- MODE_WAKE hotkey]
+#define WB_PAYLEN 195
 // The blob send is drop-on-full (never blocks loop), so the vendor TX FIFO MUST be able to hold a whole blob
 // -- otherwise tud_vendor_write_available() never reaches the frame size and EVERY frame is dropped (blank
 // panel / stale mappings). The Makefile sets -DCFG_TUD_VENDOR_TX_BUFSIZE=256; guard it here so a build without
@@ -103,7 +104,8 @@ static void webusbSendBlob()
 	p[0] = 0xA5;
 	p[1] = WB_PAYLEN;
 
-	// protocol version (20 = +per-type trackpad->stick mapping (fields 80..87, blob p[187..194]);
+	// protocol version (21 = +MODE_WAKE hotkey (fields 30/31, blob p[195..196]);
+	// 20 = +per-type trackpad->stick mapping (fields 80..87, blob p[187..194]);
 	// 19 = +Switch Pro legacy-gyro select (field 38, blob p[186]); the rumble-strength,
 	// Switch report-rate and Switch gyro-scale settings (fields 22/23/24, blob p[53..55]) are GONE -- those
 	// bytes now read 0; 18 = +configurable back4+D-pad chords (fields 34..37, blob p[182..185]);
@@ -113,7 +115,7 @@ static void webusbSendBlob()
 	// unknown op; 15 = +staged firmware-update ops 0x20..0x24; 14 = +landAll87 toggle; 13 = +per-slot link
 	// stats; 12 = +relay rate + clock fingerprint; 11 = +reset cause; 10 = +ledBright per type; 9 = +per-type
 	// cfg; 8 = +per-slot link status; 7 = +raw accel; 6 = +swPro120/gyroScale)
-	p[2] = 20;
+	p[2] = 21;
 	p[3] = g_usbMode;
 	p[4] = (uint8_t)g_mDiv;
 	p[5] = (uint8_t)g_mFric;
@@ -292,6 +294,9 @@ static void webusbSendBlob()
 		p[187 + et * 2] = g_padStickCfg[et][0];
 		p[188 + et * 2] = g_padStickCfg[et][1];
 	}
+	// v21: MODE_WAKE hotkey (modifier bitmask + HID key usage, fields 30/31)
+	p[195] = g_wakeMod;
+	p[196] = g_wakeKey;
 	// CRITICAL: usb_web.write() SPINS (`while (remain && _connected) yield();`) until the IN FIFO drains or the
 	// panel disconnects. If the panel holds the WebUSB interface open but stops reading its IN endpoint -- a
 	// backgrounded tab, or the host briefly not servicing transferIn under load -- the FIFO never empties and
@@ -1033,6 +1038,18 @@ void webusbPoll()
 				// instead of the discard-whitelist. Persisted; blob p[181] reflects state.
 				case 29:
 					g_landAll87 = v ? 1 : 0;
+					break;
+
+				// MODE_WAKE hotkey (protocol v21): 30 = modifier bitmask (any value,
+				// 0 = bare key), 31 = HID key usage, validated to the defined keyboard
+				// range like loadCfg so the wake press can never type garbage.
+				case 30:
+					g_wakeMod = v;
+					break;
+				case 31:
+					if (v >= HID_KEY_A &&
+					    v <= HID_KEY_GUI_RIGHT)
+						g_wakeKey = v;
 					break;
 				}
 				if (persist)

--- a/OpenPuck/webusb_config.cpp
+++ b/OpenPuck/webusb_config.cpp
@@ -12,6 +12,7 @@
 #include "fw_update.h"
 #include "usb_tx.h"
 #include "usb_mount.h" // modeSwitchReboot()
+#include "mode_wake.h" // wakeKeyValid() (wake-hotkey field validation)
 #include <Arduino.h>
 #include <string.h>
 
@@ -1043,12 +1044,16 @@ void webusbPoll()
 				// MODE_WAKE hotkey (protocol v21): 30 = modifier bitmask (any value,
 				// 0 = bare key), 31 = HID key usage, validated to the defined keyboard
 				// range like loadCfg so the wake press can never type garbage.
+				// 30: modifier bitmask (0 = bare key; 0xFF rejected -- it is loadCfg's
+				// unset sentinel, so it would work for the session then silently revert
+				// to the default at the next boot). 31: HID key usage, same accept
+				// policy as loadCfg (shared wakeKeyValid) so the sites cannot drift.
 				case 30:
-					g_wakeMod = v;
+					if (v != 0xFF)
+						g_wakeMod = v;
 					break;
 				case 31:
-					if (v >= HID_KEY_A &&
-					    v <= HID_KEY_GUI_RIGHT)
+					if (wakeKeyValid(v))
 						g_wakeKey = v;
 					break;
 				}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Similarly you can hold all 4 back buttons and press Y to switch (teehee) over to
 | WebUSB panel → mode 5 | DualSense + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 6 | DS4/HIDGYRO + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 9 | PS3 DualShock 3 / Sixaxis | Enumerates on a real PS3 (+ gyro/haptics) |
-| WebUSB panel → mode 10 | Wake (Alt+P power-on) | Boot keyboard that powers on a smart-power-on PC (Lenovo Alt+P) when the controller connects, then returns to the normal puck (your persisted mode, or Steam) — setup guide: [docs/WAKE_MODE.md](./docs/WAKE_MODE.md) |
+| WebUSB panel → mode 10 | Keyboard wake (power-on) | Boot keyboard that powers on a smart-power-on PC (hotkey configurable from the panel; default Alt+P, Lenovo) when the controller connects, then returns to the normal puck (your persisted mode, or Steam) — setup guide: [docs/WAKE_MODE.md](./docs/WAKE_MODE.md) |
 
 I'm also adding various QOL items as I go as well. For example having to hold the Steam button for like 6 seconds feels like an eternity. If Steam is open you can do Steam + Y for a shutdown. I'm adding Steam + Y for 2 seconds as a shutdown chort in ALL modes now.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Similarly you can hold all 4 back buttons and press Y to switch (teehee) over to
 | WebUSB panel → mode 5 | DualSense + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 6 | DS4/HIDGYRO + Gyro + Trackpad | PC only |
 | WebUSB panel → mode 9 | PS3 DualShock 3 / Sixaxis | Enumerates on a real PS3 (+ gyro/haptics) |
+| WebUSB panel → mode 10 | Wake (Alt+P power-on) | Boot keyboard that powers on a smart-power-on PC (Lenovo Alt+P) when the controller connects, then returns to the normal puck (your persisted mode, or Steam) — setup guide: [docs/WAKE_MODE.md](./docs/WAKE_MODE.md) |
 
 I'm also adding various QOL items as I go as well. For example having to hold the Steam button for like 6 seconds feels like an eternity. If Steam is open you can do Steam + Y for a shutdown. I'm adding Steam + Y for 2 seconds as a shutdown chort in ALL modes now.
 

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -97,10 +97,12 @@ with the puck ever again. Two triggers, whichever comes first:
   boots — your press already was the gesture), answers the controller
   before it gives up searching, and fires. One press, machine on.
 - **The timer.** With no press, a persistent suspend (≥15 s) re-arms by
-  itself; the wake mode then arms ~8 s later through the normal quiet
-  clock (deliberately not instantly: with no press behind the re-arm,
-  nothing may fire without a fresh, human-shaped connect), and any later
-  press lands on the armed keyboard.
+  itself. When the controller has been off for 3 s+ at that point (the
+  normal case) the wake mode arms instantly — so a press *racing* the
+  timer still fires first try — and any later press lands on the armed
+  keyboard. Only if something was still linked at the re-arm does the
+  mode fall back to the ~8 s quiet-clock arming, so a controller that
+  somehow missed its power-off can never boot the machine by itself.
 
 Press *too* early (in the first ~10 s, while the puck is still deciding
 sleep-vs-shutdown) and the controller is powered back off by the normal

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -75,7 +75,7 @@ diagnostic story:
 
 | You see | It means |
 | --- | --- |
-| No pulses when the controller connects | First rule out timing: after a *manual* mode-10 switch the mode arms ~8 s after the link goes quiet (2.5 s radio bring-up + 5 s observed quiet; auto-re-arm boots arm instantly), so a power-press within ~8 s of the switch, or a second bonded controller still powered on, means it simply was not armed yet — power the controller off, wait ~10 s, try again. If timing is ruled out: the EC never enumerated/configured the keyboard — wrong port, BIOS feature off, or the machine's EC doesn't service USB in S5. |
+| No pulses when the controller connects | First rule out timing: after a *manual* mode-10 switch (or a timer-driven auto-re-arm) the mode arms ~8 s after the link goes quiet (2.5 s radio bring-up + 5 s observed quiet; press-triggered re-arm boots arm instantly), so a power-press within ~8 s of the switch, or a second bonded controller still powered on, means it simply was not armed yet — power the controller off, wait ~10 s, try again. If timing is ruled out: the EC never enumerated/configured the keyboard — wrong port, BIOS feature off, or the machine's EC doesn't service USB in S5. |
 | Pulses, machine stays off | Reports were delivered but the hotkey parser rejected them: wrong hotkey for your vendor (§6), or the EC wants different press shaping (`WAKE_*` timings in `mode_wake.h`). |
 | Pulses, machine powers on | Working as intended. |
 
@@ -93,12 +93,14 @@ with the puck ever again. Two triggers, whichever comes first:
 
 - **Your press.** From ~10 s after shutdown, powering the controller on IS
   the re-arm: the puck sees the connect against the shut-down bus, reboots
-  straight into wake mode (which arms instantly on re-arm boots — the
-  host's downtime already served as the arming quiet), answers the
-  controller before it gives up searching, and fires. One press, machine
-  on.
+  straight into wake mode (which arms instantly on these press-triggered
+  boots — your press already was the gesture), answers the controller
+  before it gives up searching, and fires. One press, machine on.
 - **The timer.** With no press, a persistent suspend (≥15 s) re-arms by
-  itself, so a later press lands on an already-armed wake keyboard.
+  itself; the wake mode then arms ~8 s later through the normal quiet
+  clock (deliberately not instantly: with no press behind the re-arm,
+  nothing may fire without a fresh, human-shaped connect), and any later
+  press lands on the armed keyboard.
 
 Press *too* early (in the first ~10 s, while the puck is still deciding
 sleep-vs-shutdown) and the controller is powered back off by the normal
@@ -117,7 +119,9 @@ handoff grace runs out (~90–105 s after the fire), so a later press still
 works. Three caveats: if your OS has wakeup *disabled* for the device
 (Linux: `power/wakeup` in sysfs), its sleep looks like a shutdown and the
 puck will re-arm mid-sleep — recover with the escape chord or a replug, or
-enable device wakeup. A host that arms remote wakeup once but never clears
+enable device wakeup. (The game/clean PS modes never advertise remote
+wakeup at all, so with auto-rearm every sleep in those modes reads as a
+shutdown the same way.) A host that arms remote wakeup once but never clears
 it (Linux clears on resume; other OSes untested) would make shutdowns look
 like sleeps — if auto-rearm silently stops re-arming on your machine, that's
 the signature. And if the *puck itself* restarts while the host is asleep
@@ -147,8 +151,8 @@ Validated end-to-end on the M90q Gen 6.
 ## 7. What happens behind the scenes (and what was hard)
 
 Full flow: arm (~5 s of observed RF-link silence, so switching modes with the
-controller still connected can't type into a live session; auto-re-arm boots
-skip this — the host's downtime already proved the point) → fire on the
+controller still connected can't type into a live session; press-triggered
+re-arm boots skip this — the press already was the gesture) → fire on the
 first controller connect → settle → reboot into the return mode with a
 persisted one-shot **handoff grace**. During the grace (up to 90 s; it ends
 early once the OS has been stably up for 20 s — a bar BIOS POST enumeration

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -28,7 +28,7 @@ fails.
 
 Any of the usual mode-switch paths, to mode **10**:
 
-- **WebUSB panel**: the *Wake (Alt+P)* mode button. Note the panel cannot
+- **WebUSB panel**: the *Keyboard wake (power-on)* mode button. Note the panel cannot
   connect while the puck **is** in wake mode (a bare keyboard has no WebUSB);
   it returns to the puck automatically after firing, or via the escape chord.
 - **CDC serial console**: `x10`.
@@ -116,12 +116,14 @@ Validated end-to-end on the M90q Gen 6.
 
 ## 6. Other vendors / tuning the press
 
-Everything the EC sees is a `#define` at the top of `mode_wake.h`:
-
-- `WAKE_MOD` / `WAKE_KEY` — the hotkey (default `LEFTALT` + `P`, Lenovo).
-  Change these for Dell/HP/etc. equivalents.
-- `WAKE_MOD_LEAD_MS`, `WAKE_HOLD_MS`, `WAKE_RESEND_MS`, `WAKE_REPEAT`,
-  `WAKE_REPEAT_MS` — press shaping. The defaults imitate a human keystroke
+- **The hotkey is runtime config**: the *Wake hotkey* row on the WebUSB
+  panel sets the modifier(s) + key the mode types (default `Alt+P`, Lenovo).
+  Change it there for Dell/HP/etc. equivalents — no rebuild needed. The
+  setting persists on the puck, and the compiled default lives in
+  `mode_wake.h` (`WAKE_MOD_DEFAULT` / `WAKE_KEY_DEFAULT`).
+- Press *shaping* stays a `#define` at the top of `mode_wake.h`:
+  `WAKE_MOD_LEAD_MS`, `WAKE_HOLD_MS`, `WAKE_RESEND_MS`, `WAKE_REPEAT`,
+  `WAKE_REPEAT_MS`. The defaults imitate a human keystroke
   (modifier first, long held chord, restated while held) because the M90q's
   EC **ignores** a minimal combined report even though it reads it; other ECs
   are likely no less picky.

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -1,0 +1,151 @@
+# Wake Mode (MODE_WAKE): powering on a shut-down PC from the controller
+
+Wake mode turns the puck into a bare USB boot keyboard that types the firmware
+"smart power on" hotkey (Lenovo: **Alt+P**) the moment your controller
+connects, powering on a **fully shut down (S5)** machine — then reboots itself
+back into the normal puck so the booted OS sees the controller as usual. USB
+remote wakeup only covers sleep (S3); this covers real power-on.
+
+**Nothing about this mode is active by default.** If you never enter mode 10,
+the puck behaves exactly as before on every machine, Lenovo or not.
+
+## 1. Requirements
+
+- A PC whose firmware can power on from a USB keyboard hotkey. Developed and
+  validated on a **Lenovo ThinkCentre M90q Gen 6** ("Smart Power On", Alt+P).
+  Other vendors have equivalents under different names and different key
+  chords — see §6.
+- The puck plugged into the machine's **designated always-on USB port** (on
+  ThinkCentres the Smart Power On port; the EC only services that port in S5).
+- BIOS setting enabled: **Setup → Power → Smart Power On → Enabled**.
+
+Sanity check before involving the puck at all: plug a real USB keyboard into
+that port, shut the machine down, press Alt+P. If the machine doesn't power
+on, fix the BIOS/port first — the puck can't succeed where a real keyboard
+fails.
+
+## 2. Entering wake mode
+
+Any of the usual mode-switch paths, to mode **10**:
+
+- **WebUSB panel**: the *Wake (Alt+P)* mode button. Note the panel cannot
+  connect while the puck **is** in wake mode (a bare keyboard has no WebUSB);
+  it returns to the puck automatically after firing, or via the escape chord.
+- **CDC serial console**: `x10`.
+- **A configurable chord**: assign mode 10 to one of the back-4 + D-pad
+  chords from the panel.
+
+Entering wake mode is always a **one-shot**: one wake, then the puck returns
+to your normal personality (the persisted mode if you use *persist last
+mode*, Steam otherwise). See §5 for making it automatic. Arming takes a few
+seconds — the mode requires ~5 s of observed controller-radio silence before
+a connect counts as a wake gesture, so switching modes with the controller
+still on can't type into your live session.
+
+## 3. Using it
+
+1. Enter wake mode (the controller can still be on — arming waits for it).
+2. Power the controller off and shut the machine down.
+3. To wake: **press the controller's power button.** The puck types the
+   hotkey, the machine powers on, and by the time the OS is up the puck is a
+   normal puck again and the controller has reconnected by itself —
+   single press, end to end.
+
+**Leaving wake mode.** The **all-four-back-paddles + A** chord on a connected
+controller reboots straight back to Steam mode, and works whether the machine
+is on or off (wake mode is exempt from the usual
+no-mode-switch-while-suspended rule in both directions — the chord is also
+how you *enter* mode 10 with the machine already off). Timing matters,
+though: the chord only escapes **without firing** while the controller that
+was connected at the mode switch stays connected (the mode never arms with a
+link up). Once armed, a *fresh* controller connect is the wake gesture and
+fires immediately — on a running machine that types the hotkey once into the
+session and bounces back to the normal puck by itself, which is the other,
+cruder way out. Note the trigger is *any* bonded controller connecting; with
+two controllers, one left powered on prevents arming until it, too, goes
+quiet.
+
+## 4. The LED tells you what happened
+
+The wake-mode LED is **dark in every steady state** and pulses ~½ s per
+hotkey press (default: 4 pulses over ~5 s). In wake mode the LED is reserved
+for presses — the connect-time remote-wakeup pulse other modes show is
+suppressed so it can't be mistaken for a fire. That makes it the whole
+diagnostic story:
+
+| You see | It means |
+| --- | --- |
+| No pulses when the controller connects | First rule out timing: the mode arms ~8 s after the link goes quiet (2.5 s radio bring-up + 5 s observed quiet), so a power-press within ~8 s of shutdown, or a second bonded controller still powered on, means it simply was not armed yet — power the controller off, wait ~10 s, try again. If timing is ruled out: the EC never enumerated/configured the keyboard — wrong port, BIOS feature off, or the machine's EC doesn't service USB in S5. |
+| Pulses, machine stays off | Reports were delivered but the hotkey parser rejected them: wrong hotkey for your vendor (§6), or the EC wants different press shaping (`WAKE_*` timings in `mode_wake.h`). |
+| Pulses, machine powers on | Working as intended. |
+
+## 5. Automatic re-arming (`WAKE_AUTO_REARM`)
+
+By default one wake requires one manual mode-10 switch. For a machine that
+always **shuts down** (S4/S5) rather than sleeping, build with:
+
+```bash
+make build EXTRA_FLAGS="-DWAKE_AUTO_REARM=1"
+```
+
+Then a persistent USB suspend (≥15 s) in any other mode reboots the puck into
+wake mode by itself: shut the machine down, and the next controller power-on
+wakes it — no interaction with the puck ever again.
+
+**Sleep vs shutdown:** the firmware tells them apart by the host's own hand —
+an OS going to sleep arms USB remote wakeup on the puck first (that's what
+makes the existing wake-from-S3 feature work), and such suspends never
+re-arm, so sleeping the machine leaves the puck a normal puck and
+controller-wake-from-sleep keeps working. A shutdown never arms remote
+wakeup, so it re-arms as intended — even though some ECs (the M90q's
+included) re-arm the feature themselves when they take the port over in S5;
+the decision is sampled from the OS's own suspend, so that doesn't confuse
+it. A wake that *fails* (machine never boots) re-arms again when the 90 s
+handoff grace runs out (~90–105 s after the fire), so a later press still
+works. Three caveats: if your OS has wakeup *disabled* for the device
+(Linux: `power/wakeup` in sysfs), its sleep looks like a shutdown and the
+puck will re-arm mid-sleep — recover with the escape chord or a replug, or
+enable device wakeup. A host that arms remote wakeup once but never clears
+it (Linux clears on resume; other OSes untested) would make shutdowns look
+like sleeps — if auto-rearm silently stops re-arming on your machine, that's
+the signature. And if the *puck itself* restarts while the host is asleep
+(replug, firmware flash, watchdog reset), a sleeping host is indistinguishable
+from an off one — the puck re-arms ~45 s later and the resumed session finds
+the wake keyboard instead of a controller; escape-chord or replug recovers.
+Validated end-to-end on the M90q Gen 6.
+
+## 6. Other vendors / tuning the press
+
+Everything the EC sees is a `#define` at the top of `mode_wake.h`:
+
+- `WAKE_MOD` / `WAKE_KEY` — the hotkey (default `LEFTALT` + `P`, Lenovo).
+  Change these for Dell/HP/etc. equivalents.
+- `WAKE_MOD_LEAD_MS`, `WAKE_HOLD_MS`, `WAKE_RESEND_MS`, `WAKE_REPEAT`,
+  `WAKE_REPEAT_MS` — press shaping. The defaults imitate a human keystroke
+  (modifier first, long held chord, restated while held) because the M90q's
+  EC **ignores** a minimal combined report even though it reads it; other ECs
+  are likely no less picky.
+- `WAKE_RETURN_MODE` — which personality to return to after firing. The
+  default (`0xFF`) means "the normal boot policy": your persisted mode if
+  *persist last mode* is on, Steam otherwise. Set a concrete mode to force
+  one.
+
+## 7. What happens behind the scenes (and what was hard)
+
+Full flow: arm (~5 s of observed RF-link silence, so switching modes with the
+controller still connected can't type into a live session) → fire on the
+first controller connect → settle → reboot into the return mode with a
+persisted one-shot **handoff grace**. During the grace (up to 90 s; it ends
+early once the OS has been stably up for 20 s — a bar BIOS POST enumeration
+never clears, so a quick shutdown after a wake behaves normally; the one
+exception is parking in BIOS setup for 20 s+ right after a wake, which also
+ends the grace early), two standing behaviors that would otherwise
+misread a POSTing machine as "host went to sleep" hold their fire: the
+suspend-triggered controller power-off, and `WAKE_AUTO_REARM` itself. If the
+machine never boots, the grace expires and the controller is powered off
+after all — the battery is still saved. The
+post-fire boot also skips the USB mount wait and starts RF beacons
+immediately, so the controller that triggered the wake reconnects in well
+under a second instead of giving up during POST. Design details and the
+hardware findings behind each decision are in `mode_wake.h` / `mode_wake.cpp`
+comments.

--- a/docs/WAKE_MODE.md
+++ b/docs/WAKE_MODE.md
@@ -75,7 +75,7 @@ diagnostic story:
 
 | You see | It means |
 | --- | --- |
-| No pulses when the controller connects | First rule out timing: the mode arms ~8 s after the link goes quiet (2.5 s radio bring-up + 5 s observed quiet), so a power-press within ~8 s of shutdown, or a second bonded controller still powered on, means it simply was not armed yet — power the controller off, wait ~10 s, try again. If timing is ruled out: the EC never enumerated/configured the keyboard — wrong port, BIOS feature off, or the machine's EC doesn't service USB in S5. |
+| No pulses when the controller connects | First rule out timing: after a *manual* mode-10 switch the mode arms ~8 s after the link goes quiet (2.5 s radio bring-up + 5 s observed quiet; auto-re-arm boots arm instantly), so a power-press within ~8 s of the switch, or a second bonded controller still powered on, means it simply was not armed yet — power the controller off, wait ~10 s, try again. If timing is ruled out: the EC never enumerated/configured the keyboard — wrong port, BIOS feature off, or the machine's EC doesn't service USB in S5. |
 | Pulses, machine stays off | Reports were delivered but the hotkey parser rejected them: wrong hotkey for your vendor (§6), or the EC wants different press shaping (`WAKE_*` timings in `mode_wake.h`). |
 | Pulses, machine powers on | Working as intended. |
 
@@ -88,9 +88,21 @@ always **shuts down** (S4/S5) rather than sleeping, build with:
 make build EXTRA_FLAGS="-DWAKE_AUTO_REARM=1"
 ```
 
-Then a persistent USB suspend (≥15 s) in any other mode reboots the puck into
-wake mode by itself: shut the machine down, and the next controller power-on
-wakes it — no interaction with the puck ever again.
+Then the puck re-arms itself every time the host shuts down — no interaction
+with the puck ever again. Two triggers, whichever comes first:
+
+- **Your press.** From ~10 s after shutdown, powering the controller on IS
+  the re-arm: the puck sees the connect against the shut-down bus, reboots
+  straight into wake mode (which arms instantly on re-arm boots — the
+  host's downtime already served as the arming quiet), answers the
+  controller before it gives up searching, and fires. One press, machine
+  on.
+- **The timer.** With no press, a persistent suspend (≥15 s) re-arms by
+  itself, so a later press lands on an already-armed wake keyboard.
+
+Press *too* early (in the first ~10 s, while the puck is still deciding
+sleep-vs-shutdown) and the controller is powered back off by the normal
+host-asleep battery saver — just press again a few seconds later.
 
 **Sleep vs shutdown:** the firmware tells them apart by the host's own hand —
 an OS going to sleep arms USB remote wakeup on the puck first (that's what
@@ -135,7 +147,8 @@ Validated end-to-end on the M90q Gen 6.
 ## 7. What happens behind the scenes (and what was hard)
 
 Full flow: arm (~5 s of observed RF-link silence, so switching modes with the
-controller still connected can't type into a live session) → fire on the
+controller still connected can't type into a live session; auto-re-arm boots
+skip this — the host's downtime already proved the point) → fire on the
 first controller connect → settle → reboot into the return mode with a
 persisted one-shot **handoff grace**. During the grace (up to 90 s; it ends
 early once the OS has been stably up for 20 s — a bar BIOS POST enumeration

--- a/docs/index.html
+++ b/docs/index.html
@@ -163,8 +163,9 @@
         <button data-mode="5" class="modebtn">PS5 DualSense</button>
         <button data-mode="6" class="modebtn">HID gyro (DS4)</button>
         <button data-mode="9" class="modebtn">PS3 (DualShock 3)</button>
+        <button data-mode="10" class="modebtn">Wake (Alt+P power-on)</button>
       </div>
-      <p class="note">Switching reboots the copycat and re-enumerates USB (~2 s). WebUSB works in every mode, including Steam/Lizard with Steam running (Chrome claims the vendor interface; Steam keeps the HID slots). Switch HORIPAD + WebUSB is PC-only.</p>
+      <p class="note">Switching reboots the copycat and re-enumerates USB (~2 s). WebUSB works in every mode, including Steam/Lizard with Steam running (Chrome claims the vendor interface; Steam keeps the HID slots). Switch HORIPAD + WebUSB is PC-only. Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): the panel cannot connect to it; it fires once when a controller connects and returns to the normal puck (chord back-4 + A on a still-connected controller to leave it before it arms).</p>
       <div class="row"><label>Persist last mode</label>
         <button id="persistMode">off</button>
         <span class="note" style="flex:1">Off (default): every restart / fresh reconnect boots into Steam mode. On: remembers the last mode you selected.</span>
@@ -388,7 +389,7 @@
 </div>
 
 <script>
-const MODE_NAMES = ["Steam (puck)","Xbox 360","Switch (HORIPAD)","Lizard (always)","Switch Pro + gyro","PS5 DualSense","HID gyro (DS4)","PS5 (game/clean)","DS4 (game/clean)","PS3 (DualShock 3)"];
+const MODE_NAMES = ["Steam (puck)","Xbox 360","Switch (HORIPAD)","Lizard (always)","Switch Pro + gyro","PS5 DualSense","HID gyro (DS4)","PS5 (game/clean)","DS4 (game/clean)","PS3 (DualShock 3)","Wake (Alt+P power-on)"];
 const CHORD_FIELD = [17, 18, 19];          // back4 + B/X/Y
 const CHORD_DPAD_FIELD = [34, 35, 36, 37]; // back4 + D-pad left/up/right/down (firmware protocol >= 18)
 const CHORD_DPAD_DEF = [9, 8, 7, 2];       // firmware defaults: PS3, DS4 game, PS5 game, Switch HORIPAD
@@ -678,7 +679,7 @@ function setTab(et){
   setTab(0);
 })();
 for(const sel of document.querySelectorAll("select.chord")){
-  MODE_NAMES.forEach((n,i)=>{ if(i===7||i===8) return;
+  MODE_NAMES.forEach((n,i)=>{ if(i===7||i===8||i===10) return;
     const o=document.createElement("option"); o.value=i; o.textContent=n; sel.appendChild(o); });
 }
 // D-pad chords offer EVERY mode, including the game/clean ones the face selects skip: those modes drop WebUSB,
@@ -2224,8 +2225,11 @@ for(const sel of document.querySelectorAll("select.chordD")){
 }
 for(const b of document.querySelectorAll(".modebtn")){
   b.onclick=()=>{ const m=+b.dataset.mode;
-    const clean=(m===7||m===8||m===9);
-    const msg="Switch to "+MODE_NAMES[m]+"? The copycat will reboot."+(clean?"\n\nNOTE: the game/clean PlayStation modes (and PS3) drop WebUSB + host-wake, so THIS PANEL WILL DISCONNECT and can't reach the device while it's in this mode. To get back, chord on the controller: hold all four back paddles (L4+R4+L5+R5) + A to return to Steam mode. The back4+D-pad chords are how you get back INTO these modes without the panel — check their assignments in the chords card first.":"");
+    const clean=(m===7||m===8||m===9||m===10);
+    const why=(m===10)
+      ? "Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): it has no WebUSB, so THIS PANEL WILL DISCONNECT. It fires once when a controller connects after the machine is shut down, then returns to the normal puck by itself. To leave it WITHOUT firing, chord all four back paddles (L4+R4+L5+R5) + A on a STILL-CONNECTED controller before it arms (~8 s); once armed, a fresh controller connect fires immediately. Setup guide: docs/WAKE_MODE.md."
+      : "the game/clean PlayStation modes (and PS3) drop WebUSB + host-wake, so THIS PANEL WILL DISCONNECT and can't reach the device while it's in this mode. To get back, chord on the controller: hold all four back paddles (L4+R4+L5+R5) + A to return to Steam mode. The back4+D-pad chords are how you get back INTO these modes without the panel — check their assignments in the chords card first.";
+    const msg="Switch to "+MODE_NAMES[m]+"? The copycat will reboot."+(clean?"\n\nNOTE: "+why:"");
     if(confirm(msg)){ send([0x03, m]); log("mode switch requested — device will reboot"); } };
 }
 updateUf2UI();

--- a/docs/index.html
+++ b/docs/index.html
@@ -173,12 +173,8 @@
       <!-- Keyboard-wake hotkey (firmware >= v21): the chord mode 10 types to power the machine on.
            Modifier checkboxes build the left-modifier bitmask (fields 30/31 -> firmware g_wakeMod/g_wakeKey). -->
       <div class="row hide" id="wakeHotkeyRow"><label>Wake hotkey</label>
-        <span id="wakeMods" style="display:flex;gap:10px;align-items:center">
-          <label style="flex:0 0 auto"><input type="checkbox" data-bit="1"> Ctrl</label>
-          <label style="flex:0 0 auto"><input type="checkbox" data-bit="2"> Shift</label>
-          <label style="flex:0 0 auto"><input type="checkbox" data-bit="4"> Alt</label>
-          <label style="flex:0 0 auto"><input type="checkbox" data-bit="8"> Win</label>
-        </span>
+        <!-- checkboxes generated from LZ_MODS (one modifier table for the whole page) -->
+        <span id="wakeMods" style="display:flex;gap:10px;align-items:center"></span>
         <select id="wakeKeySel"></select>
         <span class="note" style="flex:1">The chord Keyboard wake mode (10) types to power the machine on. Default Alt+P (Lenovo Smart Power On); other vendors use different chords — check your firmware's wake-on-keyboard docs.</span>
       </div>
@@ -1127,7 +1123,16 @@ function applyBlob(p){
   $("#wakeHotkeyRow").classList.toggle("hide", !wakeCap);
   if(wakeCap){
     const wk=$("#wakeKeySel");
-    if(document.activeElement!==wk) wk.value=p[194];
+    // The firmware accepts any defined keyboard usage; the curated list is narrower. An out-of-list
+    // stored key gets its own hex option instead of silently blanking the select (a blank select
+    // reads as +""=0 on the next send).
+    if(document.activeElement!==wk){
+      if(![...wk.options].some(o=>+o.value===p[194])){
+        const o=document.createElement("option"); o.value=p[194];
+        o.textContent="0x"+p[194].toString(16).padStart(2,"0"); wk.appendChild(o);
+      }
+      wk.value=p[194];
+    }
     let modFocus=false;
     for(const c of document.querySelectorAll("#wakeMods input")) if(document.activeElement===c) modFocus=true;
     if(!modFocus) for(const c of document.querySelectorAll("#wakeMods input")) c.checked=!!(p[193] & +c.dataset.bit);
@@ -2249,20 +2254,23 @@ for(const sel of document.querySelectorAll("select.chord")){
 for(const sel of document.querySelectorAll("select.chordD")){
   sel.addEventListener("change", ()=>setField(CHORD_DPAD_FIELD[+sel.dataset.i], +sel.value));
 }
-// Keyboard-wake hotkey (firmware >= v21). Key options cover the usages BIOS wake hotkeys use (letters,
-// digits, F-keys + a few basics); values are HID keyboard usages, sent verbatim as field 31. The
-// modifier checkboxes OR into the left-modifier bitmask (field 30; 0 = a bare key, which is legal).
-{ const sel=document.getElementById("wakeKeySel");
-  const add=(lbl,v)=>{ const o=document.createElement("option"); o.value=v; o.textContent=lbl; sel.appendChild(o); };
-  for(let i=0;i<26;i++) add(String.fromCharCode(65+i), 0x04+i);          // A..Z
-  for(let i=0;i<9;i++) add(String(i+1), 0x1E+i); add("0", 0x27);         // 1..9, 0
-  for(let i=0;i<12;i++) add("F"+(i+1), 0x3A+i);                          // F1..F12
-  add("Enter",0x28); add("Esc",0x29); add("Space",0x2C);
-  const sendHotkey=()=>{ let m=0;
-    for(const c of document.querySelectorAll("#wakeMods input")) if(c.checked) m|=+c.dataset.bit;
-    setField(30, m).then(()=>setField(31, +sel.value)); };
-  sel.addEventListener("change", sendHotkey);
-  for(const c of document.querySelectorAll("#wakeMods input")) c.addEventListener("change", sendHotkey);
+// Keyboard-wake hotkey (firmware >= v21). Built from the same LZ_KEYS/LZ_MODS tables as the lizard
+// binding editor -- ONE HID usage table for the whole page, so a key/label added there reaches this
+// selector too. Value 0 ("none") is filtered: the firmware rejects key 0, a wake chord always has a
+// key. Each control sends ONLY its own field (30 = modifier bitmask, 31 = key): the fields are
+// independent on the firmware side, and every field write costs a full cfg.bin flash rewrite.
+{ const sel=document.getElementById("wakeKeySel"), mods=document.getElementById("wakeMods");
+  for(const [v,lbl] of LZ_KEYS){ if(!v) continue;
+    const o=document.createElement("option"); o.value=v; o.textContent=lbl; sel.appendChild(o); }
+  for(const [bit,lbl] of LZ_MODS){
+    const l=document.createElement("label"); l.style.flex="0 0 auto";
+    const c=document.createElement("input"); c.type="checkbox"; c.dataset.bit=bit;
+    l.appendChild(c); l.appendChild(document.createTextNode(" "+lbl)); mods.appendChild(l); }
+  sel.addEventListener("change", ()=>{ const v=+sel.value; if(v) setField(31, v); });
+  for(const c of mods.querySelectorAll("input"))
+    c.addEventListener("change", ()=>{ let m=0;
+      for(const b of mods.querySelectorAll("input")) if(b.checked) m|=+b.dataset.bit;
+      setField(30, m); });
 }
 for(const b of document.querySelectorAll(".modebtn")){
   b.onclick=()=>{ const m=+b.dataset.mode;

--- a/docs/index.html
+++ b/docs/index.html
@@ -163,12 +163,24 @@
         <button data-mode="5" class="modebtn">PS5 DualSense</button>
         <button data-mode="6" class="modebtn">HID gyro (DS4)</button>
         <button data-mode="9" class="modebtn">PS3 (DualShock 3)</button>
-        <button data-mode="10" class="modebtn">Wake (Alt+P power-on)</button>
+        <button data-mode="10" class="modebtn">Keyboard wake (power-on)</button>
       </div>
-      <p class="note">Switching reboots the copycat and re-enumerates USB (~2 s). WebUSB works in every mode, including Steam/Lizard with Steam running (Chrome claims the vendor interface; Steam keeps the HID slots). Switch HORIPAD + WebUSB is PC-only. Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): the panel cannot connect to it; it fires once when a controller connects and returns to the normal puck (chord back-4 + A on a still-connected controller to leave it before it arms).</p>
+      <p class="note">Switching reboots the copycat and re-enumerates USB (~2 s). WebUSB works in every mode, including Steam/Lizard with Steam running (Chrome claims the vendor interface; Steam keeps the HID slots). Switch HORIPAD + WebUSB is PC-only. Keyboard wake mode is a bare keyboard for firmware smart power on (hotkey configurable below; default Alt+P, Lenovo): the panel cannot connect to it; it fires once when a controller connects and returns to the normal puck (chord back-4 + A on a still-connected controller to leave it before it arms).</p>
       <div class="row"><label>Persist last mode</label>
         <button id="persistMode">off</button>
         <span class="note" style="flex:1">Off (default): every restart / fresh reconnect boots into Steam mode. On: remembers the last mode you selected.</span>
+      </div>
+      <!-- Keyboard-wake hotkey (firmware >= v21): the chord mode 10 types to power the machine on.
+           Modifier checkboxes build the left-modifier bitmask (fields 30/31 -> firmware g_wakeMod/g_wakeKey). -->
+      <div class="row hide" id="wakeHotkeyRow"><label>Wake hotkey</label>
+        <span id="wakeMods" style="display:flex;gap:10px;align-items:center">
+          <label style="flex:0 0 auto"><input type="checkbox" data-bit="1"> Ctrl</label>
+          <label style="flex:0 0 auto"><input type="checkbox" data-bit="2"> Shift</label>
+          <label style="flex:0 0 auto"><input type="checkbox" data-bit="4"> Alt</label>
+          <label style="flex:0 0 auto"><input type="checkbox" data-bit="8"> Win</label>
+        </span>
+        <select id="wakeKeySel"></select>
+        <span class="note" style="flex:1">The chord Keyboard wake mode (10) types to power the machine on. Default Alt+P (Lenovo Smart Power On); other vendors use different chords — check your firmware's wake-on-keyboard docs.</span>
       </div>
     </div>
 
@@ -389,7 +401,7 @@
 </div>
 
 <script>
-const MODE_NAMES = ["Steam (puck)","Xbox 360","Switch (HORIPAD)","Lizard (always)","Switch Pro + gyro","PS5 DualSense","HID gyro (DS4)","PS5 (game/clean)","DS4 (game/clean)","PS3 (DualShock 3)","Wake (Alt+P power-on)"];
+const MODE_NAMES = ["Steam (puck)","Xbox 360","Switch (HORIPAD)","Lizard (always)","Switch Pro + gyro","PS5 DualSense","HID gyro (DS4)","PS5 (game/clean)","DS4 (game/clean)","PS3 (DualShock 3)","Keyboard wake (power-on)"];
 const CHORD_FIELD = [17, 18, 19];          // back4 + B/X/Y
 const CHORD_DPAD_FIELD = [34, 35, 36, 37]; // back4 + D-pad left/up/right/down (firmware protocol >= 18)
 const CHORD_DPAD_DEF = [9, 8, 7, 2];       // firmware defaults: PS3, DS4 game, PS5 game, Switch HORIPAD
@@ -1110,6 +1122,16 @@ function applyBlob(p){
   $("#dpadChords").classList.toggle("hide", !dpadCap);
   $("#dpadOld").classList.toggle("hide", dpadCap);
   if(dpadCap) for(const sel of document.querySelectorAll("select.chordD")){ if(document.activeElement!==sel) sel.value=chordD[+sel.dataset.i]; }
+  // Keyboard-wake hotkey (firmware p[195..196] = payload p[193..194], v21+); hidden on older firmware.
+  const wakeCap=(p[0]>=21 && p.length>194);
+  $("#wakeHotkeyRow").classList.toggle("hide", !wakeCap);
+  if(wakeCap){
+    const wk=$("#wakeKeySel");
+    if(document.activeElement!==wk) wk.value=p[194];
+    let modFocus=false;
+    for(const c of document.querySelectorAll("#wakeMods input")) if(document.activeElement===c) modFocus=true;
+    if(!modFocus) for(const c of document.querySelectorAll("#wakeMods input")) c.checked=!!(p[193] & +c.dataset.bit);
+  }
 }
 function fmtSlider(id,v){ return id==="hapBlockS" ? v+" s" : ""+v; }
 function setSlider(id,v){ const el=$("#"+id); if(document.activeElement!==el){ el.value=v; } $("#"+id+"V").textContent=fmtSlider(id,el.value); }
@@ -1212,6 +1234,7 @@ function buildBackup(p, bp){
   // those settings existed carry rumble/swProRate/swGyro10 keys instead — now-removed settings, ignored.)
   if(p[0]>=18 && p.length>183) cfg.chordD=[p[180],p[181],p[182],p[183]];
   if(p[0]>=19 && p.length>184) cfg.swGyroLegacy=p[184];
+  if(p[0]>=21 && p.length>194){ cfg.wakeMod=p[193]; cfg.wakeKey=p[194]; }
   // version 2: include the lizard map so it survives a backup/restore cycle.
   // Guard on !lizardBusy to avoid a race with the one-shot lazy load (lizardExchange sets
   // lizardBusy while the initial 0x11 fetch is in flight); if the load is still pending the
@@ -1263,7 +1286,7 @@ async function importBackup(file){
   // slots, and the final commit.
   const typeN=Array.isArray(c.types)?Math.min(c.types.length,4):0;
   const lizardN=(Array.isArray(c.lizardMap) && lizardCapable())?Math.min(c.lizardMap.length,LZ_MAX):0;
-  const baseN=6 + (Array.isArray(c.chordD)?4:0) + (c.swGyroLegacy!==undefined?1:0);
+  const baseN=6 + (Array.isArray(c.chordD)?4:0) + (c.swGyroLegacy!==undefined?1:0) + (c.wakeMod!==undefined?1:0) + (c.wakeKey!==undefined?1:0);
   const padStickN=Array.isArray(c.types)?c.types.slice(0,typeN).filter(t=>Array.isArray(t.padStick)).length*2:0;
   const total=baseN + typeN*9 + padStickN + lizardN + 4 + 1;
   let step=0, stage="";
@@ -1294,6 +1317,9 @@ async function importBackup(file){
     // Switch Pro gyro mapping (v19+ backups only). Backups also carry rumble/swProRate/swGyro10 from the
     // removed settings; those fields no longer exist on the puck, so they are not replayed.
     if(c.swGyroLegacy!==undefined) await sf(38, c.swGyroLegacy?1:0);
+    // Keyboard-wake hotkey (v21+ backups; absent fields are skipped, keeping the puck's default)
+    if(c.wakeMod!==undefined) await sf(30, c.wakeMod);
+    if(c.wakeKey!==undefined) await sf(31, c.wakeKey);
     // c.types is absent in some very old backups created before per-type paddle/haptic config
     // was added to the panel export; guard so a missing field never crashes the import mid-flight.
     if(typeN){
@@ -2223,11 +2249,26 @@ for(const sel of document.querySelectorAll("select.chord")){
 for(const sel of document.querySelectorAll("select.chordD")){
   sel.addEventListener("change", ()=>setField(CHORD_DPAD_FIELD[+sel.dataset.i], +sel.value));
 }
+// Keyboard-wake hotkey (firmware >= v21). Key options cover the usages BIOS wake hotkeys use (letters,
+// digits, F-keys + a few basics); values are HID keyboard usages, sent verbatim as field 31. The
+// modifier checkboxes OR into the left-modifier bitmask (field 30; 0 = a bare key, which is legal).
+{ const sel=document.getElementById("wakeKeySel");
+  const add=(lbl,v)=>{ const o=document.createElement("option"); o.value=v; o.textContent=lbl; sel.appendChild(o); };
+  for(let i=0;i<26;i++) add(String.fromCharCode(65+i), 0x04+i);          // A..Z
+  for(let i=0;i<9;i++) add(String(i+1), 0x1E+i); add("0", 0x27);         // 1..9, 0
+  for(let i=0;i<12;i++) add("F"+(i+1), 0x3A+i);                          // F1..F12
+  add("Enter",0x28); add("Esc",0x29); add("Space",0x2C);
+  const sendHotkey=()=>{ let m=0;
+    for(const c of document.querySelectorAll("#wakeMods input")) if(c.checked) m|=+c.dataset.bit;
+    setField(30, m).then(()=>setField(31, +sel.value)); };
+  sel.addEventListener("change", sendHotkey);
+  for(const c of document.querySelectorAll("#wakeMods input")) c.addEventListener("change", sendHotkey);
+}
 for(const b of document.querySelectorAll(".modebtn")){
   b.onclick=()=>{ const m=+b.dataset.mode;
     const clean=(m===7||m===8||m===9||m===10);
     const why=(m===10)
-      ? "Wake mode is a bare keyboard for firmware smart power on (Lenovo Alt+P): it has no WebUSB, so THIS PANEL WILL DISCONNECT. It fires once when a controller connects after the machine is shut down, then returns to the normal puck by itself. To leave it WITHOUT firing, chord all four back paddles (L4+R4+L5+R5) + A on a STILL-CONNECTED controller before it arms (~8 s); once armed, a fresh controller connect fires immediately. Setup guide: docs/WAKE_MODE.md."
+      ? "Keyboard wake mode is a bare keyboard for firmware smart power on (hotkey set in the panel; default Alt+P, Lenovo): it has no WebUSB, so THIS PANEL WILL DISCONNECT. It fires once when a controller connects after the machine is shut down, then returns to the normal puck by itself. To leave it WITHOUT firing, chord all four back paddles (L4+R4+L5+R5) + A on a STILL-CONNECTED controller before it arms (~8 s); once armed, a fresh controller connect fires immediately. Setup guide: docs/WAKE_MODE.md."
       : "the game/clean PlayStation modes (and PS3) drop WebUSB + host-wake, so THIS PANEL WILL DISCONNECT and can't reach the device while it's in this mode. To get back, chord on the controller: hold all four back paddles (L4+R4+L5+R5) + A to return to Steam mode. The back4+D-pad chords are how you get back INTO these modes without the panel — check their assignments in the chords card first.";
     const msg="Switch to "+MODE_NAMES[m]+"? The copycat will reboot."+(clean?"\n\nNOTE: "+why:"");
     if(confirm(msg)){ send([0x03, m]); log("mode switch requested — device will reboot"); } };


### PR DESCRIPTION
## Summary
Adds **MODE_WAKE** (mode 10): a bare boot-protocol keyboard personality that powers on a **fully shut-down (S5)** host through firmware "smart power on" (Lenovo: Alt+P from the always-on USB port). Arm it, shut down, and the next controller power-button press types the hotkey and boots the machine — by the time the OS is up, the puck is a normal puck again and the controller has reconnected by itself. **One press, end to end.** USB remote wakeup only covers S3 sleep; this covers real power-on.

**Nothing changes for anyone who doesn't use it**: mode 10 is only entered explicitly (panel / console `x10` / assignable chord), `WAKE_AUTO_REARM` is compile-time off, the new suspend-policy logic is inert outside the wake flow, and the cfg layout is byte-identical (a dead reserved byte is repurposed; old `cfg.bin` files load unchanged).

**User guide:** [docs/WAKE_MODE.md](https://github.com/Saffsanity/openpuck/blob/mode-wake-v2/docs/WAKE_MODE.md) — BIOS setup, the designated port, LED diagnostics, auto-rearm trade-offs, adapting the hotkey to other vendors.

## How it works
- **Why a separate personality:** the S5 embedded controller runs a minimal USB host stack written against real keyboards, so it sees exactly one boot-protocol keyboard — no wake mouse, WebUSB, or CDC (reuses the clean-PS `bareHid` gating). Also endpoint budget: the puck composite already uses 6 of 7 IN endpoints.
- **Arming** requires ~5 s of *observed* RF-link silence (the quiet clock runs only while the radio is on air), so switching modes with a controller still connected can never type into the live session. The **wake gesture** is the connect up-edge, latched 2 s until the EC's keyboard is ready.
- **The press is shaped like a human keystroke** — modifier alone first, a long held chord restated while held, repeated — because the tested EC reads but *ignores* a minimal combined report. All timings are `#define`s (`mode_wake.h`), as is the hotkey for other vendors.
- **Post-fire handoff grace** (persisted one-shot in `Cfg.wakeHandoff` — flash, because this board class's bootloader wipes `.noinit` RAM on reset): during POST the bus looks suspended or dead, and without the grace the standing suspend power-off kills the controller that just triggered the wake, while `WAKE_AUTO_REARM` would swap the puck for a keyboard mid-boot. The return boot also skips the USB mount wait and opens the RF connect cooldown, so the triggering controller relinks in **under 0.5 s** (measured 0.424 s) instead of giving up during POST.
- **`WAKE_AUTO_REARM` (opt-in) is sleep-aware:** an OS entering S3 arms `DEVICE_REMOTE_WAKEUP` before suspending (the existing wake-from-S3 path depends on it); a shutdown never does. The decision is sampled once per down-episode *from a mounted host*, because the tested EC re-arms the feature itself during its S5 port takeover. Both observed takeover styles are handled — suspend-style (connection kept) and bus-reset-style (TinyUSB's `suspended()` can never read true again; a dead-bus clock measured from bus loss covers it).
- **Controller power-off** works across both takeover styles (suspend-edge path + was-mounted-then-bus-dead path), with per-slot linked-at-send retry masks for the no-ACK off relay: each slot's own link drop is its delivery receipt, and a controller that connects *after* a send — the wake gesture, or one the user just re-powered — can never be targeted by a retry.

## Validation
Hardware-validated end-to-end on a **Lenovo ThinkCentre M90q Gen 6 (SteamOS)**, including the `WAKE_AUTO_REARM=1` build, across a dozen power cycles: S5 wake (single press, controller self-reconnects), S3 sleep (puck stays a puck; controller wake-from-sleep keeps working), controller auto-power-off at shutdown, arming-race negative test, and the escape chord. Not yet exercised on a Windows host. Five multi-agent adversarial review rounds were run during development with a converging finding count; every confirmed finding is fixed in this diff. Full development history, hardware captures, and review records: #234.

- [x] clang-format-18 clean; trailing-comment lint adds zero new violations (a handful pre-exist upstream in touched files)
- [x] Both `WAKE_AUTO_REARM` variants compile clean (arduino-cli, adafruit:nrf52 1.7.0)
- [ ] CI has not run yet (first-time contributor) — maintainer: the Format/Build workflow runs need approval

## Open question for maintainer
Identity is `28DE:574B` — Valve VID with an invented PID, following the ReversePuck `28DE:1302` precedent. Happy to change (pid.codes would be the principled alternative if you'd rather avoid another invented Valve PID).
