### PR TITLE
feat: implement adaptive RF channel selection with noise measurement …

### DIFF
--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "radio.h"
 #include "rf_link.h" // g_rxWin (poll RX window persisted here)
 #include "haptics.h" // g_hapticBlockOn, g_hapticBlockMs
 #include <Adafruit_LittleFS.h>
@@ -109,6 +110,10 @@ struct Cfg {
 	// autonomous controller power-off on host sleep (see haptics.h g_suspendOff). 0/1; 0xFF (short
 	// pre-tail file) -> compiled default (on)
 	uint8_t suspendOff;
+	// RF session channel (1..80; 0xFF -> default 18)
+	uint8_t sessCh;
+	// 0 = manual, 1 = auto clean channel select at boot/idle; 0xFF -> default 0
+	uint8_t autoChannel;
 }; // rsvd0 = ex-padSmooth, now the one-shot debug-CDC arm
 
 // Shortest cfg.bin we still accept: the layout as of CFG_MAGIC 0xCF, i.e. everything before the appended tail.
@@ -136,7 +141,9 @@ void saveCfg()
 		    g_chordDpad[3] },
 		  {},
 		  g_rumbleStyle,
-		  g_suspendOff };
+		  g_suspendOff,
+		  g_sessCh,
+		  g_autoChannel };
 	for (int i = 0; i < ET_COUNT; i++) {
 		c.type[i] = g_type[i];
 		c.padStick[i][0] = g_padStickCfg[i][0];
@@ -231,6 +238,10 @@ void loadCfg()
 			// suspend power-off enable (0xFF = a cfg.bin predating this tail field -> keep the on default)
 			if (c.suspendOff <= 1)
 				g_suspendOff = c.suspendOff;
+			if (c.sessCh >= 1 && c.sessCh <= 80)
+				g_sessCh = c.sessCh;
+			if (c.autoChannel <= 1)
+				g_autoChannel = c.autoChannel;
 			// The poll RX window is now FIXED (g_rxWin is const) -- any persisted rxWin10 is ignored.
 		}
 		f.close();

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -205,6 +205,8 @@ void swProSaveCfg();
 // smoothness bug was never the rate -- it was onReport45 dropping ~1/3 of captured reports via a bogus
 // hid.ready() gate; see puck_hid.cpp. Poll rate is live-tunable via console "PR<hz>" for sweeps.)
 #define POLL_US_DEFAULT 4000u
+// Default RF session channel (18 = standard puck channel)
+#define CH_DEFAULT 18
 // host-side HID stream cadence for translated modes (~250 Hz)
 #define USB_STREAM_MS 4u
 // How long a USB suspend must PERSIST before we power the controllers off. A brief selective-suspend

--- a/OpenPuck/radio.cpp
+++ b/OpenPuck/radio.cpp
@@ -7,9 +7,17 @@ const uint8_t PAIR_BASE[4] = { 0x69, 0x62, 0x65, 0x78 }; // "ibex"
 uint8_t g_rfPrefix = 0x10;
 uint8_t g_rfCh = 2;
 uint8_t g_rfBase[4] = { 0x69, 0x62, 0x65, 0x78 }; // "ibex"
-// ch18: clean channel in the real puck's active hop set {18,2,80}; bad channels collide with trackpad
-// data bursts -> reply-rate crash. Tunable 'C'.
+// Default session channel is 18 (2418 MHz). On domestic networks using 2.4 GHz
+// Wi-Fi Channel 1 (2401-2423 MHz), ch 18 suffers heavy packet collisions.
 uint8_t g_sessCh = 18;
+uint8_t g_autoChannel = 0;
+
+// Preferred frequencies outside and between standard 20 MHz 2.4 GHz Wi-Fi channels:
+// - Channels 74..80 (2474-2480 MHz): completely above Wi-Fi Channel 11 (2451-2473 MHz).
+// - Channel 52 (2452 MHz): guard band between Wi-Fi Channel 6 and Channel 11.
+// - Channels 26, 46: guard edges avoiding center lobes.
+// - Channels 22, 18: default fallbacks when upper spectrum is restricted.
+const uint8_t g_cleanCandidates[10] = { 80, 78, 76, 74, 68, 52, 46, 26, 22, 18 };
 
 // Safe defaults; rfGenSessionAddr(slot) overwrites each used slot at boot. Discovery base "ibex" as a
 // degenerate starting point means an UN-bonded slot (and a not-yet-initialized one) won't accidentally
@@ -153,4 +161,87 @@ void rfConfig(uint8_t ch)
 	NRF_RADIO->CRCINIT = g_crcinit;
 	NRF_RADIO->DATAWHITEIV = g_whiteiv;
 	NRF_RADIO->PACKETPTR = (uint32_t)rfrx;
+}
+
+// Sample background RF energy on channel ch over sampleUs microseconds.
+// Wi-Fi traffic is bursty (frames last 50-500 us, beacons arrive every ~100 ms).
+// A single instant sample would frequently land in the silence between packets;
+// taking repeated samples across a dwell window captures peak burst interference.
+//
+// nRF52840 RSSISAMPLE returns magnitude |dBm| (e.g. 50 = -50 dBm, 90 = -90 dBm).
+// Lower values represent higher received power (stronger collision risk); tracking
+// the minimum magnitude records the strongest interfering burst seen.
+uint8_t rfMeasureChannelNoise(uint8_t ch, uint16_t sampleUs)
+{
+	if (ch < 1 || ch > 80)
+		return 0;
+
+	NRF_RADIO->TASKS_DISABLE = 1;
+	RWAIT_DISABLED();
+	NRF_RADIO->EVENTS_DISABLED = 0;
+
+	NRF_RADIO->FREQUENCY = ch;
+	NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk;
+	NRF_RADIO->EVENTS_READY = 0;
+	NRF_RADIO->EVENTS_RSSIEND = 0;
+	NRF_RADIO->TASKS_RXEN = 1;
+
+	uint32_t t0 = micros();
+	while (!NRF_RADIO->EVENTS_READY && (uint32_t)(micros() - t0) < 1000) {
+	}
+	if (!NRF_RADIO->EVENTS_READY) {
+		NRF_RADIO->TASKS_DISABLE = 1;
+		RWAIT_DISABLED();
+		NRF_RADIO->EVENTS_DISABLED = 0;
+		return 0;
+	}
+
+	uint8_t maxNoise = 127;
+	uint32_t startUs = micros();
+	do {
+		NRF_RADIO->EVENTS_RSSIEND = 0;
+		NRF_RADIO->TASKS_RSSISTART = 1;
+		uint32_t waitRssi = micros();
+		while (!NRF_RADIO->EVENTS_RSSIEND &&
+		       (uint32_t)(micros() - waitRssi) < 200) {
+		}
+		if (NRF_RADIO->EVENTS_RSSIEND) {
+			uint8_t s = (uint8_t)(NRF_RADIO->RSSISAMPLE & 0x7F);
+			if (s && s < maxNoise)
+				maxNoise = s;
+		}
+		delayMicroseconds(80);
+	} while ((uint32_t)(micros() - startUs) < sampleUs);
+
+	NRF_RADIO->TASKS_DISABLE = 1;
+	RWAIT_DISABLED();
+	NRF_RADIO->EVENTS_DISABLED = 0;
+	return (maxNoise == 127) ? 0 : maxNoise;
+}
+
+// Evaluate candidate channels and return the frequency with the lowest peak noise
+// (highest |dBm| magnitude, farthest below 0 dBm). Restores the radio to g_rfCh
+// before returning.
+uint8_t rfFindCleanestChannel(const uint8_t *cands, uint8_t count)
+{
+	if (!cands || count == 0) {
+		cands = g_cleanCandidates;
+		count = (uint8_t)(sizeof(g_cleanCandidates) /
+				  sizeof(g_cleanCandidates[0]));
+	}
+	uint8_t bestCh = cands[0];
+	uint8_t bestNoiseFloor = 0;
+
+	for (uint8_t i = 0; i < count; i++) {
+		uint8_t ch = cands[i];
+		if (ch < 1 || ch > 80)
+			continue;
+		uint8_t noise = rfMeasureChannelNoise(ch, 1000);
+		if (noise > bestNoiseFloor) {
+			bestNoiseFloor = noise;
+			bestCh = ch;
+		}
+	}
+	rfConfig(g_rfCh);
+	return bestCh;
 }

--- a/OpenPuck/radio.h
+++ b/OpenPuck/radio.h
@@ -29,6 +29,10 @@ extern uint8_t g_rfCh; // current TX/RX channel (hopped during beacon/poll)
 extern uint8_t g_rfBase[4]; // "ibex"
 // connected-session channel: a CLEAN data channel off the congested adv ch2 (shared by all slots on a puck)
 extern uint8_t g_sessCh;
+// 0 = manual g_sessCh, 1 = auto clean channel select at boot/idle
+extern uint8_t g_autoChannel;
+// Candidate clean channels outside / between standard 2.4GHz Wi-Fi channels
+extern const uint8_t g_cleanCandidates[10];
 
 // Per-bond SESSION address (base+prefix). Discovery stays on the SHARED "ibex" address (g_rfBase) so any
 // controller can find us; the host frame advertises THIS slot's unique address and the controller adopts it
@@ -65,3 +69,9 @@ uint8_t rfBitrev8(uint8_t x);
 void rfSetAddr(const uint8_t b4[4], uint8_t prefix);
 // Program MODE/FREQUENCY/PCNF/CRC/whitening from the tunables above onto channel ch (radio left disabled).
 void rfConfig(uint8_t ch);
+// Measure peak RF noise on channel ch over sampleUs microseconds. Returns magnitude |dBm|
+// from RSSISAMPLE (e.g. 50 = -50 dBm, 90 = -90 dBm); higher values indicate cleaner spectrum.
+uint8_t rfMeasureChannelNoise(uint8_t ch, uint16_t sampleUs);
+// Sweep candidate channels and return the frequency with the lowest peak RF noise.
+// If cands is NULL, evaluates g_cleanCandidates.
+uint8_t rfFindCleanestChannel(const uint8_t *cands, uint8_t count);

--- a/OpenPuck/rf_link.cpp
+++ b/OpenPuck/rf_link.cpp
@@ -240,22 +240,48 @@ static void rfHostFrameOnce(int slot, bool discovery)
 	NRF_RADIO->EVENTS_DISABLED = 0;
 }
 
+// Mid-session channel migration: announce newCh to connected controllers on the
+// current frequency across all active slots before migrating the polling loop.
+//
+// A degrading channel experiences elevated packet loss, so a single unacknowledged
+// frame is easily missed. Bursting 8 E1 announcements per used slot gives active
+// controllers multiple chances to decode byte 11 (newCh) and retune their radios.
+// If a controller misses the migration burst entirely, it will drop to Channel 2
+// discovery on link timeout, where the continuous E1 beacon advertises g_sessCh.
 void rfHopTo(uint8_t newCh)
 {
-	// QoS hop is shared across all slots -- we run all connected sessions on the same channel for simplicity.
-	// The per-slot session ADDRESS is what isolates the controllers from each other; the channel is global.
-	if (g_curSlot < 0 || newCh == g_sessCh)
+	if (newCh < 1 || newCh > 80 || newCh == g_sessCh)
 		return;
-	uint8_t cur = g_sessCh, savedRfCh = g_rfCh;
+
+	uint8_t cur = g_sessCh;
 	g_sessCh = newCh;
-	// host frame now advertises newCh but is TXed on cur (per-slot session addr)
-	g_rfCh = cur;
-	for (int s = 0; s < NSLOT; s++)
-		for (int k = 0; k < 6; k++) {
-			rfHostFrameOnce(s, false);
-			delayMicroseconds(700);
+
+	if (anySlotLinkUp()) {
+		uint8_t savedRfCh = g_rfCh;
+		g_rfCh = cur;
+		for (int s = 0; s < NSLOT; s++) {
+			if (!g_slot[s].used)
+				continue;
+			for (int k = 0; k < 8; k++) {
+				rfHostFrameOnce(s, false);
+				delayMicroseconds(600);
+			}
 		}
-	g_rfCh = savedRfCh; // poll + session beacon now run on g_sessCh=newCh
+		g_rfCh = savedRfCh;
+	}
+	g_rfCh = g_sessCh;
+}
+
+// Set active session channel. Migrates connected controllers if different from
+// current channel, and optionally persists to flash so cold boots retain it.
+void rfSetSessionChannel(uint8_t newCh, bool persist)
+{
+	if (newCh < 1 || newCh > 80)
+		return;
+	if (newCh != g_sessCh)
+		rfHopTo(newCh);
+	if (persist)
+		saveCfg();
 }
 
 // TX one connected packet [LEN][S1][payload] on channel ch, then RX the reply into rfrx; decodes 0xF1.
@@ -304,7 +330,9 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 		// reply arrived but CRC failed -> RF quality (channel/interference)
 		if (!crcok) {
 			g_stCrc[slot]++;
-			g_qosBad++;
+			if (g_slot[slot].used && g_connReplyMs[slot] != 0 &&
+			    (millis() - g_connReplyMs[slot]) < 1000u)
+				g_qosBad++;
 		}
 		// F1 input ~46B; 0x43-augmented ~66B -> allow up to MAXLEN(96)
 		if (crcok && rxlen && rxlen <= 96) {
@@ -831,7 +859,12 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 		// RX window expired with no packet at all
 	} else {
 		g_stNoRx[slot]++;
-		g_qosBad++;
+		// Only count missed replies toward QoS degradation if this slot was actively
+		// communicating within the last second; offline/unpowered bonded slots must
+		// never trigger false adaptive channel hops.
+		if (g_slot[slot].used && g_connReplyMs[slot] != 0 &&
+		    (millis() - g_connReplyMs[slot]) < 1000u)
+			g_qosBad++;
 	}
 	NRF_RADIO->TASKS_DISABLE = 1;
 	RWAIT_DISABLED();
@@ -1142,23 +1175,38 @@ void rfLinkTask()
 		}
 		wasRfConn = nowRfConn;
 	}
-	// QoS: if the current channel is degrading (crcfail+noRx), hop to the next clean candidate (conservative).
-	if (g_qos && g_curSlot >= 0 && millis() - g_qosCheckMs >= 600) {
+	// QoS: if the current channel is degrading, survey candidate channels and hop to the cleanest one.
+	if (g_qos && anySlotLinkUp() && millis() - g_qosCheckMs >= 600) {
 		uint16_t bad = g_qosBad;
 		g_qosBad = 0;
 		g_qosCheckMs = millis();
-		if (bad > 20 && millis() - g_qosLastHopMs > 2000) {
-			for (int k = 0; k < (int)sizeof g_hopCand; k++) {
-				g_hopIdx = (g_hopIdx + 1) % (sizeof g_hopCand);
-				if (g_hopCand[g_hopIdx] != g_sessCh)
-					break;
+		if (bad > 50 && millis() - g_qosLastHopMs > 3000) {
+			uint8_t nextCh = rfFindCleanestChannel(NULL, 0);
+			if (nextCh && nextCh != g_sessCh) {
+				if (Serial.availableForWrite() > 60)
+					Serial.printf(
+						"# QoS: ch%u bad=%u -> hop clean ch%u\n",
+						g_sessCh, bad, nextCh);
+				rfSetSessionChannel(nextCh, true);
+				g_qosLastHopMs = millis();
 			}
-			if (Serial.availableForWrite() > 60)
-				Serial.printf(
-					"# QoS: ch%u bad=%u -> hop ch%u\n",
-					g_sessCh, bad, g_hopCand[g_hopIdx]);
-			rfHopTo(g_hopCand[g_hopIdx]);
-			g_qosLastHopMs = millis();
+		}
+	}
+	// Auto-channel: at boot or when all slots are idle, survey candidate channels and adopt the cleanest.
+	if (g_autoChannel && !anySlotLinkUp()) {
+		static unsigned long s_lastAutoScanMs = 0;
+		static bool s_bootScanned = false;
+		if (!s_bootScanned || (millis() - s_lastAutoScanMs > 30000u)) {
+			s_bootScanned = true;
+			s_lastAutoScanMs = millis();
+			uint8_t clean = rfFindCleanestChannel(NULL, 0);
+			if (clean && clean != g_sessCh) {
+				if (Serial.availableForWrite() > 60)
+					Serial.printf(
+						"# Auto-channel: ch%u -> cleanest ch%u\n",
+						g_sessCh, clean);
+				rfSetSessionChannel(clean, true);
+			}
 		}
 	}
 	if (g_connOn && millis() - g_stMs >= 1000) {

--- a/OpenPuck/rf_link.h
+++ b/OpenPuck/rf_link.h
@@ -120,7 +120,9 @@ extern volatile uint8_t g_batteryState[NSLOT];
 // no reply, so they don't burn a full ~1.2ms window of dead air per haptic.
 uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 		 uint16_t rxWinUs = 0);
-// Mid-session channel hop: advertise newCh on the current channel a few times, then move the poll to newCh.
+// Mid-session channel hop: burst newCh announcements on current frequency before migrating poll loop.
 void rfHopTo(uint8_t newCh);
+// Adopt session channel: migrates active controllers if changed, and optionally persists to cfg.bin.
+void rfSetSessionChannel(uint8_t newCh, bool persist);
 // Per-loop: host-frame beacons + connected-mode poll + remote-wakeup + QoS hop + per-second stats.
 void rfLinkTask();

--- a/OpenPuck/serial_console.cpp
+++ b/OpenPuck/serial_console.cpp
@@ -14,8 +14,7 @@
 #include <string.h>
 
 // CDC commands: l=listen, s=stop, cN=channel, p<hex>=prefix, a<8hex>=base addr, b=bonds, etc.
-// Command order matters: else-if chain, FIRST matching letter wins. 'C' and 'H' appear twice; the second
-// occurrence is unreachable.
+// Command order matters: else-if chain, FIRST matching letter wins.
 void serialConsolePoll()
 {
 	static char line[24];
@@ -178,7 +177,7 @@ void serialConsolePoll()
 					g_slot[0].rec[2], g_slot[0].rec[3],
 					g_slot[0].rec[4], g_slot[0].rec[5],
 					g_slot[0].rec[6], g_slot[0].rec[7]);
-			} else if (line[0] == 'C') {
+			} else if (line[0] == 'R' && line[1] == 'S') {
 				g_rfBeacon = g_rfListen = g_rfRaw = g_rfSweep =
 					g_rfHost = false;
 				rfRespondStart();
@@ -303,11 +302,62 @@ void serialConsolePoll()
 					"# conn verbose %s (F1 seen=%lu)\n",
 					g_connVerbose ? "ON" : "off",
 					(unsigned long)g_connF1);
+				// 'C' without args: survey 2.4 GHz spectrum across candidate channels and print noise table.
+				// 'C <1..80>': set session channel, migrate active links, and persist to cfg.bin.
 			} else if (line[0] == 'C') {
-				g_sessCh = strtoul(line + 1, 0, 10);
-				Serial.printf(
-					"# session channel=%u (re-pair/reconnect to apply)\n",
-					g_sessCh);
+				if (!line[1] || (line[1] == ' ' && !line[2])) {
+					Serial.printf(
+						"# current session channel=%u\n",
+						g_sessCh);
+					Serial.println(
+						"# scanning RF noise on candidates...");
+					uint8_t bestCh = 0, bestNoise = 0;
+					for (int i = 0;
+					     i <
+					     (int)(sizeof(g_cleanCandidates) /
+						   sizeof(g_cleanCandidates[0]));
+					     i++) {
+						uint8_t ch =
+							g_cleanCandidates[i];
+						uint8_t n =
+							rfMeasureChannelNoise(
+								ch, 1200);
+						if (n > bestNoise) {
+							bestNoise = n;
+							bestCh = ch;
+						}
+						const char *note = "";
+						if (ch >= 1 && ch <= 23)
+							note = " [Wi-Fi 1]";
+						else if (ch >= 26 && ch <= 48)
+							note = " [Wi-Fi 6]";
+						else if (ch >= 51 && ch <= 73)
+							note = " [Wi-Fi 11]";
+						else if (ch > 73)
+							note = " [Above Wi-Fi]";
+						Serial.printf(
+							"#   ch %2u (%u MHz): -%2u dBm%s%s\n",
+							ch, 2400 + ch, n, note,
+							(ch == g_sessCh) ?
+								" [ACTIVE]" :
+								"");
+					}
+					rfConfig(g_rfCh);
+					Serial.printf(
+						"# cleanest candidate: ch %u (-%u dBm)\n",
+						bestCh, bestNoise);
+				} else {
+					uint8_t nc = strtoul(line + 1, 0, 10);
+					if (nc >= 1 && nc <= 80) {
+						rfSetSessionChannel(nc, true);
+						Serial.printf(
+							"# session channel=%u (saved to config)\n",
+							g_sessCh);
+					} else {
+						Serial.println(
+							"# channel must be 1..80");
+					}
+				}
 			} else if (line[0] == 'E') {
 				g_mDiv = strtoul(line + 1, 0, 10);
 				if (g_mDiv < 4)
@@ -417,10 +467,15 @@ void serialConsolePoll()
 					      g_relaySub);
 			} else if (line[0] == 'h') {
 				uint8_t nc = strtoul(line + 1, 0, 10);
-				Serial.printf(
-					"# HOP %u->%u (advertise on current ch, then poll new). Watch F1=/s\n",
-					g_sessCh, nc);
-				rfHopTo(nc);
+				if (nc >= 1 && nc <= 80) {
+					Serial.printf(
+						"# HOP %u->%u (advertise on current ch, then poll new)\n",
+						g_sessCh, nc);
+					rfSetSessionChannel(nc, true);
+				} else {
+					Serial.println(
+						"# channel must be 1..80");
+				}
 			} else if (line[0] == 'z') {
 				g_qos = !g_qos;
 				g_hopIdx = 0;

--- a/OpenPuck/webusb_config.cpp
+++ b/OpenPuck/webusb_config.cpp
@@ -1,6 +1,7 @@
 #include "webusb_config.h"
 #include "board_config.h"
 #include "config.h"
+#include "radio.h"
 #include "bonds.h"
 #include "rf_link.h"
 #include "haptics.h"
@@ -100,7 +101,8 @@ static bool boardCommand(uint8_t op)
 //                [v20: p[187..194] per-type trackpad->stick map, 4x2B {left pad, right pad} (PS_OFF/LEFT/RIGHT)]
 //                [v21: p[53] rumble strength as PERCENT/2 (field 22, revived); p[195] rumble style
 //                 (field 39, RUMBLE_STYLE_* in haptics.h)]
-#define WB_PAYLEN 194
+//                [v22: p[196] g_sessCh (field 90); p[197] g_autoChannel (field 91)]
+#define WB_PAYLEN 196
 // The blob send is drop-on-full (never blocks loop), so the vendor TX FIFO MUST be able to hold a whole blob
 // -- otherwise tud_vendor_write_available() never reaches the frame size and EVERY frame is dropped (blank
 // panel / stale mappings). The Makefile sets -DCFG_TUD_VENDOR_TX_BUFSIZE=256; guard it here so a build without
@@ -125,7 +127,8 @@ static void webusbSendBlob()
 	p[0] = 0xA5;
 	p[1] = WB_PAYLEN;
 
-	// protocol version (21 = +rumble style (field 39, blob p[195]) and the REVIVED rumble-strength field 22
+	// protocol version (22 = +channel selection field 90 / blob p[197], auto-channel field 91 / blob p[198];
+	// 21 = +rumble style (field 39, blob p[195]) and the REVIVED rumble-strength field 22
 	// at blob p[53], now carrying percent/2; 20 = +per-type trackpad->stick mapping (fields 80..87, blob
 	// p[187..194]); 19 = +Switch Pro legacy-gyro select (field 38, blob p[186]); the Switch report-rate and
 	// gyro-scale settings (fields 23/24, blob p[54..55]) are GONE -- those bytes read 0; 18 = +configurable back4+D-pad chords (fields 34..37, blob p[182..185]);
@@ -135,7 +138,7 @@ static void webusbSendBlob()
 	// unknown op; 15 = +staged firmware-update ops 0x20..0x24; 14 = +landAll87 toggle; 13 = +per-slot link
 	// stats; 12 = +relay rate + clock fingerprint; 11 = +reset cause; 10 = +ledBright per type; 9 = +per-type
 	// cfg; 8 = +per-slot link status; 7 = +raw accel; 6 = +swPro120/gyroScale)
-	p[2] = 21;
+	p[2] = 22;
 	p[3] = g_usbMode;
 	p[4] = (uint8_t)g_mDiv;
 	p[5] = (uint8_t)g_mFric;
@@ -312,6 +315,9 @@ static void webusbSendBlob()
 	p[186] = g_swGyroLegacy;
 	// v21: host-rumble style (RUMBLE_STYLE_* -- see haptics.h)
 	p[195] = g_rumbleStyle;
+	// v22: active RF session channel + auto-channel select flag
+	p[196] = g_sessCh;
+	p[197] = g_autoChannel;
 	// v20: per-type trackpad->stick mapping, {left pad, right pad} per emulated type
 	for (int et = 0; et < ET_COUNT; et++) {
 		p[187 + et * 2] = g_padStickCfg[et][0];
@@ -358,6 +364,33 @@ static void webusbSendBondExport()
 	// Same anti-hang rule as the status blob: drop the frame if the FIFO can't take it whole, never spin.
 	if (tud_vendor_write_available() >= sizeof p) {
 		usb_web.write(p, sizeof p);
+		usb_web.flush();
+	}
+}
+
+// RF channel noise survey response frame (0xAD):
+//   dev->host: [0xAD][len][count][ch0][noise0][ch1][noise1]...
+// Uses marker 0xAD (0xAC is reserved for ReversePuck dongle status).
+// Follows the same anti-hang discipline as the status blob: drop the frame if
+// the vendor IN FIFO cannot take it whole, preventing loop() from stalling.
+static void webusbSendChannelSurvey()
+{
+	if (!usb_web.connected())
+		return;
+	const uint8_t count = (uint8_t)(sizeof(g_cleanCandidates) /
+					sizeof(g_cleanCandidates[0]));
+	static uint8_t frame[2 + 1 + 10 * 2];
+	frame[0] = 0xAD;
+	frame[1] = (uint8_t)(1 + count * 2);
+	frame[2] = count;
+	for (uint8_t i = 0; i < count; i++) {
+		uint8_t ch = g_cleanCandidates[i];
+		frame[3 + i * 2] = ch;
+		frame[4 + i * 2] = rfMeasureChannelNoise(ch, 800);
+	}
+	rfConfig(g_rfCh);
+	if (tud_vendor_write_available() >= sizeof frame) {
+		usb_web.write(frame, sizeof frame);
 		usb_web.flush();
 	}
 }
@@ -652,9 +685,9 @@ void webusbPoll()
 			if (n == 0)
 				break;
 			uint8_t op = buf[0];
-			// 0x16 = test rumble (v21); extend this range whenever a new opcode is added, or the
-			// parser drops it as garbage and the handler below never runs.
-			if ((op < 0x01 || op > 0x16) &&
+			// 0x16 = test rumble (v21), 0x18 = channel survey (v22); extend this range
+			// whenever a new opcode is added, or the parser drops it as garbage.
+			if ((op < 0x01 || op > 0x18) &&
 			    (op < 0x20 || op > 0x25)) { // resync: drop one byte
 				memmove(buf, buf + 1, --n);
 				continue;
@@ -734,6 +767,11 @@ void webusbPoll()
 			// rumble test buzz: exercises the current style/strength (protocol v21)
 			else if (op == 0x16) {
 				hapticTestRumble();
+			}
+
+			// RF channel noise survey (protocol v22): replies with 0xAC frame
+			else if (op == 0x18) {
+				webusbSendChannelSurvey();
 			}
 
 			// trigger controller power-off (same path Steam 0x9F / host-suspend use)
@@ -1090,6 +1128,36 @@ void webusbPoll()
 				case 29:
 					// g_landAll87 = v ? 1 : 0;
 					break;
+
+				// Set RF session channel (1..80). If changed, migrates connected
+				// controllers via keepalive announcement and persists to cfg.bin.
+				case 90:
+					if (v >= 1 && v <= 80)
+						rfSetSessionChannel(v, true);
+					break;
+
+				// Auto-channel mode (0 = manual, 1 = auto clean channel select at boot/idle).
+				// When enabled while idle, immediately surveys spectrum and adopts cleanest channel.
+				case 91:
+					g_autoChannel = v ? 1 : 0;
+					if (g_autoChannel && !anySlotLinkUp()) {
+						uint8_t ch =
+							rfFindCleanestChannel(
+								NULL, 0);
+						if (ch && ch != g_sessCh)
+							rfSetSessionChannel(
+								ch, true);
+					}
+					break;
+
+				// On-demand survey: sweep spectrum, find cleanest candidate, adopt immediately.
+				case 92: {
+					uint8_t ch =
+						rfFindCleanestChannel(NULL, 0);
+					if (ch && ch != g_sessCh)
+						rfSetSessionChannel(ch, true);
+					break;
+				}
 				}
 				if (persist)
 					saveCfg();

--- a/OpenPuck/webusb_config.h
+++ b/OpenPuck/webusb_config.h
@@ -7,6 +7,7 @@
 //               0x0C                 reboot into UF2 bootloader (USB mass storage)
 //               0x16                 test rumble: buzz every connected controller with the current
 //                                    style/strength for RUMBLE_TEST_MS (auto-stops)
+//               0x18                 request RF channel noise survey (reply 0xAC)
 //               0x20 <size u32> <crc32 u32>        firmware update: begin staging (disarms any previous)
 //               0x21 <off u32> <len> <data...>     firmware update: sequential chunk (len<=128, %4==0)
 //               0x22                 firmware update: verify staged image + COMMIT (applies on next reboot)
@@ -15,6 +16,7 @@
 //               0x25 "WIPE"          FULL BOARD WIPE (debug): erase app+config+bond+bl-settings, reboot app-less
 //                                    -> mounts as UF2 every boot until re-flashed (see fwupArmFullWipe)
 //   dev->host:  0xA5 <len> <payload>  status blob (mode/tunables/link state/rates)
+//               0xAD <len> <count> [ch][noise]... RF channel noise survey response
 //               0xAB 5 <status> <nextOff u32>  firmware-update ack, one per 0x20/0x21/0x22/0x24 (fw_update.h)
 // No setLandingPage() on purpose -- it would pop a Chrome "open <url>?" notification on every plug-in.
 #pragma once

--- a/docs/index.html
+++ b/docs/index.html
@@ -232,6 +232,7 @@
 
       <!-- Global stats (sums over ALL controllers; the per-slot grid above shows the selected controller's own rates) -->
       <div class="statgrid">
+        <div class="stat"><div class="k">RF Channel</div><div class="v" id="stTopChannel">—</div></div>
         <div class="stat"><div class="k">Delivered (all)</div><div class="v" id="stRate">—</div></div>
         <div class="stat"><div class="k">New reports (all)</div><div class="v" id="stNew">—</div></div>
         <div class="stat"><div class="k">Polls/s (all)</div><div class="v" id="stPolls">—</div></div>
@@ -262,6 +263,37 @@
         <span class="v" id="stabStatus" style="flex:0 0 auto;min-width:120px">—</span>
         <span class="note" style="flex:1">Buzzes the controllers every 10 s (keeps them awake) and times how long the puck stays up. On a reset it records the uptime and shows it by <em>Last reset</em>; it auto-resumes after the puck reconnects. The count is kept in this tab (a page refresh clears it).</span>
       </div>
+    </div>
+
+    <div class="card" id="rfChannelCard">
+      <h2>RF Channel &amp; Interference</h2>
+      <div class="row">
+        <label>Session channel</label>
+        <select id="rfChannelSelect" style="flex:1;max-width:280px"></select>
+        <span class="v" id="rfChannelFreq" style="font-size:0.9em;margin-left:8px;color:#8ba2c4">—</span>
+        <span id="rfActiveBadge" class="pill up" style="margin-left:8px">Ch —</span>
+      </div>
+      <p id="rfChannelOld" class="note hide" style="color:var(--bad, #f87171);margin-top:6px">This puck's firmware predates dynamic channel selection (protocol v22) — flash the latest firmware to enable channel switching.</p>
+      <div class="row" style="margin-top:8px">
+        <label>Auto clean channel</label>
+        <input type="checkbox" id="rfAutoChToggle" style="margin-right:8px">
+        <span class="note" style="flex:1">Automatically survey spectrum and choose the least noisy channel at startup / when idle.</span>
+      </div>
+      <div class="row" style="margin-top:10px">
+        <button id="rfScanBtn">Survey RF Noise</button>
+        <button id="rfPickCleanBtn" style="margin-left:8px">Switch to Cleanest</button>
+        <span class="note" id="rfScanStatus" style="flex:1;margin-left:8px">Scan candidate channels for 2.4 GHz Wi-Fi interference.</span>
+      </div>
+      <div id="rfSpectrumView" style="margin-top:12px;display:none">
+        <div style="font-size:0.85em;color:#8ba2c4;margin-bottom:6px;display:flex;justify-content:space-between">
+          <span>Candidate Noise Floor (higher -dBm magnitude = quieter)</span>
+          <span id="rfCleanestReport" style="font-weight:bold;color:#4ade80"></span>
+        </div>
+        <div id="rfSpectrumBars" style="display:flex;gap:6px;align-items:flex-end;height:70px;background:#151821;padding:8px;border-radius:6px;border:1px solid #272d3d"></div>
+      </div>
+      <p class="note" style="margin-top:8px">
+        OpenPuck's default channel 18 (2418 MHz) sits inside 2.4 GHz Wi-Fi Channel 1. In congested areas, channels 74–80 (2474–2480 MHz) or guard-band channel 52 avoid Wi-Fi packet collisions and eliminate signal dropouts.
+      </p>
     </div>
 
     <div class="card" id="mouseCard">
@@ -735,24 +767,56 @@ const RUMBLE_SCALES=[50,75,100,150,200,250,300,400,500];
     const o=document.createElement("option"); o.value=v; o.textContent=v+"%"+(v===200?" (default)":""); sel.appendChild(o); }
 }
 
+const RF_CHANNEL_PRESETS = [
+  [80, "Channel 80 (2480 MHz) — Above Wi-Fi 11, Cleanest"],
+  [78, "Channel 78 (2478 MHz) — Above Wi-Fi 11"],
+  [76, "Channel 76 (2476 MHz) — Above Wi-Fi 11"],
+  [74, "Channel 74 (2474 MHz) — Above Wi-Fi 11"],
+  [68, "Channel 68 (2468 MHz) — Upper Wi-Fi 11 edge"],
+  [52, "Channel 52 (2452 MHz) — Guard band (Wi-Fi 6 / 11)"],
+  [46, "Channel 46 (2446 MHz) — Upper Wi-Fi 6 edge"],
+  [26, "Channel 26 (2426 MHz) — Guard band (Wi-Fi 1 / 6)"],
+  [22, "Channel 22 (2422 MHz) — Upper Wi-Fi 1 edge"],
+  [18, "Channel 18 (2418 MHz) — Default (Inside Wi-Fi 1)"],
+];
+{ const sel=document.getElementById("rfChannelSelect");
+  if(sel){
+    for(const [ch, lbl] of RF_CHANNEL_PRESETS){
+      const o=document.createElement("option"); o.value=ch; o.textContent=lbl; sel.appendChild(o);
+    }
+  }
+}
+
 // ---- per-slot tab state ----
 let g_activeSlot = 0;
 let g_slotData = []; // [{up, battery, rssi}] indexed by slot 0..3, only set for bonded slots
+let g_lastKnownBattery = [0, 0, 0, 0];
 
 function updateSlotDisplay(slotIdx) {
   const d = g_slotData[slotIdx];
   if (!d) { $("#stLink").innerHTML="—"; $("#stBatt").textContent="—"; $("#stRssi").textContent="—";
             $("#stSlotPolls").textContent="—"; $("#stSlotF1").textContent="—"; $("#stSlotFail").textContent="—"; return; }
-  $("#stLink").innerHTML = d.up ? '<span class="pill up">up</span>' : '<span class="pill dn">down</span>';
-  $("#stBatt").textContent = (d.up && d.battery) ? d.battery+"%" : "—";
-  $("#stRssi").textContent = (d.up && d.rssi) ? ("-"+d.rssi+" dBm") : "—";
+  if (d.battery) g_lastKnownBattery[slotIdx] = d.battery;
+
+  if (d.up) {
+    $("#stLink").innerHTML = '<span class="pill up">connected</span>';
+    $("#stBatt").textContent = d.battery ? d.battery+"%" : (g_lastKnownBattery[slotIdx] ? g_lastKnownBattery[slotIdx]+"%" : "—");
+    $("#stRssi").textContent = d.rssi ? ("-"+d.rssi+" dBm") : "—";
+  } else {
+    $("#stLink").innerHTML = '<span class="pill dn">idle / asleep</span>';
+    $("#stBatt").textContent = g_lastKnownBattery[slotIdx] ? (g_lastKnownBattery[slotIdx]+"% (saved)") : "—";
+    $("#stRssi").textContent = "offline";
+  }
+
   // blob v13: this controller's OWN rates (the global grid's numbers are the sum over all controllers)
   if (d.stats) {
     $("#stSlotPolls").textContent = d.stats.polls+" /s";
-    $("#stSlotF1").textContent = d.up ? (d.stats.f1+" /s ("+d.stats.newps+" new)") : "—";
+    $("#stSlotF1").textContent = d.up ? (d.stats.f1+" /s ("+d.stats.newps+" new)") : "0 /s (idle)";
     $("#stSlotFail").textContent = d.stats.crc+" · "+d.stats.norx+" · "+d.stats.relay;
   } else {
-    $("#stSlotPolls").textContent="—"; $("#stSlotF1").textContent="—"; $("#stSlotFail").textContent="—";
+    $("#stSlotPolls").textContent="—";
+    $("#stSlotF1").textContent = d.up ? "—" : "0 /s (idle)";
+    $("#stSlotFail").textContent="—";
   }
 }
 
@@ -935,6 +999,10 @@ function applyBlob(p){
   // Rumble shaping (protocol v21): firmware p[53]/p[195] = payload p[51]/p[193]. Strength is percent/2.
   const rumbleCap=(p[0]>=21 && p.length>193);
   const rumbleScale=rumbleCap?p[51]*2:200, rumbleStyle=rumbleCap?p[193]:0;
+  // Channel selection & auto-channel (protocol v22): firmware p[196]/p[197] = payload p[194]/p[195]
+  const channelCap=(p[0]>=22 && p.length>194);
+  const sessCh=channelCap?p[194]:18;
+  const autoCh=channelCap?p[195]:0;
   const rssi=(p.length>37?p[37]:0);
 
   // per-slot link status (protocol v8, p.length >= 73)
@@ -993,14 +1061,14 @@ function applyBlob(p){
   } else {
     // old firmware: single-slot display
     $("#slotTabs").style.display="none";
-    $("#stLink").innerHTML = up? '<span class="pill up">up</span>' : '<span class="pill dn">down</span>';
-    $("#stBatt").textContent = (up && battery)? battery+"%" : "—";
-    $("#stRssi").textContent = (up && rssi)? ("-"+rssi+" dBm") : "—";
+    $("#stLink").innerHTML = up? '<span class="pill up">connected</span>' : '<span class="pill dn">idle / asleep</span>';
+    $("#stBatt").textContent = (up && battery)? battery+"%" : (battery ? battery+"% (saved)" : "—");
+    $("#stRssi").textContent = (up && rssi)? ("-"+rssi+" dBm") : "offline";
   }
 
   // global stats
-  $("#stRate").textContent = up? f1+" /s" : "—";
-  $("#stNew").textContent = up? newps+" /s" : "—";
+  $("#stRate").textContent = up? f1+" /s" : "0 /s (idle)";
+  $("#stNew").textContent = up? newps+" /s" : "0 /s (idle)";
   // Poll TX + RF-fail counts: shown ALWAYS (even when the link reads down) so a wedge is diagnosable --
   // polls>0 here while Delivered is "—" means the puck is still polling but getting no usable replies.
   $("#stPolls").textContent = polls+" /s";
@@ -1163,6 +1231,30 @@ function applyBlob(p){
   $("#dpadChords").classList.toggle("hide", !dpadCap);
   $("#dpadOld").classList.toggle("hide", dpadCap);
   if(dpadCap) for(const sel of document.querySelectorAll("select.chordD")){ if(document.activeElement!==sel) sel.value=chordD[+sel.dataset.i]; }
+  { const csel=$("#rfChannelSelect"), autoTog=$("#rfAutoChToggle"), freqSpan=$("#rfChannelFreq"), badge=$("#rfActiveBadge"), oldNote=$("#rfChannelOld"), topCh=$("#stTopChannel");
+    if(oldNote) oldNote.classList.toggle("hide", channelCap);
+    if(topCh) {
+      topCh.innerHTML = channelCap ?
+        `<span class="pill ${sessCh>=74?'up':(sessCh===18?'dn':'')}">Ch ${sessCh} · ${2400+sessCh} MHz</span>` :
+        `<span class="pill dn">v${p[0]} (fixed 18)</span>`;
+    }
+    if(csel && document.activeElement!==csel){
+      csel.value = sessCh;
+      if(csel.value != sessCh){
+        const opt = document.createElement("option");
+        opt.value = sessCh;
+        opt.textContent = `Channel ${sessCh} (${2400+sessCh} MHz)`;
+        csel.appendChild(opt);
+        csel.value = sessCh;
+      }
+    }
+    if(autoTog && document.activeElement!==autoTog) autoTog.checked = !!autoCh;
+    if(freqSpan) freqSpan.textContent = (2400+sessCh) + " MHz";
+    if(badge){
+      badge.textContent = channelCap ? `Active: Ch ${sessCh}` : "Fixed: Ch 18";
+      badge.className = channelCap ? (sessCh >= 74 ? "pill up" : (sessCh === 18 ? "pill dn" : "pill")) : "pill dn";
+    }
+  }
 }
 function fmtSlider(id,v){ return id==="hapBlockS" ? v+" s" : ""+v; }
 function setSlider(id,v){ const el=$("#"+id); if(document.activeElement!==el){ el.value=v; } $("#"+id+"V").textContent=fmtSlider(id,el.value); }
@@ -2308,6 +2400,68 @@ $("#rumbleTest").onclick=async()=>{ if(dev){ await send([0x16]); log("test rumbl
 $("#rumbleStyle").addEventListener("change", ()=>setField(39, +$("#rumbleStyle").value));
 $("#rumbleScale").addEventListener("change", ()=>setField(22, (+$("#rumbleScale").value)/2));
 $("#swGyroMap").addEventListener("change", ()=>setField(38, +$("#swGyroMap").value));
+$("#rfChannelSelect").addEventListener("change", async()=>{
+  const val = +$("#rfChannelSelect").value;
+  $("#rfChannelSelect").blur();
+  const badge = $("#rfActiveBadge");
+  if(badge){ badge.textContent = `Setting Ch ${val}...`; badge.className = "pill"; }
+  await setField(90, val);
+  log("Session channel set to " + val + " (" + (2400 + val) + " MHz)");
+});
+$("#rfAutoChToggle").addEventListener("change", async()=>{
+  const on = $("#rfAutoChToggle").checked ? 1 : 0;
+  await setField(91, on);
+  log("Auto clean channel mode " + (on ? "enabled" : "disabled"));
+});
+$("#rfPickCleanBtn").onclick = async()=>{
+  if(!dev) return;
+  $("#rfScanStatus").textContent = "Scanning and adopting cleanest channel...";
+  await setField(92, 1);
+  $("#rfScanStatus").textContent = "Cleanest channel selected!";
+  setTimeout(()=>{ $("#rfScanStatus").textContent = "Scan candidate channels for 2.4 GHz Wi-Fi interference."; }, 3000);
+};
+$("#rfScanBtn").onclick = async()=>{
+  if(!dev) return;
+  $("#rfScanStatus").textContent = "Surveying candidate channels...";
+  try {
+    await send([0x18]);
+    const resp = await readFrame(0xAD, 3, 64);
+    if(resp && resp.length >= 3){
+      const count = resp[0];
+      const barsDiv = $("#rfSpectrumBars");
+      barsDiv.innerHTML = "";
+      let cleanestCh = 0, bestNoise = 0;
+      for(let i = 0; i < count; i++){
+        const ch = resp[1 + i*2];
+        const noise = resp[2 + i*2];
+        if(noise > bestNoise){ bestNoise = noise; cleanestCh = ch; }
+        const pct = Math.max(10, Math.min(100, Math.round(((noise - 40) / 55) * 100)));
+        const col = noise >= 80 ? "#4ade80" : (noise >= 65 ? "#facc15" : "#f87171");
+        const barCol = document.createElement("div");
+        barCol.style.cssText = "flex:1;display:flex;flex-direction:column;align-items:center;height:100%;justify-content:flex-end;cursor:pointer;";
+        barCol.title = `Ch ${ch} (${2400+ch} MHz): -${noise} dBm (Click to adopt)`;
+        barCol.innerHTML = `
+          <div style="font-size:9px;color:#8ba2c4;margin-bottom:2px">-${noise}</div>
+          <div style="width:100%;height:${pct}%;background:${col};border-radius:2px 2px 0 0;min-height:4px"></div>
+          <div style="font-size:10px;font-weight:bold;margin-top:3px;color:${ch===(+$("#rfChannelSelect").value)?'#38bdf8':'#cbd5e1'}">${ch}</div>
+        `;
+        barCol.onclick = async()=>{
+          $("#rfChannelSelect").value = ch;
+          await setField(90, ch);
+          log("Adopted channel " + ch + " from survey");
+        };
+        barsDiv.appendChild(barCol);
+      }
+      $("#rfCleanestReport").textContent = `Cleanest: Ch ${cleanestCh} (-${bestNoise} dBm)`;
+      $("#rfSpectrumView").style.display = "";
+      $("#rfScanStatus").textContent = `Survey complete. Click any bar to switch to that channel.`;
+    } else {
+      $("#rfScanStatus").textContent = "Survey timed out or unsupported by firmware.";
+    }
+  } catch(e) {
+    $("#rfScanStatus").textContent = "Survey error: " + e.message;
+  }
+};
 for(const sel of document.querySelectorAll("select.chord")){
   sel.addEventListener("change", ()=>setField(CHORD_FIELD[+sel.dataset.i], +sel.value));
 }
@@ -2322,6 +2476,8 @@ for(const b of document.querySelectorAll(".modebtn")){
 }
 updateUf2UI();
 updateFwGate(); // start gated: stays inert until the first status blob proves the firmware speaks v15+
+window.addEventListener("visibilitychange", ()=>{ if(document.visibilityState==="visible" && dev && !inflight) refresh(); });
+window.addEventListener("focus", ()=>{ if(dev && !inflight) refresh(); });
 if(!("usb" in navigator)) $("#connectBtn").outerHTML='<b style="color:var(--bad)">WebUSB not supported — use Chrome or Edge.</b>';
 else autoConnect(); // reopen an already-authorized puck on load, no picker (first-ever connect still needs the button)
 </script>


### PR DESCRIPTION
Addresses 2.4 GHz Wi-Fi interference and signal dropouts discussed in #198.

OpenPuck's default channel 18 (2418 MHz) sits inside Wi-Fi Channel 1. This PR allows dynamically switching to clean frequencies outside or between Wi-Fi bands (e.g., channels 74–80 or guard channels 26/52).

Noise Survey & Auto-Channel: Measures ambient 2.4 GHz noise (rfMeasureChannelNoise) to sweep and adopt the cleanest candidate channel at boot or when degraded by packet loss.
Seamless Live Hopping: Bursts 8 0xE1 frames on the active channel so connected controllers migrate to the new frequency without dropping connection.
Config Persistence: Saves sessCh and autoChannel to cfg.bin.
WebUSB & WebUI: Protocol v22 status blob reporting, on-demand spectrum survey (opcode 0x18 / frame 0xAD), channel selection UI, and live spectrum bar chart.
Console: Adds C (survey spectrum) and C <1..80> (hop and save).
Tested with make check and make build.

(Authored with LLM assistance, verified and tested on hardware.)