### PR TITLE
RGB mode LED display for XIAO nrf52840

### DIFF
--- a/OpenPuck/OpenPuck.ino
+++ b/OpenPuck/OpenPuck.ino
@@ -165,6 +165,9 @@ void setup()
 	g_xbox = !modeIsPuck(g_usbMode);
 	g_active = controllerFor(g_usbMode);
 
+	// mode is final -- light the board RGB mode color (no-op without RGB)
+	ledShowMode();
+
 	// ---- USB descriptor rebuild ----
 	// Puck mode drops the CDC serial console (clearConfiguration) to free a USB endpoint for the wake-mouse
 	// interface that wakes a sleeping Windows host. The one-shot debug arm (g_debugCdcThisBoot, set via WebUSB

--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -51,6 +51,9 @@ uint8_t g_padHaptics = 1;
 uint8_t g_rumble = 1;
 uint8_t g_ledBright = 0;
 
+// board RGB mode-color LED enable (status_led.cpp); default on
+uint8_t g_modeLed = 1;
+
 void applyActiveType()
 {
 	g_etype = etypeForMode(g_usbMode);
@@ -103,6 +106,8 @@ struct Cfg {
 	uint8_t chordDpad[4];
 	// per-type trackpad->stick mapping: [et][0] = left pad, [et][1] = right pad (PS_*)
 	uint8_t padStick[ET_COUNT][2];
+	// modeLed: the board RGB mode-color LED enable (status_led.h g_modeLed).
+	uint8_t modeLed;
 }; // rsvd0 = ex-padSmooth, now the one-shot debug-CDC arm
 
 // Shortest cfg.bin we still accept: the layout as of CFG_MAGIC 0xCF, i.e. everything before the appended tail.
@@ -128,7 +133,8 @@ void saveCfg()
 		  {},
 		  { g_chordDpad[0], g_chordDpad[1], g_chordDpad[2],
 		    g_chordDpad[3] },
-		  {} };
+		  {},
+		  g_modeLed };
 	for (int i = 0; i < ET_COUNT; i++) {
 		c.type[i] = g_type[i];
 		c.padStick[i][0] = g_padStickCfg[i][0];
@@ -199,6 +205,10 @@ void loadCfg()
 					if (c.padStick[i][k] <= PS_MAX)
 						g_padStickCfg[i][k] =
 							c.padStick[i][k];
+			// Board RGB mode-color LED: 0xFF (a file predating this tail field) or anything
+			// other than 0/1 keeps the compiled default (on).
+			if (c.modeLed <= 1)
+				g_modeLed = c.modeLed;
 			// grow a short file to the current layout on the next save
 			if (got < (int)sizeof c)
 				consume = true;

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -165,6 +165,9 @@ extern uint8_t g_rumble;
 extern uint8_t g_ledBright;
 // Live mirror of g_padStickCfg[g_etype]: {left pad, right pad} -> stick (PS_*).
 extern uint8_t g_padStick[2];
+// Board RGB mode-color LED (XIAO etc.): 1 = steady color for the current USB
+// mode, 0 = dark. No effect on boards without an RGB LED (see status_led.h).
+extern uint8_t g_modeLed;
 
 // Copy g_type[g_etype] into the live mirrors above (safe defaults when g_etype == ET_NONE).
 void applyActiveType();

--- a/OpenPuck/status_led.cpp
+++ b/OpenPuck/status_led.cpp
@@ -1,5 +1,6 @@
 #include "status_led.h"
 #include <Arduino.h>
+#include "config.h"
 
 #if defined(OPK_BOARD_MDBT50Q_CX_40)
 #include <nrf_gpio.h>
@@ -15,6 +16,88 @@
 
 static unsigned long g_pulseMs = 0;
 static bool g_lit = false;
+
+#if OPK_RGB_LED
+
+#define RGB_LED_OFF ((RGB_LED_ON) == HIGH ? LOW : HIGH)
+
+// channel masks (bit0 = R, bit1 = G, bit2 = B)
+#define RGB_DARK 0
+#define RGB_RED 1
+#define RGB_GREEN 2
+#define RGB_BLUE 4
+#define RGB_WHITE 7
+
+static uint8_t modeColor(uint8_t mode)
+{
+	if (modeIsPuck(mode))
+		return RGB_WHITE;
+	switch (mode) {
+	case MODE_XBOX:
+		return RGB_GREEN;
+	case MODE_SW_HORI:
+	case MODE_SW_PRO:
+		return RGB_RED;
+	case MODE_PS5:
+	case MODE_HIDGYRO:
+	case MODE_PS5_GAME:
+	case MODE_DS4_GAME:
+	case MODE_PS3:
+		return RGB_BLUE;
+	}
+	return RGB_DARK;
+}
+
+static uint8_t steadyColor()
+{
+	return g_modeLed ? modeColor(g_usbMode) : RGB_DARK;
+}
+
+static void rgbWrite(uint8_t mask)
+{
+	digitalWrite(RGB_LED_PIN_R,
+		     (mask & RGB_RED) ? RGB_LED_ON : RGB_LED_OFF);
+	digitalWrite(RGB_LED_PIN_G,
+		     (mask & RGB_GREEN) ? RGB_LED_ON : RGB_LED_OFF);
+	digitalWrite(RGB_LED_PIN_B,
+		     (mask & RGB_BLUE) ? RGB_LED_ON : RGB_LED_OFF);
+}
+
+void ledInit()
+{
+	pinMode(RGB_LED_PIN_R, OUTPUT);
+	pinMode(RGB_LED_PIN_G, OUTPUT);
+	pinMode(RGB_LED_PIN_B, OUTPUT);
+
+	// dark until the boot mode is loaded; setup() calls ledShowMode() then
+	rgbWrite(RGB_DARK);
+}
+
+void ledShowMode()
+{
+	if (!g_lit)
+		rgbWrite(steadyColor());
+}
+
+void ledWakePulse()
+{
+	g_pulseMs = millis();
+	g_lit = true;
+
+	// flash white over the steady color; when the steady color IS white
+	// (Steam/Lizard) flash dark instead so the pulse stays visible
+	rgbWrite(steadyColor() == RGB_WHITE ? RGB_DARK : RGB_WHITE);
+}
+
+void ledTask()
+{
+	if (g_lit && millis() - g_pulseMs >= PULSE_MS) {
+		g_lit = false;
+		rgbWrite(steadyColor());
+	}
+}
+
+#else // !OPK_RGB_LED -- plain single wake LED on two candidate pins
 
 static void ledWrite(int level)
 {
@@ -37,6 +120,10 @@ void ledInit()
 	ledWrite(WAKE_LED_OFF);
 }
 
+void ledShowMode()
+{
+}
+
 void ledWakePulse()
 {
 	g_pulseMs = millis();
@@ -53,3 +140,5 @@ void ledTask()
 		ledWrite(WAKE_LED_OFF);
 	}
 }
+
+#endif

--- a/OpenPuck/status_led.h
+++ b/OpenPuck/status_led.h
@@ -1,15 +1,26 @@
-// status_led.h -- LED indication of wake activity.
+// status_led.h -- LED indication of wake activity and, on RGB boards, the
+// current USB mode.
 //
-// The LED is DARK in all steady states -- including while wake is armed (host suspended) -- and flashes for
-// half a second when a wake is actually sent (USBDevice.remoteWakeup()). It's a wake debugger: flash + PC
-// stays asleep = resume signal was sent and the HOST ignored it (fix host-side: powercfg /deviceenablewake);
-// no flash = firmware never fired (didn't see the gesture, or didn't consider the bus suspended).
+// Plain (single-LED) boards: the LED is DARK in all steady states -- including while wake is armed (host
+// suspended) -- and flashes for half a second when a wake is actually sent (USBDevice.remoteWakeup()). It's a
+// wake debugger: flash + PC stays asleep = resume signal was sent and the HOST ignored it (fix host-side:
+// powercfg /deviceenablewake); no flash = firmware never fired (didn't see the gesture, or didn't consider
+// the bus suspended).
+//
+// RGB boards (XIAO nRF52840 and anything else whose variant defines LED_RED/LED_GREEN/LED_BLUE): the LED
+// additionally shows a steady color for the current USB mode -- white = Steam/Lizard, green = Xbox,
+// red = Switch, blue = PlayStation -- toggleable from the WebUSB panel (g_modeLed; off = the dark steady
+// state above). The wake pulse rides the same channels: 500 ms white, or dark when the steady color is
+// already white.
 //
 // Board note: built with the Feather nRF52840 variant, but the usual hardware is a SuperMini "Pro Micro"
 // clone. The Feather's user LED is P1.15 (D3, active high); the SuperMini's blue user LED is P0.15 (= D24 in
 // the Feather pin map -- SPI MISO, unused here). We drive BOTH pins so the indicator works on either board.
 // Override the pins/polarity below if your board differs.
 #pragma once
+
+// the RGB gate below keys off the variant's LED_* pin macros
+#include <Arduino.h>
 
 #ifndef WAKE_LED_PIN_A
 
@@ -25,8 +36,41 @@
 #define WAKE_LED_ON HIGH // set LOW if your board's LED is wired active-low
 #endif
 
+// RGB mode-color support. Auto-enabled when the board variant defines all three channel pins (the Seeed XIAO
+// variant does; the Adafruit Feather variant lacks LED_GREEN, so Feather/SuperMini builds keep the plain
+// wake LED). Force with -DOPK_RGB_LED=0/1.
+#ifndef OPK_RGB_LED
+#if defined(LED_RED) && defined(LED_GREEN) && defined(LED_BLUE)
+#define OPK_RGB_LED 1
+#else
+#define OPK_RGB_LED 0
+#endif
+#endif
+
+#if OPK_RGB_LED
+#ifndef RGB_LED_PIN_R
+#define RGB_LED_PIN_R LED_RED
+#endif
+#ifndef RGB_LED_PIN_G
+#define RGB_LED_PIN_G LED_GREEN
+#endif
+#ifndef RGB_LED_PIN_B
+#define RGB_LED_PIN_B LED_BLUE
+#endif
+#ifndef RGB_LED_ON
+
+// The XIAO's RGB LED is common-anode: a channel lights when its pin is driven
+// LOW (the Seeed variant's LED_STATE_ON=1 is wrong for this hardware).
+#define RGB_LED_ON LOW
+#endif
+#endif
+
 void ledInit(); // call once from setup(): pins to output, LED off
 
 // call at each USBDevice.remoteWakeup() site: LED on now, off after 500ms
 void ledWakePulse();
 void ledTask(); // call every loop(): times out the pulse
+
+// apply the steady mode color (dark when g_modeLed=0); no-op without RGB.
+// Call after the boot mode is final and whenever g_modeLed changes.
+void ledShowMode();

--- a/OpenPuck/webusb_config.cpp
+++ b/OpenPuck/webusb_config.cpp
@@ -12,6 +12,7 @@
 #include "fw_update.h"
 #include "usb_tx.h"
 #include "usb_mount.h" // modeSwitchReboot()
+#include "status_led.h" // ledShowMode() on the mode-LED toggle
 #include <Arduino.h>
 #include <string.h>
 
@@ -78,7 +79,8 @@ static bool boardCommand(uint8_t op)
 //                [v18: p[182..185] chordDpad left/up/right/down (back4+D-pad mode assignments)]
 //                [v19: p[186] swGyroLegacy (Switch Pro gyro mapping: 0 = corrected, 1 = legacy/pre-#189)]
 //                [v20: p[187..194] per-type trackpad->stick map, 4x2B {left pad, right pad} (PS_OFF/LEFT/RIGHT)]
-#define WB_PAYLEN 193
+//                [v21: p[195] modeLed (board RGB mode-color LED enable)]
+#define WB_PAYLEN 194
 // The blob send is drop-on-full (never blocks loop), so the vendor TX FIFO MUST be able to hold a whole blob
 // -- otherwise tud_vendor_write_available() never reaches the frame size and EVERY frame is dropped (blank
 // panel / stale mappings). The Makefile sets -DCFG_TUD_VENDOR_TX_BUFSIZE=256; guard it here so a build without
@@ -103,7 +105,8 @@ static void webusbSendBlob()
 	p[0] = 0xA5;
 	p[1] = WB_PAYLEN;
 
-	// protocol version (20 = +per-type trackpad->stick mapping (fields 80..87, blob p[187..194]);
+	// protocol version (21 = +board mode-LED toggle (field 30, blob p[195]);
+	// 20 = +per-type trackpad->stick mapping (fields 80..87, blob p[187..194]);
 	// 19 = +Switch Pro legacy-gyro select (field 38, blob p[186]); the rumble-strength,
 	// Switch report-rate and Switch gyro-scale settings (fields 22/23/24, blob p[53..55]) are GONE -- those
 	// bytes now read 0; 18 = +configurable back4+D-pad chords (fields 34..37, blob p[182..185]);
@@ -113,7 +116,7 @@ static void webusbSendBlob()
 	// unknown op; 15 = +staged firmware-update ops 0x20..0x24; 14 = +landAll87 toggle; 13 = +per-slot link
 	// stats; 12 = +relay rate + clock fingerprint; 11 = +reset cause; 10 = +ledBright per type; 9 = +per-type
 	// cfg; 8 = +per-slot link status; 7 = +raw accel; 6 = +swPro120/gyroScale)
-	p[2] = 20;
+	p[2] = 21;
 	p[3] = g_usbMode;
 	p[4] = (uint8_t)g_mDiv;
 	p[5] = (uint8_t)g_mFric;
@@ -292,6 +295,8 @@ static void webusbSendBlob()
 		p[187 + et * 2] = g_padStickCfg[et][0];
 		p[188 + et * 2] = g_padStickCfg[et][1];
 	}
+	// v21: board RGB mode-color LED enable (panel reflects + toggles it)
+	p[195] = g_modeLed;
 	// CRITICAL: usb_web.write() SPINS (`while (remain && _connected) yield();`) until the IN FIFO drains or the
 	// panel disconnects. If the panel holds the WebUSB interface open but stops reading its IN endpoint -- a
 	// backgrounded tab, or the host briefly not servicing transferIn under load -- the FIFO never empties and
@@ -1033,6 +1038,13 @@ void webusbPoll()
 				// instead of the discard-whitelist. Persisted; blob p[181] reflects state.
 				case 29:
 					g_landAll87 = v ? 1 : 0;
+					break;
+
+				// board RGB mode-color LED: steady color per USB mode (no-op on
+				// boards without an RGB LED). Persisted; blob p[195] reflects state.
+				case 30:
+					g_modeLed = v ? 1 : 0;
+					ledShowMode();
 					break;
 				}
 				if (persist)

--- a/docs/index.html
+++ b/docs/index.html
@@ -169,6 +169,10 @@
         <button id="persistMode">off</button>
         <span class="note" style="flex:1">Off (default): every restart / fresh reconnect boots into Steam mode. On: remembers the last mode you selected.</span>
       </div>
+      <div class="row"><label>Mode color LED</label>
+        <button id="modeLed">on</button>
+        <span class="note" style="flex:1">On boards with an RGB user LED (e.g. XIAO nRF52840) the LED shows a steady color for the current mode: white = Steam/Lizard, green = Xbox, red = Switch, blue = PlayStation. No effect on boards without one (Pro Micro / Feather).</span>
+      </div>
     </div>
 
     <div class="card">
@@ -1072,6 +1076,8 @@ function applyBlob(p){
   $("#persistMode").textContent = persistMode? "on":"off"; $("#persistMode").classList.toggle("active",!!persistMode);
   // land-all-0x87 experiment toggle (blob v14/v17, firmware p[181] -> JS p[179])
   { const la=(p.length>179?p[179]:0); $("#landAll87").textContent = la?"on":"off"; $("#landAll87").classList.toggle("active",!!la); }
+  // board RGB mode-color LED toggle (blob v21, firmware p[195] -> JS p[193]; default on for older firmware)
+  { const ml=(p.length>193?p[193]:1); $("#modeLed").textContent = ml?"on":"off"; $("#modeLed").classList.toggle("active",!!ml); }
   // per-type button config (blob v10/v17): 4 types x 9 bytes. readBlob() strips the 2-byte [0xA5][len] header, so
   // the firmware's buffer index 75 lands at JS index 73 here.
   if(p.length>=73+TYPE_DEFS.length*9){
@@ -2207,6 +2213,7 @@ $("#wipeBoard").onclick=async()=>{
   log("FULL BOARD WIPE sent — the board is erasing firmware + all data (~15–20 s), then reboots as a blank UF2 drive. Flash OpenPuck (.uf2) to restore it.");
 };
 $("#persistMode").onclick=()=>{ const on=$("#persistMode").classList.contains("active"); setField(16, on?0:1); };
+$("#modeLed").onclick=()=>{ const on=$("#modeLed").classList.contains("active"); setField(30, on?0:1); };
 $("#landAll87").onclick=async()=>{ const on=$("#landAll87").classList.contains("active"); await setField(29, on?0:1); log("land-all-0x87 "+(on?"disabled":"enabled")); };
 // Connection tuning: post-connect haptic block on (field 27) + seconds (field 28). (poll RX window is fixed.)
 for(const id of ["mDiv","mFric"]){


### PR DESCRIPTION
It's been a while, but as discussed in https://github.com/safijari/openpuck/issues/88#issuecomment-4980809295 I'm making my LED features for nrf52840 into a pull request. This adds an config option to toggle whether the LED should indicate which controller mode OpenPuck is currently on.