### PR TITLE
Improvements to Steam puck runtime, reliability and transport

### DIFF
--- a/OpenPuck/OpenPuck.ino
+++ b/OpenPuck/OpenPuck.ino
@@ -45,6 +45,13 @@ using namespace Adafruit_LittleFS_Namespace;
 #include "usb_tx.h"
 #include <stdio.h>
 
+#include <nrf_gpio.h>
+
+static inline void feedWatchdogIfRunning()
+{
+	if (NRF_WDT->RUNSTATUS && (NRF_WDT->RREN & WDT_RREN_RR0_Msk))
+		NRF_WDT->RR[0] = WDT_RR_RR_Reload;
+}
 #if CFG_TUD_HID < 4
 #error "CFG_TUD_HID must be >= 4 (up to 4 HID interfaces per mode). Build with `make build` (bakes it in), or pass -DCFG_TUD_HID=4 in build.extra_flags."
 #endif
@@ -123,6 +130,8 @@ void modeSwitchReboot(uint8_t mode)
 
 void setup()
 {
+	// Restore watchdog margin immediately if a soft reset left WDT running.
+	feedWatchdogIfRunning();
 	// full-board wipe (debug-only "erase everything"): if the panel armed one, this never returns -- it erases
 	// the app + config/bond + bootloader-settings flash from RAM and resets into the app-less UF2 bootloader.
 	// Checked before the staged-update apply (both use the meta page; only one can be armed at a time).
@@ -262,8 +271,8 @@ void setup()
 		USBDevice.attach();
 	}
 	Serial.begin(115200);
-	for (int i = 0; i < 300 && !USBDevice.mounted(); i++)
-		delay(10); // wait up to 3s for USB mount, but NEVER hang
+	// Do not block RF/controller startup waiting for USB enumeration.
+	// TinyUSB continues enumeration asynchronously after USBDevice.attach().
 	if (USBDevice.suspended()) {
 		USBDevice.remoteWakeup();
 		ledWakePulse();
@@ -396,8 +405,13 @@ void loop()
 	faultDiagSetStage(7);
 	usbMountTask(); // dynamic mount/unmount of connected controllers (no-op unless enabled)
 	faultDiagSetStage(8);
-	usbTxPump(); // drain queued device->host reports HERE, in loop -- never off-loop (jitters the RF poll)
+	// deliver any armed post-resume wake nudge on the shared boot mouse
+	wakeHidTask();
+
+	// drain queued device->host reports HERE, in loop -- never off-loop (jitters the RF poll)
+	usbTxPump();
 	puckCmdLogDrain(); // print captured USB feature commands (diagnostic; no-op unless g_cmdCapture)
+	// loop-context only; one record max, Debug CDC boot only
 	loops++;
 	if (millis() - secMs >= 1000) {
 		g_loopPeriodUs = loops ? (uint16_t)(1000000UL / loops) : 0;
@@ -439,7 +453,12 @@ void loop()
 	faultDiagSetStage(7);
 	usbMountTask(); // dynamic mount/unmount of connected controllers (no-op unless enabled)
 	faultDiagSetStage(8);
-	usbTxPump(); // drain queued device->host reports HERE, in loop -- never off-loop (jitters the RF poll)
+	// deliver any armed post-resume wake nudge on the shared boot mouse
+	wakeHidTask();
+
+	// drain queued device->host reports HERE, in loop -- never off-loop (jitters the RF poll)
+	usbTxPump();
 	puckCmdLogDrain(); // print captured USB feature commands (diagnostic; no-op unless g_cmdCapture)
+	// loop-context only; one record max, Debug CDC boot only
 #endif
 }

--- a/OpenPuck/bonds.h
+++ b/OpenPuck/bonds.h
@@ -17,11 +17,42 @@ struct Slot {
 	uint8_t resp[63];
 	uint16_t resp_len;
 
-	// 0 = none; else the feature-01 cmd byte (0x83/0xAE/0xED/...) just relayed to this slot's controller
-	// (puck_hid.cpp handleSet, usbd task) and awaiting its real reply. Cleared by rf_link.cpp (loop/RF
-	// context) when the controller has responded to this request and overwrote resp with the response.
-	// Not persisted.
-	volatile uint8_t pendingQueryCmd;
+	// Controller feature queries are serialized per slot. Failure state stays separate
+	// from resp so a reject or timeout never destroys the last valid response. These
+	// fields are runtime-only and are not persisted.
+	volatile uint8_t
+
+		// 0 = none; otherwise the query currently on-air
+		pendingQueryCmd;
+	volatile uint8_t
+
+		// host GET stalls until a new query is queued
+		pendingQueryFailed;
+	volatile uint8_t
+
+		// 0xAE selector distinguishes concurrent same-command replies
+		pendingQuerySelector;
+	volatile uint8_t pendingQuerySelectorValid;
+	volatile uint32_t pendingQueryDeadlineMs;
+	// Once Type-4 completes, keep that exact controller
+	// response immutable until the host consumes it with a matching RID1 GET.
+	volatile uint8_t queryResponseReady;
+	volatile uint8_t queryResponseCmd;
+	volatile uint8_t queryResponseSelector;
+	volatile uint8_t queryResponseSelectorValid;
+	// The newest response-bearing RID1 SET owns
+	// queryHostGeneration; queued/on-air/ready stages carry that generation end-to-end.
+	volatile uint32_t queryHostGeneration;
+	volatile uint32_t pendingQueryGeneration;
+	volatile uint32_t queryResponseGeneration;
+	// A successfully queued host generation remains unresolved
+	// until its matching ready response is consumed. This persists across the
+	// relay-FIFO dequeue -> pendingQueryCmd RF-arm transition.
+	volatile uint32_t queryConsumedGeneration;
+	volatile uint32_t
+
+		// actual 0x9F TX time; Type-2 ownership only
+		shutdownStatusOwnerMs;
 };
 extern Slot g_slot[NSLOT];
 

--- a/OpenPuck/controllers.cpp
+++ b/OpenPuck/controllers.cpp
@@ -1,5 +1,6 @@
 #include "controllers.h"
 #include "config.h"
+#include "wake_hid.h"
 #include "puck_hid.h"
 #include "mode_xinput.h"
 #include "mode_switch_hori.h"
@@ -12,6 +13,12 @@
 #include "mode_xbox_og.h"
 
 IController *g_active = nullptr;
+// Personalities without a specialized wake fallback use the dedicated boot-mouse
+// interface registered by setup().
+void IController::wakeEvent()
+{
+	wakeHidArmNudge();
+}
 
 // Map a USB-presentation mode to its singleton controller. Steam and Lizard share the puck controller (the
 // lizard-vs-forward decision is made per-report inside it).

--- a/OpenPuck/controllers.h
+++ b/OpenPuck/controllers.h
@@ -47,10 +47,10 @@ class IController {
 	{
 	}
 
-	// a wake gesture fired while suspended; queue any post-resume input the host needs to actually wake
-	virtual void wakeEvent()
-	{
-	}
+	// A deliberate wake gesture fired while suspended. Personalities that use the
+	// shared boot-mouse wake interface inherit the default nudge; puck modes override
+	// this because their wake behavior depends on the selected puck USB contract.
+	virtual void wakeEvent();
 	virtual bool isPuck() const
 	{
 		return false;

--- a/OpenPuck/fault_diag.cpp
+++ b/OpenPuck/fault_diag.cpp
@@ -98,6 +98,8 @@ extern "C" void HardFault_Handler(void)
 void faultDiagArmIntentionalReset()
 {
 	NRF_POWER->GPREGRET2 = G2_INTENT;
+	if (NRF_WDT->RUNSTATUS && (NRF_WDT->RREN & WDT_RREN_RR0_Msk))
+		NRF_WDT->RR[0] = WDT_RR_RR_Reload;
 }
 
 // Live stage + loop heartbeat. The post-reset GPREGRET2 breadcrumb only works if the bootloader preserves

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -1,4 +1,5 @@
 #include "haptics.h"
+#include "rf_timing.h"
 #include "bonds.h"
 #include "config.h"
 #include "rf_link.h"
@@ -43,11 +44,12 @@ bool g_hapticRelay = true;
 // Per-slot reconnect block. 0 = idle; non-zero = drop haptics aimed at this slot until millis() catches up.
 unsigned long g_hapticBlockUntil[NSLOT] = { 0 };
 
-// Controller power-off. CONFIRMED from a real Windows USB capture of the Valve puck: Steam's "turn off
-// controller" is the single feature-0x01 command 0x9F with payload ASCII "off!" (6F 66 66 21). The dongle
-// forwards host feature reports verbatim, so the controller acts on report 0x9F directly -- we relay it the
-// same way (E3 SET sub-TLV). The wire relay is NO-ACK, so send a small burst: a single lost frame must not
-// leave the controller on.
+// Controller power-off. CONFIRMED from a real Windows USB capture of the Valve
+// puck: Steam's "turn off controller" is feature-0x01 command 0x9F with payload
+// ASCII "off!" (6F 66 66 21). Steam's per-interface 0x9F targets only that
+// controller; slot 0xFF remains the broadcast form used by host suspend and the
+// panel/test power-off path. The controller returns transaction status, so relay
+// this command once rather than enqueueing a duplicate burst.
 void hapticSendShutdown(uint8_t slot)
 {
 	static const uint8_t OFF[4] = { 0x6f, 0x66, 0x66, 0x21 }; // "off!"
@@ -56,9 +58,8 @@ void hapticSendShutdown(uint8_t slot)
 	// broadcast default (0xFF) remains for the triggers that logically mean "all off": host suspend and
 	// the panel/test power-off button.
 	faultDiagTrace(FR_OFF, slot);
-	for (uint8_t i = 0; i < HAPTIC_SHUTDOWN_SHOTS; i++)
-		relayEnqueue(IBEX_CMD_TURN_OFF_CONTROLLER, OFF, sizeof OFF,
-			     false, slot);
+	relayEnqueue(IBEX_CMD_TURN_OFF_CONTROLLER, OFF, sizeof OFF, false,
+		     slot);
 	// Tell the puck presentation layer to show this slot (or all, for 0xFF broadcast) cleanly DISCONNECTED to
 	// Steam and hold it there through the controller's post-off F1 tail -- otherwise the dying replies bounce
 	// the connection state (phantom reconnect / never-removed). Covers every power-off path (Steam 0x9F, the
@@ -66,16 +67,21 @@ void hapticSendShutdown(uint8_t slot)
 	puckNotePowerOff(slot);
 }
 
-// millis of last translated host rumble (0x80), per-slot (4 XInput interfaces each have their own stream)
-static unsigned long g_rumble80Ms[NSLOT] = { 0 };
-
-// Steam/Triton rumble is latched on until an explicit zero report; tracked per-slot so each controller's
-// stuck-rumble watchdog is independent
+// Translated 0x80 rumble state is stored AFTER mode-specific shaping/scaling.
+// SDL's Steam/Triton driver resends active rumble every 40 ms because the
+// controller hardware safety timeout is about 50 ms.
+#define RUMBLE_RESEND_INTERVAL_MS 40u
+static unsigned long g_rumble80Ms[NSLOT] = {
+	0
+}; // last successfully queued 0x80 TX
+static uint16_t g_rumble80Low[NSLOT] = { 0 };
+static uint16_t g_rumble80High[NSLOT] = { 0 };
 static bool g_rumble80On[NSLOT] = { false, false, false, false };
 
-// A rumble STOP is relayed as this many copies over successive poll cycles (see hapticSteamRumble): the relay
-// is NO-ACK, and a lost final stop leaves the controller latched rumbling. 3 gives temporal diversity a
-// single-frame RF loss can't wipe out without meaningfully changing steady-state traffic.
+// A rumble STOP is relayed as this many copies over successive poll cycles (see hapticSteamRumble). An ON is
+// self-healing because the active keepalive repeats it every 40 ms. A STOP is the dangerous final frame: if it
+// is lost, the controller can remain latched rumbling with no later ON/STOP traffic to correct it. Three copies
+// provide temporal diversity against a single-frame RF loss without changing steady-state traffic.
 #define RUMBLE_STOP_REPS 3
 
 // ---- relay rings: one per bond slot. Multi-producer (USB ISR + loop-context console/xinput), one consumer
@@ -87,6 +93,8 @@ struct RelayMsg {
 	// set by the caller at relayEnqueue() time (see haptics.h) -- true iff a real controller reply is
 	// wanted for this specific message, i.e. whether rfConnFlushRelay appends the query-reply trailer.
 	bool expectReply;
+	// Correlates a queued response request with the host transaction that created it.
+	uint32_t queryGeneration;
 };
 // deep enough to hold a full Steam settings/LED transaction burst without loss
 #define RELAY_QLEN 32
@@ -110,6 +118,25 @@ bool relayPending()
 	// check the current slot's queue; called from rfConnQueueHapticRelay which runs with g_curSlot set
 	int cur = (g_curSlot >= 0 && g_curSlot < NSLOT) ? g_curSlot : 0;
 	return g_rqHead[cur] != g_rqTail[cur];
+}
+bool relayQueryPending(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return false;
+	bool found = false;
+	uint32_t pm = __get_PRIMASK();
+	__disable_irq();
+	uint8_t i = g_rqTail[slot], guard = RELAY_QLEN + 1;
+	while (i != g_rqHead[slot] && guard--) {
+		const RelayMsg &m = g_rq[slot][i];
+		if (m.rid && m.expectReply) {
+			found = true;
+			break;
+		}
+		i = rqNext(i);
+	}
+	__set_PRIMASK(pm);
+	return found;
 }
 bool relayEnqueue(uint8_t rid, const uint8_t *payload, uint8_t plen,
 		  bool isHaptic, uint8_t slot, bool expectReply)
@@ -139,6 +166,8 @@ bool relayEnqueue(uint8_t rid, const uint8_t *payload, uint8_t plen,
 		g_rq[s][h].rid = rid;
 		g_rq[s][h].len = plen;
 		g_rq[s][h].expectReply = expectReply;
+		g_rq[s][h].queryGeneration =
+			expectReply ? g_slot[s].queryHostGeneration : 0u;
 		g_rq[s][h].isHaptic = isHaptic;
 		if (plen)
 			memcpy(g_rq[s][h].data, payload, plen);
@@ -265,6 +294,34 @@ bool hapticRelaySlotOk(int slot)
 {
 	return slot >= 0 && slot < NSLOT && hapticLinkUp(slot);
 }
+
+int hapticResolveRelaySlot(int requestedSlot, uint8_t *liveCount,
+			   uint8_t *decision)
+{
+	uint8_t live = 0;
+	int sole = -1;
+	for (int s = 0; s < NSLOT; s++)
+		if (hapticLinkUp(s)) {
+			live++;
+			sole = s;
+		}
+	uint8_t d = HROUTE_NO_LIVE;
+	int out = -1;
+	if (requestedSlot >= 0 && requestedSlot < NSLOT &&
+	    hapticLinkUp(requestedSlot)) {
+		d = HROUTE_EXACT;
+		out = requestedSlot;
+	} else if (live == 1) {
+		d = HROUTE_SINGLE_FALLBACK;
+		out = sole;
+	} else if (live > 1)
+		d = HROUTE_AMBIGUOUS;
+	if (liveCount)
+		*liveCount = live;
+	if (decision)
+		*decision = d;
+	return out;
+}
 static void hapticCancelPendingOn(int slot)
 {
 	// void queued ON entries (stale haptics / rumble across a reconnect). Per-slot: only the reconnected
@@ -327,12 +384,40 @@ static uint32_t isqrt32(uint32_t v)
 	return r;
 }
 
+static bool hapticQueueRumble80(uint16_t lowFreq, uint16_t highFreq,
+				uint8_t slot, bool stopBurst)
+{
+	// Match SDL's maintained Steam/Triton report 0x80 layout exactly:
+	// type=0, intensity=0, left/right speed carry the two motor amplitudes,
+	// and both gains are zero.
+	uint8_t p[9] = { 0x00,
+			 0x00,
+			 0x00,
+			 (uint8_t)(lowFreq & 0xFF),
+			 (uint8_t)(lowFreq >> 8),
+			 0x00,
+			 (uint8_t)(highFreq & 0xFF),
+			 (uint8_t)(highFreq >> 8),
+			 0x00 };
+
+	uint8_t reps = stopBurst ? RUMBLE_STOP_REPS : 1;
+	bool queued = false;
+	for (uint8_t i = 0; i < reps; i++)
+		if (relayEnqueue(0x80, p, sizeof p, true, slot))
+			queued = true;
+
+	if (queued)
+		g_rumble80Ms[slot] = millis();
+	return queued;
+}
+
 bool hapticSteamRumble(uint16_t lowFreq, uint16_t highFreq, uint8_t slot)
 {
 	if (slot >= NSLOT)
 		return false;
 	// Shape the decoded host amplitudes: style first (which motor plays, and the response curve), then the
-	// strength scale. Integer-only -- this runs in the USB OUT callback (ISR context), so no float math.
+	// strength scale. Integer-only: host OUTPUT paths can invoke this from TinyUSB callback context, while
+	// loop-context test/keepalive paths use the same shaping without introducing float math.
 	{
 		uint32_t l = lowFreq, h = highFreq, t;
 		switch (g_rumbleStyle) {
@@ -368,51 +453,31 @@ bool hapticSteamRumble(uint16_t lowFreq, uint16_t highFreq, uint8_t slot)
 		highFreq = (h > 0xFFFF) ? 0xFFFF : (uint16_t)h;
 	}
 	bool on = lowFreq || highFreq;
-	// per-type rumble disable: drop ON commands; zero/stop still pass to clear any queued relay
-	if (on && !g_rumble)
-		return false;
+	// If rumble is disabled while active, turn the next ON request into a stop.
+	if (on && !g_rumble) {
+		lowFreq = highFreq = 0;
+		on = false;
+	}
 	// Per-slot settle gate (the per-slot reconnect block + link-up check). 0x82 haptics in Steam mode use the
 	// same gate; for XInput, the host only sends a stream while a controller is connected, so this also doubles
 	// as "no controller here, no relay".
 	if (on && haptic82Blocked(slot))
 		return false;
-	if (!on && !hapticLinkUp(slot))
+	if (!on && !hapticLinkUp(slot)) {
+		g_rumble80Low[slot] = 0;
+		g_rumble80High[slot] = 0;
+		g_rumble80On[slot] = false;
+		g_rumble80Ms[slot] = 0;
 		return false;
+	}
 
-	// SDL's current Steam/Triton structs define output report 0x80 as:
-	//   type, uint16 intensity, {uint16 speed, int8 gain} left/right.
-	// We map conventional gamepad low/high-frequency motors to left/right speeds and use max as intensity.
-	uint16_t intensity = lowFreq > highFreq ? lowFreq : highFreq;
-	uint8_t p[9];
-
-	// haptic_type_t::HAPTIC_TYPE_RUMBLE; 0 is the off/zero report
-	p[0] = on ? 0x04 : 0x00;
-	p[1] = (uint8_t)(intensity & 0xFF);
-	p[2] = (uint8_t)(intensity >> 8);
-	p[3] = (uint8_t)(lowFreq & 0xFF);
-	p[4] = (uint8_t)(lowFreq >> 8);
-	p[5] = 0;
-	p[6] = (uint8_t)(highFreq & 0xFF);
-	p[7] = (uint8_t)(highFreq >> 8);
-	p[8] = 0;
-	// The RF relay is NO-ACK -- any single frame can be lost. For an ON that's self-healing: a continuous
-	// stream of rumble commands follows during play, so a dropped frame is corrected microseconds later. A
-	// STOP is the dangerous one: if the host's FINAL zero (game/stream quit) -- or the watchdog's stop below
-	// -- is the last frame on the wire and it's lost, the controller stays latched rumbling with nothing left
-	// to correct it (the reported "constant rumble that didn't stop after closing GFN", cleared only by a
-	// replug). And once we optimistically mark g_rumble80On=false, the watchdog can't rescue it either. So
-	// relay a STOP as a short BURST: rfConnFlushRelay drains one ring entry per poll cycle, so N copies go out
-	// on successive cycles (~4ms apart) -- temporal diversity that a single-frame RF loss can't wipe out.
-	// Bursting only the on->off transition leaves steady-state (repeated-ON / repeated-OFF) traffic unchanged.
 	bool stopping = !on && g_rumble80On[slot];
-	uint8_t reps = stopping ? RUMBLE_STOP_REPS : 1;
-	bool queued = false;
-	for (uint8_t i = 0; i < reps; i++)
-		if (relayEnqueue(0x80, p, sizeof p, true, slot))
-			queued = true;
-	if (!queued)
+	if (!hapticQueueRumble80(lowFreq, highFreq, slot, stopping))
 		return false;
-	g_rumble80Ms[slot] = millis();
+
+	// Save already-shaped/scaled values; keepalive must not apply shaping twice.
+	g_rumble80Low[slot] = lowFreq;
+	g_rumble80High[slot] = highFreq;
 	g_rumble80On[slot] = on;
 	return true;
 }
@@ -420,6 +485,193 @@ bool hapticSteamRumble(uint16_t lowFreq, uint16_t highFreq, uint8_t slot)
 // haptics broadcast to all connected slots (slot 0xFF); the stop frame is broadcast too (a stuck latch can
 // affect any controller, and the haptic-engine clear-re-init is settings-only so it's harmless on healthy
 // ones).
+// Hardware-accepted production contract, derived from official Valve/Proteus RF captures and T4.2 testing:
+//   * USB OUTPUT 0x87/0x88/0x89 body is exactly 63 bytes.
+//   * RF uses E3 40 05 <rid> <63-byte body>; that E3 is the poll turn and returns normal F1.
+//   * Short ordinary relay TLVs are appended behind PCM up to the existing 96-byte RF payload ceiling.
+//   * During a live PCM session, a temporarily empty PCM queue does not allow a short relay to steal the turn;
+//     it waits through a 24-ms grace for the next PCM body. Oversized relay heads still escape standalone.
+#define PCM_BODY_LEN 63u
+#define PCM_RF_PAYLOAD_LEN 67u
+#define PCM_RF_MAX_PAYLOAD 96u
+#define PCM_QUEUE_LEN 8u
+#define PCM_ACTIVE_GRACE_MS 24u
+struct PcmMsg {
+	uint8_t rid;
+	uint8_t body[PCM_BODY_LEN];
+};
+static PcmMsg g_pcmQ[NSLOT][PCM_QUEUE_LEN];
+static volatile uint8_t g_pcmHead[NSLOT] = { 0 }, g_pcmTail[NSLOT] = { 0 };
+static uint32_t g_pcmLastUsbMs[NSLOT] = { 0 };
+static inline uint8_t pcmNext(uint8_t v)
+{
+	return (uint8_t)((v + 1u) % PCM_QUEUE_LEN);
+}
+bool pcmEnqueue(uint8_t rid, const uint8_t *payload, uint16_t plen,
+		uint8_t slot)
+{
+	if (slot >= NSLOT || rid < 0x87 || rid > 0x89 || !payload ||
+	    plen != PCM_BODY_LEN)
+		return false;
+	uint32_t now = millis();
+	uint32_t pm = __get_PRIMASK();
+	__disable_irq();
+	uint8_t h = g_pcmHead[slot], nx = pcmNext(h);
+	if (nx == g_pcmTail[slot])
+		g_pcmTail[slot] = pcmNext(g_pcmTail[slot]);
+	g_pcmQ[slot][h].rid = rid;
+	memcpy(g_pcmQ[slot][h].body, payload, PCM_BODY_LEN);
+	g_pcmHead[slot] = nx;
+	g_pcmLastUsbMs[slot] = now;
+	__set_PRIMASK(pm);
+	return true;
+}
+bool pcmSessionActive(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return false;
+	uint32_t pm = __get_PRIMASK();
+	__disable_irq();
+	uint32_t last = g_pcmLastUsbMs[slot];
+	bool pending = (g_pcmTail[slot] != g_pcmHead[slot]);
+	__set_PRIMASK(pm);
+	if (pending)
+		return true;
+	return last != 0u && (uint32_t)(millis() - last) <= PCM_ACTIVE_GRACE_MS;
+}
+bool pcmAnyActive(void)
+{
+	for (uint8_t s = 0; s < NSLOT; s++)
+		if (pcmSessionActive(s))
+			return true;
+	return false;
+}
+bool pcmRelayPending(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return false;
+	uint32_t pm = __get_PRIMASK();
+	__disable_irq();
+	bool pending = (g_rqTail[slot] != g_rqHead[slot]);
+	__set_PRIMASK(pm);
+	return pending;
+}
+bool pcmRelayNeedsStandalone(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return false;
+	bool needStandalone = false;
+	uint32_t pm = __get_PRIMASK();
+	__disable_irq();
+	uint8_t guard = RELAY_QLEN + 1;
+	while (g_rqTail[slot] != g_rqHead[slot]) {
+		if (!guard--) {
+			g_rqHead[slot] = g_rqTail[slot] = 0;
+			g_ringFault++;
+			faultDiagTrace(FR_RINGF, g_ringFault);
+			break;
+		}
+		RelayMsg &m = g_rq[slot][g_rqTail[slot]];
+		if (!m.rid) {
+			g_rqTail[slot] = rqNext(g_rqTail[slot]);
+			continue;
+		}
+		// Feature queries and TURN_OFF_CONTROLLER are transaction/status boundaries.
+		if (m.expectReply ||
+		    (!m.isHaptic && m.rid == IBEX_CMD_TURN_OFF_CONTROLLER)) {
+			needStandalone = true;
+			break;
+		}
+		uint8_t rl = m.len;
+		if (rl > RELAY_MAXP)
+			rl = RELAY_MAXP;
+		uint8_t need = (uint8_t)((m.isHaptic ? 3u : 4u) + rl);
+		needStandalone =
+			((uint16_t)PCM_RF_PAYLOAD_LEN + (uint16_t)need) >
+			(uint16_t)PCM_RF_MAX_PAYLOAD;
+		break;
+	}
+	__set_PRIMASK(pm);
+	return needStandalone;
+}
+static bool pcmAppendRelayLocked(uint8_t cur, uint8_t *p, uint8_t *plen)
+{
+	uint8_t guard = RELAY_QLEN + 1;
+	while (g_rqTail[cur] != g_rqHead[cur]) {
+		if (!guard--) {
+			g_rqHead[cur] = g_rqTail[cur] = 0;
+			g_ringFault++;
+			faultDiagTrace(FR_RINGF, g_ringFault);
+			return false;
+		}
+		RelayMsg &m = g_rq[cur][g_rqTail[cur]];
+		if (!m.rid) {
+			g_rqTail[cur] = rqNext(g_rqTail[cur]);
+			continue;
+		}
+		if (m.expectReply ||
+		    (!m.isHaptic && m.rid == IBEX_CMD_TURN_OFF_CONTROLLER))
+			return false; // status/transaction boundary
+		uint8_t rl = m.len;
+		if (rl > RELAY_MAXP)
+			rl = RELAY_MAXP;
+		uint8_t need = (uint8_t)((m.isHaptic ? 3u : 4u) + rl);
+		if ((uint16_t)(*plen) + need > PCM_RF_MAX_PAYLOAD)
+			return false;
+		g_rqTail[cur] = rqNext(g_rqTail[cur]);
+		uint8_t pos = *plen;
+		if (!m.isHaptic) {
+			p[pos++] = (uint8_t)(2u + rl);
+			p[pos++] = 0x01;
+			p[pos++] = m.rid;
+			p[pos++] = rl;
+		} else {
+			p[pos++] = (uint8_t)(1u + rl);
+			p[pos++] = 0x05;
+			p[pos++] = m.rid;
+		}
+		if (rl) {
+			memcpy(p + pos, m.data, rl);
+			pos = (uint8_t)(pos + rl);
+		}
+		*plen = pos;
+		return true;
+	}
+	return false;
+}
+bool rfConnFlushPcm(uint8_t ch, uint8_t s1, uint8_t *rxOut)
+{
+	int cur = (g_curSlot >= 0 && g_curSlot < NSLOT) ? g_curSlot : 0;
+	PcmMsg msg;
+	bool have = false;
+	uint32_t pm = __get_PRIMASK();
+	__disable_irq();
+	if (g_pcmTail[cur] != g_pcmHead[cur]) {
+		msg = g_pcmQ[cur][g_pcmTail[cur]];
+		g_pcmTail[cur] = pcmNext(g_pcmTail[cur]);
+		have = true;
+	}
+	__set_PRIMASK(pm);
+	if (!have)
+		return false;
+	uint8_t p[PCM_RF_MAX_PAYLOAD];
+	uint8_t plen = PCM_RF_PAYLOAD_LEN;
+	p[0] = 0xE3;
+	p[1] = 0x40;
+	p[2] = 0x05;
+	p[3] = msg.rid;
+	memcpy(p + 4, msg.body, PCM_BODY_LEN);
+	pm = __get_PRIMASK();
+	__disable_irq();
+	while (pcmAppendRelayLocked((uint8_t)cur, p, &plen)) {
+	}
+	__set_PRIMASK(pm);
+	uint8_t rx = rfConnTx(ch, s1, p, plen, 0);
+	if (rxOut)
+		*rxOut = rx;
+	hapLogAdd(0xFC, msg.rid, msg.body, 16);
+	return true;
+}
 // Stability-test keepalive: while g_stabTest, buzz every connected controller for ~150ms once per 10s so an
 // unattended uptime measurement isn't ended by a controller idle-sleeping. Toggled by WebUSB cmd 0x0F; the
 // panel times uptime-until-reset. Reboots clear g_stabTest (the panel re-arms it on reconnect).
@@ -467,52 +719,1162 @@ void rfConnQueueHapticRelay()
 	}
 }
 // rfConnFlushRelay(ch, s1): drain one entry from the current slot's relay queue and TX it. Each slot's queue
-// is independent, so each controller only sees its own commands. With N connected slots the per-slot relay
-// rate is 1/N of the per-cycle rate; sustained buzz streams are still 1 packet/cycle/slot.
+// is independent, so each controller only sees its own commands. Response-bearing feature commands execute
+// in a standalone RF turn and retain one in-flight generation until its
+// matching Type-4 response is consumed. Retrieval is ordered around ordinary E3
+// polls so stale prior-command responses can drain without extending the 80-ms
+// transaction deadline. Bounded replay paths cover: delayed retrieval, one deferred
+// query retry, one deferred initial-fetch retry, stale-response replay, a no-Type4
+// grace replay, one repeated-stale replay, silence recovery after either replay,
+// same-PID zero-RX retries for the terminal replay calls, and one evidence-gated
+// terminal FETCH. Every replay is generation-owned and capped so no path can loop.
+static volatile uint8_t g_featureFetchPhase[NSLOT] = { 0 };
+static volatile uint8_t g_featureTurnConsumed[NSLOT] = { 0 };
+// Phase-ownership latch: one generation may authorize one existing poll.
+static volatile uint32_t g_featureLatePollAuthGeneration[NSLOT] = { 0 };
+// Same-generation pre-split authorization only; not a response cache or retry budget.
+static volatile uint32_t g_featureCoframeGeneration[NSLOT] = { 0 };
+
+// Cross-command quiescence begins only after a genuinely RF-armed generation is
+// consumed. Unqueued fallback generations do not start this quiet window.
+static volatile uint32_t g_featureLastArmedGeneration[NSLOT] = { 0 };
+static volatile uint8_t g_featureLastArmedCmd[NSLOT] = { 0 };
+static volatile uint32_t g_featureObservedConsumedGeneration[NSLOT] = { 0 };
+static volatile uint8_t g_featureLastConsumedCmd[NSLOT] = { 0 };
+static volatile uint32_t g_featureQuiesceStartMs[NSLOT] = { 0 };
+
+// The original query arm time bounds the single delayed retrieval probe.
+static volatile uint32_t g_featureQueryArmMs[NSLOT] = { 0 };
+static volatile uint32_t g_featureDelayedFetchGeneration[NSLOT] = { 0 };
+
+// A query with zero RX may retry once after exactly one scheduler opportunity.
+// Retain the original payload and S1; clear the latch before retry I/O.
+static uint32_t g_featureDeferredQueryRetryGeneration[NSLOT] = { 0 };
+static uint8_t g_featureDeferredQueryRetryLen[NSLOT] = { 0 };
+static uint8_t g_featureDeferredQueryRetryWaitTurns[NSLOT] = { 0 };
+static uint8_t g_featureDeferredQueryRetryPayload[NSLOT][80] = { { 0 } };
+
+// The normal initial FETCH may retry once after one scheduler opportunity.
+// Delayed retrieval probes do not use this retry state.
+static uint32_t g_featureDeferredFetchRetryGeneration[NSLOT] = { 0 };
+static uint8_t g_featureDeferredFetchRetryWaitTurns[NSLOT] = { 0 };
+static uint8_t g_featureDeferredFetchRetryPayload[NSLOT][4] = { { 0 } };
+
+// Cache the exact active query so a structurally valid stale Type-4 mismatch can
+// authorize one replay of the current generation.
+static uint32_t g_featureQuerySnapshotGeneration[NSLOT] = { 0 };
+static uint8_t g_featureQuerySnapshotLen[NSLOT] = { 0 };
+static uint8_t g_featureQuerySnapshotPayload[NSLOT][80] = { { 0 } };
+static uint32_t g_featureStaleReplayGeneration[NSLOT] = { 0 };
+static uint32_t g_featureStaleReplayUsedGeneration[NSLOT] = { 0 };
+
+// If the delayed probe still yields no Type-4, allow one ordinary grace poll
+// before one exact current-query replay.
+static uint8_t g_featureDelayedProbeSawType4[NSLOT] = { 0 };
+static uint32_t g_featureNoType4GraceGeneration[NSLOT] = { 0 };
+static uint8_t g_featureNoType4GraceState[NSLOT] = { 0 };
+static uint32_t g_featureNoType4ReplayUsedGeneration[NSLOT] = { 0 };
+
+// A new exact stale mismatch observed after the first stale replay can authorize
+// one additional bounded replay for the same generation.
+static uint32_t g_featureRepeatStaleGeneration[NSLOT] = { 0 };
+static uint32_t g_featureRepeatStaleUsedGeneration[NSLOT] = { 0 };
+
+// After a stale replay, track whether any Type-4 arrives. Pure silence may
+// authorize one mutually-exclusive recovery replay.
+static uint32_t g_featurePostStaleSilenceTrackGeneration[NSLOT] = { 0 };
+static uint8_t g_featurePostStaleSilenceSawType4[NSLOT] = { 0 };
+static uint32_t g_featurePostStaleSilenceReplayGeneration[NSLOT] = { 0 };
+static uint32_t g_featurePostStaleSilenceUsedGeneration[NSLOT] = { 0 };
+static void featureClearPostStaleSilenceTrack(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featurePostStaleSilenceTrackGeneration[slot] = 0u;
+	g_featurePostStaleSilenceSawType4[slot] = 0u;
+}
+static void featureClearPostStaleSilenceReplay(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featurePostStaleSilenceReplayGeneration[slot] = 0u;
+}
+static void featureResetPostStaleSilence(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featurePostStaleSilenceUsedGeneration[slot] = 0u;
+	featureClearPostStaleSilenceTrack(slot);
+	featureClearPostStaleSilenceReplay(slot);
+}
+
+// Once the no-Type4 replay is spent, any later Type-4 invalidates the pure-silence
+// premise used by the terminal recovery branch.
+static uint32_t g_featurePostNoType4Type4SeenGeneration[NSLOT] = { 0 };
+// Track no-Type4 replay evidence and ownership of the one terminal retrieval.
+static volatile uint32_t g_featureNoType4ReplayActiveGeneration[NSLOT] = { 0 };
+static volatile uint32_t g_featureNoType4CurrentResponseGeneration[NSLOT] = {
+	0
+};
+static volatile uint32_t g_featureTerminalFetchGeneration[NSLOT] = { 0 };
+static volatile uint32_t g_featureTerminalFetchUsedGeneration[NSLOT] = { 0 };
+static uint32_t g_featurePostNoType4ReplayGeneration[NSLOT] = { 0 };
+static uint32_t g_featurePostNoType4ReplayUsedGeneration[NSLOT] = { 0 };
+static void featureClearPostNoType4Replay(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featurePostNoType4ReplayGeneration[slot] = 0u;
+}
+static void featureClearTerminalFetchEvidence(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featureNoType4ReplayActiveGeneration[slot] = 0u;
+	g_featureNoType4CurrentResponseGeneration[slot] = 0u;
+	g_featureTerminalFetchGeneration[slot] = 0u;
+}
+static void featureResetPostNoType4(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featurePostNoType4Type4SeenGeneration[slot] = 0u;
+	g_featurePostNoType4ReplayUsedGeneration[slot] = 0u;
+	featureClearPostNoType4Replay(slot);
+}
+
+// use arms one post-replay stale recovery. Any subsequent Type4 before service cancels it.
+static uint32_t g_featurePostNoType4StaleGeneration[NSLOT] = { 0 };
+static uint32_t g_featurePostNoType4StaleUsedGeneration[NSLOT] = { 0 };
+static void featureClearPostNoType4StaleReplay(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featurePostNoType4StaleGeneration[slot] = 0u;
+}
+static void featureResetPostNoType4StaleReplay(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featurePostNoType4StaleUsedGeneration[slot] = 0u;
+	featureClearPostNoType4StaleReplay(slot);
+}
+
+static void featureClearRepeatStaleReplay(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featureRepeatStaleGeneration[slot] = 0u;
+}
+static void featureResetRepeatStaleReplay(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featureRepeatStaleUsedGeneration[slot] = 0u;
+	featureClearRepeatStaleReplay(slot);
+}
+
+static void featureClearNoType4Grace(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featureNoType4GraceGeneration[slot] = 0u;
+	g_featureNoType4GraceState[slot] = 0u;
+}
+static void featureResetNoType4Grace(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featureDelayedProbeSawType4[slot] = 0u;
+	g_featureNoType4ReplayUsedGeneration[slot] = 0u;
+	featureClearNoType4Grace(slot);
+}
+
+static void featureClearStaleQueryReplay(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featureStaleReplayGeneration[slot] = 0u;
+}
+static void featureResetQuerySnapshot(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featureQuerySnapshotGeneration[slot] = 0u;
+	g_featureQuerySnapshotLen[slot] = 0u;
+	memset(g_featureQuerySnapshotPayload[slot], 0,
+	       sizeof g_featureQuerySnapshotPayload[slot]);
+	g_featureStaleReplayUsedGeneration[slot] = 0u;
+	featureClearStaleQueryReplay(slot);
+}
+
+static void featureClearDeferredFetchRetry(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featureDeferredFetchRetryGeneration[slot] = 0u;
+	g_featureDeferredFetchRetryWaitTurns[slot] = 0u;
+	memset(g_featureDeferredFetchRetryPayload[slot], 0,
+	       sizeof g_featureDeferredFetchRetryPayload[slot]);
+}
+
+static void featureClearDeferredQueryRetry(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	g_featureDeferredQueryRetryGeneration[slot] = 0u;
+	g_featureDeferredQueryRetryLen[slot] = 0u;
+	g_featureDeferredQueryRetryWaitTurns[slot] = 0u;
+}
+
+static void featureObserveConsumedGeneration(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	Slot &S = g_slot[slot];
+	uint32_t consumed = S.queryConsumedGeneration;
+	if (consumed == g_featureObservedConsumedGeneration[slot])
+		return;
+	g_featureObservedConsumedGeneration[slot] = consumed;
+	// Only an RF-armed generation establishes the quiet-window source.
+	if (consumed != 0u && consumed == g_featureLastArmedGeneration[slot]) {
+		g_featureLastConsumedCmd[slot] = g_featureLastArmedCmd[slot];
+		g_featureQuiesceStartMs[slot] = millis();
+	}
+}
+void rfConnFeatureObserveType4(uint8_t slot, uint8_t seenCmd, uint8_t reason)
+{
+	// Stale replay is deliberately narrow: only an exact, structurally
+	// valid stale-command mismatch may arm one late exact current-query replay.
+	if (slot >= NSLOT || reason != 0x20u)
+		return;
+	Slot &S = g_slot[slot];
+	uint32_t gen = S.pendingQueryGeneration;
+	if (!S.pendingQueryCmd || !gen || S.pendingQueryCmd == seenCmd)
+		return;
+	if (g_featureQuerySnapshotGeneration[slot] != gen ||
+	    !g_featureQuerySnapshotLen[slot])
+		return;
+	if (g_featureStaleReplayUsedGeneration[slot] == gen ||
+	    g_featureStaleReplayGeneration[slot] == gen)
+		return;
+	g_featureStaleReplayGeneration[slot] = gen;
+}
+
+void rfConnFeatureObserveType4DuringDelayedProbe(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	uint32_t gen = g_slot[slot].pendingQueryGeneration;
+	if (!gen)
+		return;
+	// Any Type4 observed during the delayed probe invalidates the no-Type4
+	// premise. Current responses complete normally; stale responses are handled separately.
+	if (g_featureDelayedFetchGeneration[slot] == gen)
+		g_featureDelayedProbeSawType4[slot] = 1u;
+	if (g_featureNoType4GraceGeneration[slot] == gen)
+		featureClearNoType4Grace(slot);
+}
+
+void rfConnFeatureObserveType4AfterStaleReplay(uint8_t slot, uint8_t seenCmd,
+					       uint8_t reason)
+{
+	// A repeated-stale replay requires a new structurally valid mismatch after
+	// the first late-query replay budget has already been consumed.
+	if (slot >= NSLOT || reason != 0x20u)
+		return;
+	Slot &S = g_slot[slot];
+	uint32_t gen = S.pendingQueryGeneration;
+	if (!S.pendingQueryCmd || !gen || S.pendingQueryCmd == seenCmd)
+		return;
+	if (g_featureQuerySnapshotGeneration[slot] != gen ||
+	    !g_featureQuerySnapshotLen[slot])
+		return;
+	if (g_featureStaleReplayUsedGeneration[slot] != gen)
+		return;
+	if (g_featureNoType4ReplayUsedGeneration[slot] == gen)
+		return;
+	if (g_featureRepeatStaleUsedGeneration[slot] == gen ||
+	    g_featureRepeatStaleGeneration[slot] == gen)
+		return;
+	g_featureRepeatStaleGeneration[slot] = gen;
+}
+
+void rfConnFeatureObserveType4DuringPostStaleSilence(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	Slot &S = g_slot[slot];
+	uint32_t gen = S.pendingQueryGeneration;
+	if (!S.pendingQueryCmd || !gen)
+		return;
+	// Any Type4 after a stale-query replay destroys the pure-silence premise.
+	if (g_featurePostStaleSilenceTrackGeneration[slot] == gen)
+		g_featurePostStaleSilenceSawType4[slot] = 1u;
+	if (g_featurePostStaleSilenceReplayGeneration[slot] == gen)
+		featureClearPostStaleSilenceReplay(slot);
+}
+
+void rfConnFeatureObserveType4AfterNoType4Replay(uint8_t slot, uint8_t seenCmd,
+						 uint8_t reason)
+{
+	if (slot >= NSLOT)
+		return;
+	Slot &S = g_slot[slot];
+	uint32_t gen = S.pendingQueryGeneration;
+	if (!S.pendingQueryCmd || !gen)
+		return;
+	// Cache evidence only, never response bytes: a no-Type4 replay must be active
+	// inside its RF call, with a FETCH-pending current command.
+	if (g_featureNoType4ReplayActiveGeneration[slot] == gen &&
+	    reason == 0x80u && seenCmd == S.pendingQueryCmd)
+		g_featureNoType4CurrentResponseGeneration[slot] = gen;
+	// Once the no-Type4 replay starts, any later Type4 destroys the pure-silence
+	// premise and cancels a pending silence-based replay.
+	if (g_featureNoType4ReplayUsedGeneration[slot] == gen) {
+		g_featurePostNoType4Type4SeenGeneration[slot] = gen;
+		if (g_featurePostNoType4ReplayGeneration[slot] == gen)
+			featureClearPostNoType4Replay(slot);
+	}
+}
+
+void rfConnFeatureObserveType4ForPostNoType4Stale(uint8_t slot, uint8_t seenCmd,
+						  uint8_t reason)
+{
+	if (slot >= NSLOT)
+		return;
+	Slot &S = g_slot[slot];
+	uint32_t gen = S.pendingQueryGeneration;
+	if (!S.pendingQueryCmd || !gen)
+		return;
+	if (g_featureNoType4ReplayUsedGeneration[slot] != gen)
+		return; // dedicated no-Type4 replay ownership
+	if (g_featureTerminalFetchUsedGeneration[slot] == gen)
+		return;
+	// Once the post-replay stale branch is armed, any later Type4 cancels it.
+	if (g_featurePostNoType4StaleGeneration[slot] == gen) {
+		featureClearPostNoType4StaleReplay(slot);
+		return;
+	}
+	if ((reason & 0x20u) == 0u || seenCmd == S.pendingQueryCmd)
+		return;
+	if (g_featureQuerySnapshotGeneration[slot] != gen ||
+	    !g_featureQuerySnapshotLen[slot])
+		return;
+	// Do not create another recovery branch after a silence replay or after any
+	// stale-response recovery branch has already consumed this generation.
+	if (g_featurePostNoType4ReplayUsedGeneration[slot] == gen ||
+	    g_featurePostNoType4StaleUsedGeneration[slot] == gen ||
+	    g_featurePostStaleSilenceUsedGeneration[slot] == gen ||
+	    g_featureRepeatStaleUsedGeneration[slot] == gen)
+		return;
+	g_featurePostNoType4StaleGeneration[slot] = gen;
+	// Explicit stale handling owns this branch; cancel any pending pure-silence recovery.
+	if (g_featurePostNoType4ReplayGeneration[slot] == gen)
+		featureClearPostNoType4Replay(slot);
+}
+
+uint8_t rfConnFeatureFetchPhase(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return 0;
+	if (!g_slot[slot].pendingQueryCmd) {
+		g_featureFetchPhase[slot] = 0;
+		return 0;
+	}
+	return g_featureFetchPhase[slot];
+}
+bool rfConnFeatureFetchPending(uint8_t slot)
+{
+	uint8_t p = rfConnFeatureFetchPhase(slot);
+	return p == FEATURE_FETCH_WAIT_POLL || p == FEATURE_FETCH_ELIGIBLE;
+}
+bool rfConnFeatureFetchEligible(uint8_t slot)
+{
+	return rfConnFeatureFetchPhase(slot) == FEATURE_FETCH_ELIGIBLE;
+}
+bool rfConnFeatureForceOrdinaryPoll(uint8_t slot)
+{
+	// The wait slot and deferred query retry own the first two opportunities after the initial query transmission.
+	if (slot < NSLOT && g_featureDeferredQueryRetryGeneration[slot] != 0u)
+		return false;
+	// Suppress the forced follow-up poll while the initial FETCH wait/retry latch owns
+	// the next two scheduler opportunities.
+	if (slot < NSLOT && g_featureDeferredFetchRetryGeneration[slot] != 0u)
+		return false;
+	// A stale-triggered current-query replay owns the next scheduler RF opportunity.
+	if (slot < NSLOT && g_featureStaleReplayGeneration[slot] != 0u)
+		return false;
+	// A repeated-stale replay owns the next scheduler RF opportunity.
+	if (slot < NSLOT && g_featureRepeatStaleGeneration[slot] != 0u)
+		return false;
+	if (slot < NSLOT &&
+	    g_featurePostStaleSilenceReplayGeneration[slot] != 0u)
+		return false;
+	if (slot < NSLOT && g_featurePostNoType4StaleGeneration[slot] != 0u)
+		return false;
+	if (slot < NSLOT && g_featurePostNoType4ReplayGeneration[slot] != 0u)
+		return false;
+	if (slot < NSLOT && g_featureTerminalFetchGeneration[slot] != 0u)
+		return false;
+	uint8_t p = rfConnFeatureFetchPhase(slot);
+	return p == FEATURE_FETCH_WAIT_POLL || p == FEATURE_FETCH_FOLLOWUP_POLL;
+}
+bool rfConnFeatureCoframeWaitPollAuthBegin(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return false;
+	Slot &S = g_slot[slot];
+	uint32_t gen = g_featureCoframeGeneration[slot];
+	if (!gen || !S.pendingQueryCmd || S.pendingQueryGeneration != gen)
+		return false;
+	if (g_featureFetchPhase[slot] != FEATURE_FETCH_WAIT_POLL)
+		return false;
+	if (!S.pendingQueryDeadlineMs ||
+	    (int32_t)(millis() - S.pendingQueryDeadlineMs) >= 0)
+		return false;
+	g_featureFetchPhase[slot] = FEATURE_FETCH_FOLLOWUP_POLL;
+
+	return true;
+}
+
+void rfConnFeatureCoframeWaitPollAuthEnd(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	uint32_t gen = g_featureCoframeGeneration[slot];
+	Slot &S = g_slot[slot];
+
+	g_featureCoframeGeneration[slot] = 0u;
+	if (!S.pendingQueryCmd) {
+		rfConnFeaturePollCompleted(slot);
+		return;
+	}
+	if (gen && S.pendingQueryGeneration == gen) {
+		// Exactly the result of one unresolved WAIT_POLL ordinary poll:
+		// split FETCH becomes eligible on the next existing feature turn.
+		g_featureFetchPhase[slot] = FEATURE_FETCH_ELIGIBLE;
+
+		return;
+	}
+	g_featureFetchPhase[slot] = 0u; // generation changed: fail closed
+}
+
+bool rfConnFeatureLateWaitPollAuthBegin(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return false;
+	Slot &S = g_slot[slot];
+	if (!S.pendingQueryCmd || !S.pendingQueryGeneration)
+		return false;
+	uint32_t gen = S.pendingQueryGeneration;
+	if (g_featureNoType4ReplayUsedGeneration[slot] != gen)
+		return false;
+	if (g_featureLatePollAuthGeneration[slot] == gen)
+		return false;
+	if (g_featureFetchPhase[slot] != FEATURE_FETCH_WAIT_POLL)
+		return false;
+	if (!S.pendingQueryDeadlineMs ||
+	    (int32_t)(millis() - S.pendingQueryDeadlineMs) >= 0)
+		return false;
+	g_featureLatePollAuthGeneration[slot] = gen;
+	// Phase-only authorization: the existing ordinary poll remains the only RF action.
+	g_featureFetchPhase[slot] = FEATURE_FETCH_FOLLOWUP_POLL;
+
+	return true;
+}
+
+void rfConnFeatureLateWaitPollAuthEnd(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	uint32_t gen = g_featureLatePollAuthGeneration[slot];
+	if (!gen) {
+		rfConnFeaturePollCompleted(slot);
+		return;
+	}
+	Slot &S = g_slot[slot];
+
+	g_featureLatePollAuthGeneration[slot] = 0u;
+	if (!S.pendingQueryCmd) {
+		// Preserve the normal completed-query cleanup.
+		rfConnFeaturePollCompleted(slot);
+		return;
+	}
+	if (S.pendingQueryGeneration == gen) {
+		// This is exactly the state rfConnFeaturePollCompleted() would
+		// produce after a WAIT_POLL ordinary poll that did not complete the query.
+		g_featureFetchPhase[slot] = FEATURE_FETCH_ELIGIBLE;
+
+		return;
+	}
+	// Generation changed unexpectedly: fail closed rather than authorizing a new owner.
+	g_featureFetchPhase[slot] = 0u;
+}
+
+void rfConnFeaturePollCompleted(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	uint8_t completedPhase = g_featureFetchPhase[slot];
+	if (!g_slot[slot].pendingQueryCmd) {
+		g_featureLatePollAuthGeneration[slot] = 0u;
+		g_featureCoframeGeneration[slot] = 0u;
+		g_featureFetchPhase[slot] = 0;
+		featureClearNoType4Grace(slot);
+		g_featureDelayedProbeSawType4[slot] = 0u;
+		featureClearPostStaleSilenceTrack(slot);
+		featureClearPostStaleSilenceReplay(slot);
+		g_featurePostNoType4Type4SeenGeneration[slot] = 0u;
+		featureClearPostNoType4Replay(slot);
+		featureResetPostNoType4StaleReplay(slot);
+		featureClearTerminalFetchEvidence(slot);
+		return;
+	}
+	uint32_t gen = g_slot[slot].pendingQueryGeneration;
+	if (completedPhase == FEATURE_FETCH_WAIT_POLL)
+		g_featureFetchPhase[slot] = FEATURE_FETCH_ELIGIBLE;
+	else if (completedPhase == FEATURE_FETCH_FOLLOWUP_POLL)
+		g_featureFetchPhase[slot] = 0;
+
+	// Only the post-poll belonging to the already-spent delayed probe may arm a
+	// no-Type4 replay, and only if no Type4 was observed during that probe/poll.
+	if (completedPhase == FEATURE_FETCH_FOLLOWUP_POLL &&
+	    g_featureDelayedFetchGeneration[slot] == gen) {
+		bool arm = !g_featureDelayedProbeSawType4[slot] &&
+			   g_featureDelayedFetchGeneration[slot] == gen &&
+			   g_featureStaleReplayGeneration[slot] != gen &&
+			   g_featureStaleReplayUsedGeneration[slot] != gen &&
+			   g_featureNoType4ReplayUsedGeneration[slot] != gen;
+		g_featureDelayedProbeSawType4[slot] = 0u;
+		if (arm) {
+			g_featureNoType4GraceGeneration[slot] = gen;
+			g_featureNoType4GraceState[slot] = 1u;
+		}
+	} else if (completedPhase == 0u &&
+		   g_featureNoType4GraceGeneration[slot] == gen &&
+		   g_featureNoType4GraceState[slot] == 1u) {
+		// The explicitly allowed ordinary grace poll completed without any Type4.
+		g_featureNoType4GraceState[slot] = 2u;
+	}
+
+	if (completedPhase == FEATURE_FETCH_FOLLOWUP_POLL &&
+	    g_featurePostStaleSilenceTrackGeneration[slot] == gen) {
+		bool armPostStaleSilence =
+			!g_featurePostStaleSilenceSawType4[slot] &&
+			g_featureStaleReplayUsedGeneration[slot] == gen &&
+			g_featureNoType4ReplayUsedGeneration[slot] != gen &&
+			g_featureRepeatStaleGeneration[slot] != gen &&
+			g_featureRepeatStaleUsedGeneration[slot] != gen &&
+			g_featurePostStaleSilenceUsedGeneration[slot] != gen;
+		featureClearPostStaleSilenceTrack(slot);
+		if (armPostStaleSilence) {
+			g_featurePostStaleSilenceReplayGeneration[slot] = gen;
+		}
+	}
+
+	// The no-Type4 replay records ownership before RF I/O and also consumes the
+	// shared first late-query replay budget. Its dedicated used-generation marker
+	// is authoritative here. A completed follow-up poll with no later Type4 and no
+	// prior silence recovery proves the terminal-silence condition.
+	if (completedPhase == FEATURE_FETCH_FOLLOWUP_POLL &&
+	    g_featureNoType4ReplayUsedGeneration[slot] == gen) {
+		bool armPostNoType4Silence =
+			g_featurePostNoType4Type4SeenGeneration[slot] != gen &&
+			g_featurePostNoType4ReplayUsedGeneration[slot] != gen &&
+			g_featurePostNoType4ReplayGeneration[slot] != gen &&
+			g_featurePostNoType4StaleGeneration[slot] != gen &&
+			g_featurePostNoType4StaleUsedGeneration[slot] != gen &&
+			g_featurePostStaleSilenceReplayGeneration[slot] !=
+				gen &&
+			g_featurePostStaleSilenceUsedGeneration[slot] != gen &&
+			g_featureRepeatStaleGeneration[slot] != gen &&
+			g_featureRepeatStaleUsedGeneration[slot] != gen;
+		if (armPostNoType4Silence) {
+			g_featurePostNoType4ReplayGeneration[slot] = gen;
+		}
+
+		// A terminal FETCH may be armed only after the full post-replay poll cycle
+		// fails to accept the generation and exact-current FETCH evidence was seen.
+		if (completedPhase == FEATURE_FETCH_FOLLOWUP_POLL &&
+		    g_featureNoType4ReplayUsedGeneration[slot] == gen &&
+		    g_featureNoType4CurrentResponseGeneration[slot] == gen &&
+		    g_featureTerminalFetchGeneration[slot] != gen &&
+		    g_featureTerminalFetchUsedGeneration[slot] != gen &&
+		    g_slot[slot].pendingQueryCmd &&
+		    g_slot[slot].pendingQueryGeneration == gen &&
+		    g_slot[slot].pendingQueryDeadlineMs &&
+		    (int32_t)(millis() - g_slot[slot].pendingQueryDeadlineMs) <
+			    0) {
+			g_featureTerminalFetchGeneration[slot] = gen;
+		}
+	}
+}
+bool rfConnFeatureTurnConsumed(uint8_t slot)
+{
+	return slot < NSLOT && g_featureTurnConsumed[slot] != 0;
+}
 bool rfConnFlushRelay(uint8_t ch, uint8_t s1)
 {
 	int cur = (g_curSlot >= 0 && g_curSlot < NSLOT) ? g_curSlot : 0;
+	bool quiesceDeferred = false;
+
+	// Timeout retires transaction ownership only; resp remains the last valid value.
+	Slot &queryState = g_slot[cur];
+	featureObserveConsumedGeneration((uint8_t)cur);
+	if (queryState.pendingQueryCmd && queryState.pendingQueryDeadlineMs &&
+	    (int32_t)(millis() - queryState.pendingQueryDeadlineMs) >= 0) {
+		uint32_t pm = __get_PRIMASK();
+		__disable_irq();
+		queryState.pendingQueryCmd = 0;
+		queryState.pendingQueryGeneration = 0;
+		queryState.pendingQueryDeadlineMs = 0;
+		queryState.pendingQuerySelectorValid = 0;
+		queryState.pendingQueryFailed = 1;
+		__set_PRIMASK(pm);
+	}
 	// Snapshot one entry under a short critical section. relayEnqueue() (the producer) runs on the
 	// high-priority usbd task and, when the ring is full, evicts the oldest by advancing g_rqTail itself --
 	// the same variable this consumer reads/advances. Reading the entry while a producer could overwrite it
 	// is a torn read (and dual-writing g_rqTail desyncs head/tail), so copy the entry out and consume the
 	// slot atomically here, then do the (slow) RF TX on the copy with interrupts enabled.
+	// FETCH becomes eligible only after one ordinary poll/status turn.
+	g_featureTurnConsumed[cur] = 0;
+	// After the first query returns zero RX, reserve exactly the first
+	// next rfConnFlushRelay scheduler opportunity with no RF call and no post-poll
+	// poll, then retry the exact current query once on the second opportunity. The
+	// forced-poll helper remains suppressed while the generation latch is set.
+	if (g_featureDeferredQueryRetryGeneration[cur] != 0u) {
+		uint32_t retryGeneration =
+			g_featureDeferredQueryRetryGeneration[cur];
+		if (!queryState.pendingQueryCmd ||
+		    queryState.pendingQueryGeneration != retryGeneration) {
+			featureClearDeferredQueryRetry((uint8_t)cur);
+		} else if (g_featureDeferredQueryRetryWaitTurns[cur] != 0u) {
+			g_featureDeferredQueryRetryWaitTurns[cur]--;
+			g_featureTurnConsumed[cur] = 1;
+
+			// feature turn consumed; intentionally no rfConnTx() in the wait slot
+			return false;
+		} else {
+			uint8_t retryLen = g_featureDeferredQueryRetryLen[cur];
+			// Clear before RF I/O: even another rxlen==0 cannot schedule attempt #3.
+			featureClearDeferredQueryRetry((uint8_t)cur);
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			bool coframeAuthDeferred =
+				g_featureCoframeGeneration[cur] ==
+					retryGeneration &&
+				queryState.pendingQueryCmd &&
+				queryState.pendingQueryGeneration ==
+					retryGeneration;
+			if (coframeAuthDeferred) {
+				g_featureFetchPhase[cur] =
+					FEATURE_FETCH_FOLLOWUP_POLL;
+			}
+			rfConnTx(ch, s1,
+				 g_featureDeferredQueryRetryPayload[cur],
+				 retryLen, 400);
+			rfTimingEndFeatureResponse();
+			if (coframeAuthDeferred) {
+				if (!queryState.pendingQueryCmd ||
+				    queryState.pendingQueryGeneration !=
+					    retryGeneration) {
+					g_featureCoframeGeneration[cur] = 0u;
+					g_featureFetchPhase[cur] = 0u;
+				} else {
+					g_featureFetchPhase[cur] =
+						FEATURE_FETCH_WAIT_POLL;
+				}
+			}
+			return true;
+		}
+	}
+	// Service only the NORMAL initial FETCH retry latch. The first later turn is
+	// observation-only; the second later turn retries the exact FETCH once using
+	// the scheduler-provided S1/PID. The post-poll phase remains armed for a later turn.
+	if (g_featureDeferredFetchRetryGeneration[cur] != 0u) {
+		uint32_t retryGeneration =
+			g_featureDeferredFetchRetryGeneration[cur];
+		if (!queryState.pendingQueryCmd ||
+		    queryState.pendingQueryGeneration != retryGeneration) {
+			featureClearDeferredFetchRetry((uint8_t)cur);
+		} else if (g_featureDeferredFetchRetryWaitTurns[cur] != 0u) {
+			g_featureDeferredFetchRetryWaitTurns[cur]--;
+			g_featureTurnConsumed[cur] = 1;
+
+			// reserved wait turn: no RF feature action
+			return false;
+		} else {
+			uint8_t retryFetch[4];
+			memcpy(retryFetch,
+			       g_featureDeferredFetchRetryPayload[cur],
+			       sizeof retryFetch);
+			// Clear before RF I/O so another rxlen==0 can never schedule attempt #3.
+			featureClearDeferredFetchRetry((uint8_t)cur);
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			rfConnTx(ch, s1, retryFetch, sizeof retryFetch, 400);
+			rfTimingEndFeatureResponse();
+
+			return true;
+		}
+	}
+	// A valid stale Type4 proves prior-command response state while the current
+	// generation is still pending. Reassert the original query once, then restart
+	// only the existing poll/FETCH sequence without resetting its deadline or
+	// delayed-probe ownership.
+	if (g_featureStaleReplayGeneration[cur] != 0u) {
+		uint32_t replayGeneration = g_featureStaleReplayGeneration[cur];
+		if (!queryState.pendingQueryCmd ||
+		    queryState.pendingQueryGeneration != replayGeneration ||
+		    g_featureQuerySnapshotGeneration[cur] != replayGeneration ||
+		    !g_featureQuerySnapshotLen[cur]) {
+			featureClearStaleQueryReplay((uint8_t)cur);
+		} else {
+			uint8_t replay[80];
+			uint8_t replayLen = g_featureQuerySnapshotLen[cur];
+			memcpy(replay, g_featureQuerySnapshotPayload[cur],
+			       replayLen);
+			// The stale mismatch already passed structural validation. Track the
+			// replay for a possible silence recovery unless that recovery budget was
+			// already consumed for this generation.
+			if (g_featurePostStaleSilenceUsedGeneration[cur] !=
+				    replayGeneration &&
+			    g_featureRepeatStaleUsedGeneration[cur] !=
+				    replayGeneration) {
+				g_featurePostStaleSilenceTrackGeneration[cur] =
+					replayGeneration;
+				g_featurePostStaleSilenceSawType4[cur] = 0u;
+			} else {
+				featureClearPostStaleSilenceTrack((uint8_t)cur);
+			}
+			// Clear and mark used before RF I/O: this generation can never receive
+			// another stale-triggered current-query replay, even if the replay returns zero.
+			featureClearStaleQueryReplay((uint8_t)cur);
+			g_featureStaleReplayUsedGeneration[cur] =
+				replayGeneration;
+			g_featureFetchPhase[cur] = FEATURE_FETCH_WAIT_POLL;
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			rfConnTx(ch, s1, replay, replayLen, 400);
+			rfTimingEndFeatureResponse();
+
+			return true;
+		}
+	}
+	if (g_featureNoType4GraceGeneration[cur] != 0u) {
+		uint32_t pgen = g_featureNoType4GraceGeneration[cur];
+		if (!queryState.pendingQueryCmd ||
+		    queryState.pendingQueryGeneration != pgen ||
+		    g_featureQuerySnapshotGeneration[cur] != pgen ||
+		    !g_featureQuerySnapshotLen[cur] ||
+		    g_featureStaleReplayGeneration[cur] == pgen ||
+		    g_featureStaleReplayUsedGeneration[cur] == pgen ||
+		    g_featureNoType4ReplayUsedGeneration[cur] == pgen) {
+			featureClearNoType4Grace((uint8_t)cur);
+		} else if (g_featureNoType4GraceState[cur] == 1u) {
+			// Grace turn is observation-only from the feature layer: deliberately do
+			// NOT consume the turn so the caller performs one ordinary RF poll.
+
+			return false;
+		} else if (g_featureNoType4GraceState[cur] == 2u) {
+			uint8_t replay[80];
+			uint8_t replayLen = g_featureQuerySnapshotLen[cur];
+			memcpy(replay, g_featureQuerySnapshotPayload[cur],
+			       replayLen);
+			// The no-Type4 replay consumes the shared late-query reassertion budget
+			// before RF I/O, so this generation cannot take another stale-response replay from the shared budget.
+			featureClearNoType4Grace((uint8_t)cur);
+			g_featureNoType4ReplayUsedGeneration[cur] = pgen;
+			g_featureStaleReplayUsedGeneration[cur] = pgen;
+			g_featureFetchPhase[cur] = FEATURE_FETCH_WAIT_POLL;
+			g_featureTurnConsumed[cur] = 1;
+
+			g_featureNoType4ReplayActiveGeneration[cur] = pgen;
+			rfTimingBeginFeatureResponse();
+			rfConnTx(ch, s1, replay, replayLen, 400);
+			rfTimingEndFeatureResponse();
+			g_featureNoType4ReplayActiveGeneration[cur] = 0u;
+
+			return true;
+		}
+	}
+	// After one stale-triggered current-query replay, a later exact stale mismatch is fresh
+	// evidence that the stale tail persisted, so permit one additional
+	// one additional bounded current-query replay on this scheduler opportunity.
+	if (g_featureRepeatStaleGeneration[cur] != 0u) {
+		uint32_t repeatedStaleGeneration =
+			g_featureRepeatStaleGeneration[cur];
+		if (!queryState.pendingQueryCmd ||
+		    queryState.pendingQueryGeneration !=
+			    repeatedStaleGeneration ||
+		    g_featureQuerySnapshotGeneration[cur] !=
+			    repeatedStaleGeneration ||
+		    !g_featureQuerySnapshotLen[cur] ||
+		    g_featureStaleReplayUsedGeneration[cur] !=
+			    repeatedStaleGeneration ||
+		    g_featureNoType4ReplayUsedGeneration[cur] ==
+			    repeatedStaleGeneration ||
+		    g_featureRepeatStaleUsedGeneration[cur] ==
+			    repeatedStaleGeneration) {
+			featureClearRepeatStaleReplay((uint8_t)cur);
+		} else {
+			uint8_t replay[80];
+			uint8_t replayLen = g_featureQuerySnapshotLen[cur];
+			memcpy(replay, g_featureQuerySnapshotPayload[cur],
+			       replayLen);
+			// Mark used before RF I/O so this generation cannot arm another replay.
+			featureClearRepeatStaleReplay((uint8_t)cur);
+			g_featureRepeatStaleUsedGeneration[cur] =
+				repeatedStaleGeneration;
+			g_featureFetchPhase[cur] = FEATURE_FETCH_WAIT_POLL;
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			rfConnTx(ch, s1, replay, replayLen, 400);
+			rfTimingEndFeatureResponse();
+
+			return true;
+		}
+	}
+	// Repeated-stale recovery has priority. Silence recovery requires a prior
+	// stale-triggered replay followed by a complete poll cycle with no Type4.
+	// The stale replay originated from a reason-0x20 mismatch. Repeated-stale and
+	// silence recovery share one additional-replay budget.
+	if (g_featurePostStaleSilenceReplayGeneration[cur] != 0u) {
+		uint32_t postStaleSilenceGeneration =
+			g_featurePostStaleSilenceReplayGeneration[cur];
+		if (!queryState.pendingQueryCmd ||
+		    queryState.pendingQueryGeneration !=
+			    postStaleSilenceGeneration ||
+		    g_featureQuerySnapshotGeneration[cur] !=
+			    postStaleSilenceGeneration ||
+		    !g_featureQuerySnapshotLen[cur] ||
+		    g_featureStaleReplayUsedGeneration[cur] !=
+			    postStaleSilenceGeneration ||
+		    g_featureNoType4ReplayUsedGeneration[cur] ==
+			    postStaleSilenceGeneration ||
+		    g_featureRepeatStaleGeneration[cur] ==
+			    postStaleSilenceGeneration ||
+		    g_featureRepeatStaleUsedGeneration[cur] ==
+			    postStaleSilenceGeneration ||
+		    g_featurePostStaleSilenceUsedGeneration[cur] ==
+			    postStaleSilenceGeneration) {
+			featureClearPostStaleSilenceReplay((uint8_t)cur);
+		} else {
+			uint8_t replay[80];
+			uint8_t replayLen = g_featureQuerySnapshotLen[cur];
+			memcpy(replay, g_featureQuerySnapshotPayload[cur],
+			       replayLen);
+			// Consume both additional recovery budgets before RF I/O.
+			featureClearPostStaleSilenceReplay((uint8_t)cur);
+			g_featurePostStaleSilenceUsedGeneration[cur] =
+				postStaleSilenceGeneration;
+			g_featureRepeatStaleUsedGeneration[cur] =
+				postStaleSilenceGeneration;
+			g_featureFetchPhase[cur] = FEATURE_FETCH_WAIT_POLL;
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			uint8_t postStaleSilenceRx =
+				rfConnTx(ch, s1, replay, replayLen, 400);
+			rfTimingEndFeatureResponse();
+
+			// A zero RX is transport silence, not proof that the query was not received.
+			// Reusing the exact same s1/PID makes this one ESB retransmission-safe attempt;
+			// no new scheduler stage, query generation, or deadline is created.
+			if (postStaleSilenceRx == 0 &&
+			    queryState.pendingQueryCmd &&
+			    queryState.pendingQueryGeneration ==
+				    postStaleSilenceGeneration &&
+			    queryState.pendingQueryDeadlineMs &&
+			    (int32_t)(millis() -
+				      queryState.pendingQueryDeadlineMs) < 0) {
+				rfTimingBeginFeatureResponse();
+				rfConnTx(ch, s1, replay, replayLen, 400);
+				rfTimingEndFeatureResponse();
+			}
+			return true;
+		}
+	}
+	// A stale mismatch after the no-Type4 replay is handled before pure-silence
+	// recovery. Pure silence cannot arm this branch, and a generation that already
+	// used silence recovery cannot acquire another recovery stage.
+	if (g_featurePostNoType4StaleGeneration[cur] != 0u) {
+		uint32_t postNoType4StaleGeneration =
+			g_featurePostNoType4StaleGeneration[cur];
+		if (!queryState.pendingQueryCmd ||
+		    queryState.pendingQueryGeneration !=
+			    postNoType4StaleGeneration ||
+		    g_featureQuerySnapshotGeneration[cur] !=
+			    postNoType4StaleGeneration ||
+		    !g_featureQuerySnapshotLen[cur] ||
+		    g_featureNoType4ReplayUsedGeneration[cur] !=
+			    postNoType4StaleGeneration ||
+		    g_featurePostNoType4ReplayUsedGeneration[cur] ==
+			    postNoType4StaleGeneration ||
+		    g_featurePostNoType4StaleUsedGeneration[cur] ==
+			    postNoType4StaleGeneration ||
+		    g_featurePostStaleSilenceReplayGeneration[cur] ==
+			    postNoType4StaleGeneration ||
+		    g_featurePostStaleSilenceUsedGeneration[cur] ==
+			    postNoType4StaleGeneration ||
+		    g_featureRepeatStaleGeneration[cur] ==
+			    postNoType4StaleGeneration ||
+		    g_featureRepeatStaleUsedGeneration[cur] ==
+			    postNoType4StaleGeneration) {
+			featureClearPostNoType4StaleReplay((uint8_t)cur);
+		} else {
+			uint8_t replay[80];
+			uint8_t replayLen = g_featureQuerySnapshotLen[cur];
+			memcpy(replay, g_featureQuerySnapshotPayload[cur],
+			       replayLen);
+			// Mark used before RF I/O so no later recovery branch can recurse.
+			featureClearPostNoType4StaleReplay((uint8_t)cur);
+			g_featurePostNoType4StaleUsedGeneration[cur] =
+				postNoType4StaleGeneration;
+			g_featureFetchPhase[cur] = FEATURE_FETCH_WAIT_POLL;
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			rfConnTx(ch, s1, replay, replayLen, 400);
+			rfTimingEndFeatureResponse();
+
+			return true;
+		}
+	}
+	// The no-Type4 replay already consumed the shared first late-query budget.
+	// Silence recovery therefore keys off its dedicated ownership marker and runs
+	// only after the complete post-replay poll cycle remains silent.
+	if (g_featurePostNoType4ReplayGeneration[cur] != 0u) {
+		uint32_t postNoType4SilenceGeneration =
+			g_featurePostNoType4ReplayGeneration[cur];
+		if (!queryState.pendingQueryCmd ||
+		    queryState.pendingQueryGeneration !=
+			    postNoType4SilenceGeneration ||
+		    g_featureQuerySnapshotGeneration[cur] !=
+			    postNoType4SilenceGeneration ||
+		    !g_featureQuerySnapshotLen[cur] ||
+		    g_featureNoType4ReplayUsedGeneration[cur] !=
+			    postNoType4SilenceGeneration ||
+		    g_featurePostNoType4Type4SeenGeneration[cur] ==
+			    postNoType4SilenceGeneration ||
+		    g_featurePostNoType4ReplayUsedGeneration[cur] ==
+			    postNoType4SilenceGeneration ||
+		    g_featurePostStaleSilenceReplayGeneration[cur] ==
+			    postNoType4SilenceGeneration ||
+		    g_featurePostStaleSilenceUsedGeneration[cur] ==
+			    postNoType4SilenceGeneration ||
+		    g_featureRepeatStaleGeneration[cur] ==
+			    postNoType4SilenceGeneration ||
+		    g_featureRepeatStaleUsedGeneration[cur] ==
+			    postNoType4SilenceGeneration) {
+			featureClearPostNoType4Replay((uint8_t)cur);
+		} else {
+			uint8_t replay[80];
+			uint8_t replayLen = g_featureQuerySnapshotLen[cur];
+			memcpy(replay, g_featureQuerySnapshotPayload[cur],
+			       replayLen);
+			// Mark used before RF I/O so a silent attempt cannot recursively re-arm.
+			featureClearPostNoType4Replay((uint8_t)cur);
+			g_featurePostNoType4ReplayUsedGeneration[cur] =
+				postNoType4SilenceGeneration;
+			// Present FOLLOWUP_POLL only during the first silence-replay RF call so an
+			// exact-current Type4 returned synchronously can still be accepted.
+			g_featureFetchPhase[cur] = FEATURE_FETCH_FOLLOWUP_POLL;
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			uint8_t postNoType4SilenceRx =
+				rfConnTx(ch, s1, replay, replayLen, 400);
+			rfTimingEndFeatureResponse();
+
+			if (queryState.pendingQueryCmd &&
+			    queryState.pendingQueryGeneration ==
+				    postNoType4SilenceGeneration) {
+				g_featureFetchPhase[cur] =
+					FEATURE_FETCH_WAIT_POLL;
+			}
+			// A zero RX is transport silence, not proof that the query was not received.
+			// Reusing the exact same s1/PID makes this one ESB retransmission-safe attempt;
+			// no new scheduler stage, query generation, or deadline is created.
+			if (postNoType4SilenceRx == 0 &&
+			    queryState.pendingQueryCmd &&
+			    queryState.pendingQueryGeneration ==
+				    postNoType4SilenceGeneration &&
+			    queryState.pendingQueryDeadlineMs &&
+			    (int32_t)(millis() -
+				      queryState.pendingQueryDeadlineMs) < 0) {
+				rfTimingBeginFeatureResponse();
+				rfConnTx(ch, s1, replay, replayLen, 400);
+				rfTimingEndFeatureResponse();
+			}
+			return true;
+		}
+	}
+	if (g_featureTerminalFetchGeneration[cur] != 0u) {
+		uint32_t terminalFetchGeneration =
+			g_featureTerminalFetchGeneration[cur];
+		if (!queryState.pendingQueryCmd ||
+		    queryState.pendingQueryGeneration !=
+			    terminalFetchGeneration ||
+		    g_featureNoType4ReplayUsedGeneration[cur] !=
+			    terminalFetchGeneration ||
+		    g_featureNoType4CurrentResponseGeneration[cur] !=
+			    terminalFetchGeneration ||
+		    g_featureTerminalFetchUsedGeneration[cur] ==
+			    terminalFetchGeneration ||
+		    !queryState.pendingQueryDeadlineMs ||
+		    (int32_t)(millis() - queryState.pendingQueryDeadlineMs) >=
+			    0) {
+			g_featureTerminalFetchGeneration[cur] = 0u;
+		} else {
+			uint8_t fetch[4] = { 0xE3, 0x01, 0x03, 0x00 };
+			g_featureTerminalFetchGeneration[cur] = 0u;
+			g_featureTerminalFetchUsedGeneration[cur] =
+				terminalFetchGeneration;
+			// FOLLOWUP_POLL makes rfConnFeatureFetchPending() false during this terminal
+			// FETCH, matching the normal response-acceptance state.
+			g_featureFetchPhase[cur] = FEATURE_FETCH_FOLLOWUP_POLL;
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			rfConnTx(ch, s1, fetch, sizeof fetch, 400);
+			rfTimingEndFeatureResponse();
+
+			return true;
+		}
+	}
+	// After the normal FETCH/follow-up-poll sequence has fully
+	// returned to phase 0, give this still-pending generation exactly one later
+	// retrieval opportunity on the first scheduler turn at/after +24 ms from the original query.
+	if (queryState.pendingQueryCmd &&
+	    queryState.pendingQueryGeneration != 0u &&
+	    g_featureFetchPhase[cur] == 0u && g_featureQueryArmMs[cur] != 0u &&
+	    g_featureDelayedFetchGeneration[cur] !=
+		    queryState.pendingQueryGeneration) {
+		uint32_t delayedFetchAgeMs =
+			(uint32_t)(millis() - g_featureQueryArmMs[cur]);
+		if (delayedFetchAgeMs >= FEATURE_DELAYED_FETCH_DELAY_MS) {
+			uint8_t fetch[4] = { 0xE3, 0x01, 0x03, 0x00 };
+			g_featureDelayedFetchGeneration[cur] =
+				queryState.pendingQueryGeneration;
+			// Reuse FOLLOWUP_POLL so the next RF turn is guaranteed to be an
+			// ordinary poll after the delayed retrieval probe as well.
+			g_featureFetchPhase[cur] = FEATURE_FETCH_FOLLOWUP_POLL;
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			uint8_t fetchRx =
+				rfConnTx(ch, s1, fetch, sizeof fetch, 400);
+			rfTimingEndFeatureResponse();
+			// Preserve one immediate same-PID retransmission for this FETCH invocation:
+			// allow one retry after rxlen==0, but never another delayed probe.
+			if (fetchRx == 0) {
+				rfTimingBeginFeatureResponse();
+				fetchRx = rfConnTx(ch, s1, fetch, sizeof fetch,
+						   400);
+				rfTimingEndFeatureResponse();
+			}
+			return true;
+		}
+	}
+	if (rfConnFeatureFetchEligible((uint8_t)cur)) {
+		if (!queryState.pendingQueryCmd) {
+			g_featureFetchPhase[cur] = 0;
+		} else {
+			uint8_t fetch[4] = { 0xE3, 0x01, 0x03, 0x00 };
+			// Clear the pre-FETCH guard before parsing this RF return. A matching Type-4
+			// returned by FETCH itself is therefore eligible for the active generation.
+			g_featureFetchPhase[cur] = FEATURE_FETCH_FOLLOWUP_POLL;
+			g_featureTurnConsumed[cur] = 1;
+
+			rfTimingBeginFeatureResponse();
+			uint8_t fetchRx =
+				rfConnTx(ch, s1, fetch, sizeof fetch, 400);
+			rfTimingEndFeatureResponse();
+			// A zero-length return from the initial FETCH reserves a no-RF wait turn
+			// followed by one same-S1/PID retry. Snapshot the exact FETCH and reserve
+			// one no-RF wait slot plus one deferred retry. The existing FOLLOWUP_POLL
+			// phase remains armed throughout and the original query deadline is unchanged.
+			if (fetchRx == 0) {
+				g_featureDeferredFetchRetryGeneration[cur] =
+					queryState.pendingQueryGeneration;
+				g_featureDeferredFetchRetryWaitTurns[cur] = 1u;
+				memcpy(g_featureDeferredFetchRetryPayload[cur],
+				       fetch, sizeof fetch);
+			}
+			return true;
+		}
+	}
 	RelayMsg msg;
 	bool have = false;
 	uint32_t pm = __get_PRIMASK();
 	__disable_irq();
 	uint8_t guard = RELAY_QLEN + 1;
 	while (g_rqTail[cur] != g_rqHead[cur]) {
-		if (!guard--) { // desynced/corrupt ring -> recover, don't spin IRQs-off (watchdog-hang class)
+		// desynced/corrupt ring -> recover, don't spin IRQs-off (watchdog-hang class)
+		if (!guard--) {
 			g_rqHead[cur] = g_rqTail[cur] = 0;
 			g_ringFault++;
 			faultDiagTrace(FR_RINGF, g_ringFault);
 			break;
 		}
 		RelayMsg &m = g_rq[cur][g_rqTail[cur]];
+		// The relay queue is also the feature-query FIFO. Leave the next expectReply
+		// entry in place until the active controller query completes/fails.
+		// A completed but unconsumed Type4 response still owns the feature slot.
+		// Leave the next expectReply entry in the FIFO until the host consumes it.
+		if (m.rid && m.expectReply &&
+		    (g_slot[cur].pendingQueryCmd != 0 ||
+		     g_slot[cur].queryResponseReady))
+			break;
+		if (m.rid && m.expectReply &&
+		    g_featureLastConsumedCmd[cur] != 0u &&
+		    m.rid != g_featureLastConsumedCmd[cur] &&
+		    g_featureQuiesceStartMs[cur] != 0u) {
+			uint32_t now = millis();
+			uint32_t elapsed =
+				(uint32_t)(now - g_featureQuiesceStartMs[cur]);
+			if (elapsed < FEATURE_CROSS_COMMAND_QUIESCE_MS) {
+				quiesceDeferred = true;
+
+				// leave the response-bearing entry in the FIFO
+				break;
+			}
+		}
 		g_rqTail[cur] = rqNext(g_rqTail[cur]); // consume the slot
 		// rid 0 = entry voided by hapticCancelPendingOn -> skip
 		if (m.rid) {
-			msg = m; // copy out before the producer can reuse the slot
+			// copy out before the producer can reuse the slot
+			msg = m;
 			have = true;
 			break;
 		}
 	}
 	__set_PRIMASK(pm);
+	if (quiesceDeferred) {
+		// Caller performs the ordinary poll turn while the query stays queued.
+		return false;
+	}
 	if (have) {
 		RelayMsg &m = msg;
 		{
 			uint8_t rl = m.len;
 			if (rl > RELAY_MAXP)
 				rl = RELAY_MAXP;
-			// On-air sub-TLV framing. CONFIRMED from real puck<->controller sniffs: a command LANDS on
-			// the controller only with the type-01 + inner-len form E3 [2+rl][01][rid][innerlen][data];
-			// the legacy form E3 [1+rl][05][rid][data] makes the controller DISCARD any 0x87+ command.
+			// Configuration commands require the type-01 + inner-length form
+			// E3 [2+rl][01][rid][innerlen][data]. Haptic reports use the type-05 form below.
 
 			// Same shape as the `[len][tag][value]` TLV grammar the F1 REPLY side
 			// already uses (tags 0x02/0x04/0x06, docs/PROTOCOL.md sec 7.3): read as len=1, tag=3,
 			// value=0. If the caller decides they want an answer, we add the queryTrailer.
 			// Should check later if there's a way to somehow determine which types need the trailer and which ones don't.
+			// Preserve co-framing as the primary query form.
 			bool queryTrailer = m.expectReply;
 			uint8_t p[5 + RELAY_MAXP + 3], plen;
 			if (!m.isHaptic) {
@@ -524,7 +1886,7 @@ bool rfConnFlushRelay(uint8_t ch, uint8_t s1)
 				p[4] = rl;
 				memcpy(p + 5, m.data, rl);
 				plen = (uint8_t)(5 + rl);
-				if (queryTrailer && plen + 3 <= sizeof p) {
+				if (queryTrailer && plen <= sizeof p - 3u) {
 					p[plen + 0] = 0x01;
 					p[plen + 1] = 0x03;
 					p[plen + 2] = 0x00;
@@ -539,11 +1901,11 @@ bool rfConnFlushRelay(uint8_t ch, uint8_t s1)
 				memcpy(p + 4, m.data, rl);
 				plen = (uint8_t)(4 + rl);
 			}
-			hapLogAdd(0xFE, m.rid, m.data, rl);
 			// Lifecycle log (CDC debug boot): EXACTLY what we TX to the controller, so a capture shows
 			// whether OpenPuck (or Steam in the background) pokes the controller right before a buzz
 			// latches -- the piece the I45 stream (controller->us) can't show. Low rate outside a haptic
 			// burst; guarded so it never blocks the loop. cur = target slot.
+			hapLogAdd(0xFE, m.rid, m.data, rl);
 			if (Serial.availableForWrite() > 60) {
 				// boosted: this print runs at relay-flood rate and CDC flush enters the same
 				// TinyUSB DMA claim window as HID sends (the issue-72 livelock; see usb_tx.cpp)
@@ -557,26 +1919,121 @@ bool rfConnFlushRelay(uint8_t ch, uint8_t s1)
 				Serial.println();
 				usbTxUnboost();
 			}
+			// Transaction ownership starts at the actual RF transmission. This prevents a later
+			// USB query from overwriting the command currently awaiting Type-4 data.
+			if (m.expectReply) {
+				uint32_t pm = __get_PRIMASK();
+				__disable_irq();
+				queryState.pendingQueryCmd = m.rid;
+				queryState.pendingQueryGeneration =
+					m.queryGeneration;
+				queryState.pendingQueryFailed = 0;
+				queryState.pendingQueryDeadlineMs =
+					millis() + FEATURE_QUERY_TIMEOUT_MS;
+				g_featureLastArmedGeneration[cur] =
+					m.queryGeneration;
+				g_featureLastArmedCmd[cur] = m.rid;
+				g_featureQueryArmMs[cur] = millis();
+				g_featureDelayedFetchGeneration[cur] = 0u;
+				g_featureNoType4ReplayActiveGeneration[cur] =
+					0u;
+				g_featureNoType4CurrentResponseGeneration[cur] =
+					0u;
+				g_featureTerminalFetchGeneration[cur] = 0u;
+				g_featureTerminalFetchUsedGeneration[cur] = 0u;
+				featureClearDeferredQueryRetry((uint8_t)cur);
+				featureClearDeferredFetchRetry((uint8_t)cur);
+				featureResetQuerySnapshot((uint8_t)cur);
+				featureResetNoType4Grace((uint8_t)cur);
+				featureResetRepeatStaleReplay((uint8_t)cur);
+				featureResetPostStaleSilence((uint8_t)cur);
+				featureResetPostNoType4((uint8_t)cur);
+				featureResetPostNoType4StaleReplay(
+					(uint8_t)cur);
+				g_featureQuerySnapshotGeneration[cur] =
+					m.queryGeneration;
+				g_featureQuerySnapshotLen[cur] = plen;
+				memcpy(g_featureQuerySnapshotPayload[cur], p,
+				       plen);
+				queryState.pendingQuerySelectorValid =
+					(m.rid ==
+						 IBEX_CMD_GET_STRING_ATTRIBUTE &&
+					 rl >= 1) ?
+						1 :
+						0;
+				queryState.pendingQuerySelector =
+					queryState.pendingQuerySelectorValid ?
+						m.data[0] :
+						0;
+				__set_PRIMASK(pm);
+				// bit0: 01 03 00 co-frame present
+				rfTimingBeginFeatureResponse();
+			}
+			if (!m.isHaptic &&
+			    m.rid == IBEX_CMD_TURN_OFF_CONTROLLER)
+				queryState.shutdownStatusOwnerMs = millis();
 			// slot was already consumed under the critical section above.
 			// s1 carries a PID distinct from the GET poll (caller cycles it) so the controller's ESB
 			// dedup never treats the GET as a retransmit of this relay.
 			//
-			// HARVEST the relay's reply as INPUT. Like any frame we send, the controller auto-ACKs a
-			// relay with its current input in the ACK payload (~90us later, per the RE poll->ACK
-			// capture). The old 80us window closed BEFORE that reply arrived, so every relay's input was
-			// discarded -- and yet HW A/B showed the delivered input rate RISING when haptics relay
-			// (an extra frame/cycle during a trackpad drag), because each frame makes the controller
-			// refresh its ACK payload and the following E3 poll caught the fresher value. Reading the
-			// reply directly turns each relay into a SECOND input sample per cycle: rfConnTx runs the
-			// full F1 decode (seq-dedup guards double-forward), so a drag streaming haptics now collects
-			// ~2x the samples, closing the gap to the real puck. A present reply returns early (~90us);
-			// only a genuine no-reply pays the bounded 400us window, so airtime stays in budget.
-			rfConnTx(
-				ch, s1, p, plen,
-				400); // one relay per poll cycle -- reply harvested as input
+			// A relay can return the controller's current input in its ACK payload. Decode that reply
+			// through the normal F1 path so relay-heavy periods do not discard usable input samples;
+			// sequence deduplication prevents double-forwarding. The bounded receive window limits the
+			// airtime cost when no reply is present.
+			if (m.expectReply) {
+				uint32_t coframeGeneration = m.queryGeneration;
+				g_featureCoframeGeneration[cur] =
+					coframeGeneration;
+				g_featureFetchPhase[cur] =
+					FEATURE_FETCH_FOLLOWUP_POLL;
+
+				uint8_t queryRx =
+					rfConnTx(ch, s1, p, plen, 400);
+				rfTimingEndFeatureResponse();
+
+				if (!queryState.pendingQueryCmd ||
+				    queryState.pendingQueryGeneration !=
+					    coframeGeneration) {
+					g_featureCoframeGeneration[cur] = 0u;
+					g_featureFetchPhase[cur] = 0u;
+				} else {
+					// The post-call fallback arm below remains authoritative.
+					g_featureFetchPhase[cur] = 0u;
+				}
+				// Preserve the two-attempt maximum. Snapshot the
+				// exact current-query bytes now, reserve one later scheduler opportunity with no RF,
+				// and permit attempt #2 only on the following scheduler opportunity.
+				if (queryRx == 0) {
+					g_featureDeferredQueryRetryGeneration
+						[cur] = m.queryGeneration;
+					g_featureDeferredQueryRetryLen[cur] =
+						plen;
+					g_featureDeferredQueryRetryWaitTurns[cur] =
+						1u;
+					memcpy(g_featureDeferredQueryRetryPayload
+						       [cur],
+					       p, plen);
+				}
+			} else {
+				rfConnTx(ch, s1, p, plen, 400);
+			}
+			// Preserve one-feature-turn ownership. Only unresolved
+			// co-framed queries enter the normal split-FETCH fallback path.
+			if (m.expectReply) {
+				g_featureTurnConsumed[cur] = 1;
+				if (queryState.pendingQueryCmd &&
+				    queryState.pendingQueryGeneration ==
+					    m.queryGeneration)
+					g_featureFetchPhase[cur] =
+						FEATURE_FETCH_WAIT_POLL;
+				else
+					g_featureFetchPhase[cur] = 0;
+			}
 		}
 	}
-	return have; // true = a relay frame went out this cycle (its reply is harvested as input, above)
+
+	// true = a relay frame went out this cycle (its reply is harvested as input, above)
+	return have;
 }
 
 void hapticReinit(uint8_t slot)
@@ -647,6 +2104,8 @@ void hapticInit()
 	for (int s = 0; s < NSLOT; s++) {
 		g_rqHead[s] = g_rqTail[s] = 0;
 		g_rumble80On[s] = false;
+		g_rumble80Low[s] = 0;
+		g_rumble80High[s] = 0;
 		g_rumble80Ms[s] = 0;
 		// post-connect haptic block is permanently disabled (not armed, not configurable)
 		g_hapticBlockUntil[s] = 0;
@@ -662,6 +2121,8 @@ void hapticOnReconnect(int slot)
 	// post-connect haptic block is permanently disabled -- relay haptics immediately on (re)connect
 	g_hapticBlockUntil[slot] = 0;
 	g_rumble80On[slot] = false;
+	g_rumble80Low[slot] = 0;
+	g_rumble80High[slot] = 0;
 	g_rumble80Ms[slot] = 0;
 	// Scrub haptics queued before the link came up (stale across the reconnect) -- this slot only.
 	hapticCancelPendingOn(slot);
@@ -811,10 +2272,15 @@ void hapticTask()
 		suspArmed = false; // fire once per suspend
 	}
 	wasSusp = susp;
-	// Per-slot stuck-rumble watchdog: force zero after 2.5s without a refresh.
+	// Translated-rumble keepalive. Triton hardware has an approximately
+	// 50 ms safety timeout; SDL resends active rumble every 40 ms.
 	for (int s = 0; s < NSLOT; s++) {
-		if (g_rumble80On[s] && millis() - g_rumble80Ms[s] > 2500u)
-			hapticSteamRumble(0, 0, (uint8_t)s);
+		if (!g_rumble80On[s] || !hapticLinkUp(s))
+			continue;
+		if ((uint32_t)(millis() - g_rumble80Ms[s]) >=
+		    RUMBLE_RESEND_INTERVAL_MS)
+			hapticQueueRumble80(g_rumble80Low[s], g_rumble80High[s],
+					    (uint8_t)s, false);
 	}
 	// (No automatic idle-clear re-init either: same 0x81-click reason. A genuinely stuck buzz is cleared
 	// on demand from the panel. Verbatim relay -- like the real puck -- is the steady-state behavior.)

--- a/OpenPuck/haptics.h
+++ b/OpenPuck/haptics.h
@@ -25,9 +25,8 @@
 #define HAPTIC_BLOCK_MS_DEFAULT 10000u
 // max relayed payload bytes per entry: RF frame = [E3][len][05][rid][payload] and MAXLEN=64 -> 60
 #define RELAY_MAXP 60u
-// Controller power-off: hapticSendShutdown() relays Steam's confirmed "turn off controller" command (feature-0x01
-// cmd 0x9F, payload "off!" -- captured from the real puck). Sent as a small burst because the RF relay is NO-ACK.
-#define HAPTIC_SHUTDOWN_SHOTS 3u
+// Controller power-off: feature command IBEX_CMD_TURN_OFF_CONTROLLER (0x9F), payload "off!".
+// One transmission receives the controller status ACK; do not duplicate this write.
 // Rumble strength: percent of the decoded host amplitude applied in every translated (non-puck) mode. 200
 // (double) is the default the panel's removed rumble-strength slider shipped with, so an untouched puck feels
 // exactly as before. Runtime-adjustable and persisted -- console "RS<pct>".
@@ -106,6 +105,13 @@ extern uint16_t
 
 // anything still queued (xinput uses it to pace rumble re-queues)
 bool relayPending();
+bool relayQueryPending(uint8_t slot);
+
+// Feature queries remain owned by the transmitted RF transaction for this bounded response window.
+#define FEATURE_QUERY_TIMEOUT_MS 80u
+// A recent shutdown command temporarily owns Type-2 status attribution for this bounded interval.
+#define SHUTDOWN_STATUS_OWNER_MS 25u
+
 extern uint8_t g_relayOp; // relay frame opcode (E3 poll)
 extern uint8_t g_relaySub; // relay sub-TLV type byte = SET
 extern volatile uint8_t g_testHaptic; // 't<n>' injects n test haptics
@@ -114,7 +120,7 @@ extern volatile uint8_t g_hapticStop;
 // Per-slot block: arm after a (re)connect, drop haptics aimed at the slot for g_hapticBlockMs (when g_hapticBlockOn).
 extern unsigned long g_hapticBlockUntil[NSLOT];
 
-// relay the controller power-off (0x9F "off!"), burst x3. Steam's per-interface 0x9F passes that slot so
+// Relay controller power-off (0x9F "off!") exactly once. Steam's per-interface command targets one slot;
 // only that controller powers off; host-suspend / the panel test button keep the broadcast default (all off).
 void hapticSendShutdown(uint8_t slot = 0xFF);
 
@@ -148,6 +154,17 @@ static inline bool hapLogPull(uint32_t *, uint8_t *, uint8_t *, uint8_t *,
 bool hapticLinkUp(int slot = -1);
 bool haptic82Blocked(int slot = -1);
 bool hapticRelaySlotOk(int slot);
+
+// Output-haptic target resolution: exact live slot wins; when the selected duplicate
+// HID interface is inactive and exactly one controller is live, redirect safely to that sole live slot.
+enum HapticRouteDecision : uint8_t {
+	HROUTE_EXACT = 0,
+	HROUTE_SINGLE_FALLBACK = 1,
+	HROUTE_NO_LIVE = 2,
+	HROUTE_AMBIGUOUS = 3
+};
+int hapticResolveRelaySlot(int requestedSlot, uint8_t *liveCount = nullptr,
+			   uint8_t *decision = nullptr);
 // queue a Steam/Triton 0x80 rumble frame. `slot` = bond slot of the originating controller (0..NSLOT-1);
 // defaults to 0 for the legacy single-controller callers. Per-slot so each connected controller can have its
 // own active rumble stream when the host presents multiple gamepads (e.g. 4 XInput devices).
@@ -166,6 +183,63 @@ void rfConnQueueHapticRelay();
 // returns true if a relay frame was actually transmitted this call (queue had an entry), so the poll loop can
 // count relay TXs separately from poll cycles.
 bool rfConnFlushRelay(uint8_t ch, uint8_t s1);
+// Defer only a different response-bearing command after a consumed query.
+#define FEATURE_CROSS_COMMAND_QUIESCE_MS 24u
+// One delayed response-retrieval probe; the original query and its 80-ms deadline are unchanged.
+#define FEATURE_DELAYED_FETCH_DELAY_MS 24u
+// QUERY zero-RX skips one scheduler opportunity, then retries with the next
+// turn's S1/PID. FETCH same-PID zero-RX retries stay immediate; the initial
+// FETCH retry starts on the second later opportunity. Retry caps are unchanged.
+#define FEATURE_FETCH_WAIT_POLL 1u
+#define FEATURE_FETCH_ELIGIBLE 2u
+#define FEATURE_FETCH_FOLLOWUP_POLL 3u
+uint8_t rfConnFeatureFetchPhase(uint8_t slot);
+bool rfConnFeatureFetchPending(uint8_t slot);
+bool rfConnFeatureFetchEligible(uint8_t slot);
+bool rfConnFeatureForceOrdinaryPoll(uint8_t slot);
+void rfConnFeaturePollCompleted(uint8_t slot);
+// Terminal retrieval is evidence-gated; cached responses are not accepted
+// directly. Late acceptance is only during an already-required WAIT_POLL and
+// adds no RF call.
+bool rfConnFeatureLateWaitPollAuthBegin(uint8_t slot);
+void rfConnFeatureLateWaitPollAuthEnd(uint8_t slot);
+bool rfConnFeatureCoframeWaitPollAuthBegin(uint8_t slot);
+void rfConnFeatureCoframeWaitPollAuthEnd(uint8_t slot);
+bool rfConnFeatureTurnConsumed(uint8_t slot);
+// Recovery replays are one-shot. Same-S1/PID retransmit is allowed only after
+// zero RX and never creates another recovery stage or extends the deadline.
+// A valid stale Type4 may spend the first exact current-query replay.
+void rfConnFeatureObserveType4(uint8_t slot, uint8_t seenCmd, uint8_t reason);
+// Delayed-probe plus grace-poll silence shares that first replay budget.
+void rfConnFeatureObserveType4DuringDelayedProbe(uint8_t slot);
+// Only a new exact stale mismatch after the first stale replay can permit one
+// repeated-stale replay.
+void rfConnFeatureObserveType4AfterStaleReplay(uint8_t slot, uint8_t seenCmd,
+					       uint8_t reason);
+// A valid reason-0x20 prior-command mismatch that spent the first stale replay
+// may track the full-cycle silence branch; repeated-stale and silence recovery
+// are mutually exclusive.
+void rfConnFeatureObserveType4DuringPostStaleSilence(uint8_t slot);
+// Full-cycle silence after a no-Type4 replay permits one final exact replay on
+// the next scheduler RF opportunity.
+void rfConnFeatureObserveType4AfterNoType4Replay(uint8_t slot, uint8_t seenCmd,
+						 uint8_t reason);
+// A later stale/current reason-0x20 mismatch can preempt that silence path and
+// permit one cached current-query replay.
+void rfConnFeatureObserveType4ForPostNoType4Stale(uint8_t slot, uint8_t seenCmd,
+						  uint8_t reason);
+
+// Triton PCM transport: 63-byte OUTPUT PCM bodies use the controller's
+// E3/type-05 framing; active sessions run at 31 stereo samples / 8 kHz = 3875 us per RF turn.
+#define PCM_ACTIVE_CYCLE_US 3875u
+bool pcmEnqueue(uint8_t rid, const uint8_t *payload, uint16_t plen,
+		uint8_t slot);
+bool rfConnFlushPcm(uint8_t ch, uint8_t s1, uint8_t *rxOut);
+bool pcmSessionActive(uint8_t slot);
+bool pcmAnyActive(void);
+bool pcmRelayPending(uint8_t slot);
+bool pcmRelayNeedsStandalone(uint8_t slot);
+
 // times a relay-ring drain hit its iteration cap (head/tail desync or corruption) -- non-zero means we caught
 // and recovered from what would otherwise be an IRQ-off watchdog hang. Surfaced on the WebUSB panel.
 extern volatile uint16_t g_ringFault;

--- a/OpenPuck/puck_hid.cpp
+++ b/OpenPuck/puck_hid.cpp
@@ -14,6 +14,7 @@
 #include <Adafruit_TinyUSB.h>
 #include <Arduino.h>
 #include <string.h>
+#include <stdio.h>
 
 uint8_t g_fwdNewOnly = 1;
 // Content dedup for the Steam input forward: only forward a 0x45/0x42 report when its body EXCLUDING the
@@ -131,7 +132,8 @@ static Adafruit_USBD_HID hid[NSLOT];
 // avoids printf here). handleSet/handleGet (usbd task) push a compact record under PRIMASK; puckCmdLogDrain()
 // prints them from loop() context. When g_cmdCapture is on, the high-rate I45 input stream is also suppressed
 // (rf_link) so the command sequence is readable. Toggle from the console with "FC".
-bool g_cmdCapture = true;
+// Serial feature-command streaming is opt-in via console "FC".
+bool g_cmdCapture = false;
 struct FCmdRec {
 	uint8_t dir; // 0 = SET (host->puck write), 1 = GET (host read)
 	uint8_t iface; // HID interface index = bond slot the command hit
@@ -160,24 +162,57 @@ static void fcPush(uint8_t dir, int iface, uint8_t rid, uint8_t cmd,
 	}
 	__set_PRIMASK(pm);
 }
+#ifndef FC_DRAIN_MAX_PER_LOOP
+#define FC_DRAIN_MAX_PER_LOOP 1u
+#endif
 void puckCmdLogDrain(void)
 {
-	// boosted: runs at Steam's feature-storm rate and CDC flush enters the same TinyUSB DMA claim window
-	// as HID sends (the issue-72 livelock; see usb_tx.cpp)
-	usbTxBoost();
-	while (g_fcHead != g_fcTail) {
-		if (Serial.availableForWrite() < 70)
-			break; // don't stall loop on CDC backpressure; resume next iteration
+	if (!g_cmdCapture || g_fcHead == g_fcTail)
+		return;
+
+	for (uint8_t drained = 0;
+	     drained < FC_DRAIN_MAX_PER_LOOP && g_fcHead != g_fcTail;
+	     drained++) {
 		FCmdRec r = g_fc[g_fcTail];
+
+		// Format only in the normal loop task (large stack), never on TinyUSB's
+		// ~800-byte usbd callback stack. One bounded line + one CDC write keeps
+		// diagnostics from monopolizing the RF/USB loop under feature storms.
+		char line[128];
+		int used = snprintf(line, sizeof line,
+				    "# FC %s if=%u rid=%u cmd=%02X len=%u:",
+				    r.dir ? "GET" : "SET", r.iface, r.rid,
+				    r.cmd, r.len);
+		if (used < 0)
+			return;
+		if (used >= (int)sizeof line)
+			used = sizeof line - 1;
+
+		for (uint8_t i = 0; i < 10 && used < (int)sizeof line - 4;
+		     i++) {
+			int n = snprintf(line + used,
+					 sizeof line - (size_t)used, " %02X",
+					 r.b[i]);
+			if (n <= 0)
+				break;
+			if (n >= (int)(sizeof line - (size_t)used)) {
+				used = sizeof line - 1;
+				break;
+			}
+			used += n;
+		}
+		if (used < (int)sizeof line - 1)
+			line[used++] = '\n';
+
+		// Preserve the record when CDC is full; retry it on the next loop.
+		if (Serial.availableForWrite() < used)
+			break;
+
 		g_fcTail = (uint8_t)((g_fcTail + 1) & 31);
-		Serial.printf("# FC %s if=%u rid=%u cmd=%02X len=%u:",
-			      r.dir ? "GET" : "SET", r.iface, r.rid, r.cmd,
-			      r.len);
-		for (uint8_t i = 0; i < 10; i++)
-			Serial.printf(" %02X", r.b[i]);
-		Serial.println();
+		usbTxBoost();
+		Serial.write((const uint8_t *)line, (size_t)used);
+		usbTxUnboost();
 	}
-	usbTxUnboost();
 }
 
 // ===================== seamless LIZARD decision =====================
@@ -239,8 +274,8 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 	//   0x83 HAPTIC_LFO_TONE(9) 0x84 HAPTIC_LOG_SWEEP(8) 0x85 HAPTIC_SCRIPT(3)  0x86 (3, unnamed)
 	// These ids are NOT the feature-0x01 command ids (controller_constants.h) -- same numbers, different
 	// meanings -- so a rule written for one channel must never be applied to the other.
-	// The 63-byte settings/config reports 0x87/0x88/0x89 are NOT haptics and reach the controller via the
-	// feature-0x01 passthrough path instead.
+	// OUTPUT 0x87/0x88/0x89 are Triton PCM reports, a separate HID namespace
+	// from FEATURE commands with overlapping numeric IDs; full 63-byte bodies use the PCM queue.
 	if (type == HID_REPORT_TYPE_OUTPUT) {
 		if (rid >= 0x80 && rid <= 0x89) {
 			// capture ALL OUTPUT reports (even un-relayed) for the 'H' dump
@@ -266,31 +301,35 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 		// (issues #163 / #166): "Soft Press" survived because it rides 0x82 ID_OUT_REPORT_HAPTIC_COMMAND,
 		// while every pulse-based click was thrown away. Pulses are self-terminating (repeat_count in the
 		// payload), so there is no latch to strand and no stop frame to lose.
-		if (g_hapticRelay && rid >= 0x80 && rid <= 0x86 && n >= 1 &&
-		    hapticRelaySlotOk(slot) && !lizardActive() && !muted) {
-			if (!haptic82Blocked(slot)) {
-				relayEnqueue(rid, b,
-					     (uint8_t)(n > RELAY_MAXP ?
-							       RELAY_MAXP :
-							       n),
-					     true, (uint8_t)slot);
+		uint8_t liveOutputTargets = 0,
+			outputRouteDecision = HROUTE_NO_LIVE;
+		int resolvedSlot = hapticResolveRelaySlot(
+			slot, &liveOutputTargets, &outputRouteDecision);
+		bool outputRelayAllowed =
+			g_hapticRelay && rid >= 0x80 && rid <= 0x89 && n >= 1 &&
+			resolvedSlot >= 0 && !lizardActive() && !muted;
+		if (outputRelayAllowed) {
+			if (!haptic82Blocked(resolvedSlot)) {
+				if (rid >= 0x87 && rid <= 0x89) {
+					if (n == 63u)
+						pcmEnqueue(
+							rid, b, n,
+							(uint8_t)resolvedSlot);
+				} else {
+					relayEnqueue(
+						rid, b,
+						(uint8_t)(n > RELAY_MAXP ?
+								  RELAY_MAXP :
+								  n),
+						true, (uint8_t)resolvedSlot);
+				}
 			}
 		}
 
-#if OPK_LOG
 		// Per-report Serial echo: gated to the diagnostic build only. handleSet runs on the TinyUSB device
-		// task, whose FreeRTOS stack is just 800 bytes; a Serial.printf there costs 200-500B and, stacked
-		// under TinyUSB's control-transfer frames + a preempting USB ISR, can blow the stack -> the exact
-		// SP-corruption-during-exception-entry that shows up as RR_LOCKUP. Production keeps this path
-		// printf-free; the same data is already in the OPK_LOG capture ring (hapLogAdd) for the WebUSB panel.
-		if (Serial.availableForWrite() > 80) {
-			Serial.printf("# OUT if%d rid=%02X n=%u:", slot, rid,
-				      n);
-			for (uint16_t i = 0; i < n && i < 14; i++)
-				Serial.printf(" %02X", b[i]);
-			Serial.println();
-		}
-#endif
+		// task, whose FreeRTOS stack is just 800 bytes; formatted Serial output there can exhaust the stack
+		// underneath TinyUSB control-transfer frames and a preempting USB ISR. Production keeps this path
+		// printf-free; the same data is captured to the OPK_LOG ring and formatted later from loop().
 		return;
 	}
 	if (type != HID_REPORT_TYPE_FEATURE || n < 1)
@@ -323,14 +362,15 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 		}
 	}
 
-	// Controller power-off: Steam's "turn off controller" is feature-0x01 frame 9F 04 6F 66 66 21 ("off!"),
-	// confirmed from a real puck capture. The feature-0x01 relay below forwards it once; hapticSendShutdown
-	// bursts it for NO-ACK reliability. Slot-targeted: the command arrived on THIS controller's interface,
-	// so only this controller powers off (broadcasting killed all connected controllers at once).
-
-	// TODO: Why do we spam this? Doesn't the controller respond with a TAG4 upon command receival?
-	if (rid == 1 && cmd == IBEX_CMD_TURN_OFF_CONTROLLER)
+	// 0x9F is the feature-command namespace's TURN_OFF_CONTROLLER command.
+	// It arrived on this controller's interface, so only this slot is targeted;
+	// broadcast shutdown remains reserved for host-suspend/panel paths.
+	// hapticSendShutdown queues the single RF write and updates presentation state;
+	// return so generic feature passthrough cannot enqueue a duplicate copy.
+	if (rid == 1 && cmd == IBEX_CMD_TURN_OFF_CONTROLLER) {
 		hapticSendShutdown((uint8_t)slot);
+		return;
+	}
 
 	// report 0x01 = raw passthrough -> queue for RF relay to the controller
 	if (rid == 1 && n >= 2) {
@@ -378,6 +418,23 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 
 		// clang-format on
 
+		uint32_t queryGeneration = 0;
+		if (relayQuery && slot >= 0 && slot < NSLOT) {
+			uint32_t pm = __get_PRIMASK();
+			__disable_irq();
+			queryGeneration = S.queryHostGeneration + 1u;
+			if (queryGeneration == 0u)
+				queryGeneration = 1u;
+			S.queryHostGeneration = queryGeneration;
+			if (S.queryResponseReady) {
+				S.queryResponseReady = 0;
+				S.queryResponseCmd = 0;
+				S.queryResponseSelector = 0;
+				S.queryResponseSelectorValid = 0;
+				S.queryResponseGeneration = 0;
+			}
+			__set_PRIMASK(pm);
+		}
 		bool queryArmed = false;
 		bool relayOk = hapticRelaySlotOk(slot) && !localAnswer;
 		if (relayOk) {
@@ -385,17 +442,15 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 			// multi-register 0x87 settings blocks (LED brightness) and calibration writes exceed the old
 			// 18B cap, and the chopped frames were why those settings never landed on the controller.
 			uint8_t rl = (len <= pln) ? len : (uint8_t)pln;
-#if OPK_LOG
-			if (len > RELAY_MAXP && Serial.availableForWrite() > 60)
-				Serial.printf(
-					"# RELAY TRUNC cmd=%02X len=%u>%u\n",
-					cmd, len, (unsigned)RELAY_MAXP);
-#endif
-			relayEnqueue(cmd, pl, rl, false, (uint8_t)slot,
-				     relayQuery);
+			// Diagnostic build only -- no formatted Serial output on the 800-byte usbd-task stack in production.
+			// The GET is captured to the OPK_LOG ring above and drained from loop context.
+			bool queued = relayEnqueue(cmd, pl, rl, false,
+						   (uint8_t)slot, relayQuery);
+			// relayEnqueue snapshots the host generation into this response-bearing FIFO entry.
 
-			if (relayQuery && slot >= 0 && slot < NSLOT) {
-				g_slot[slot].pendingQueryCmd = cmd;
+			if (relayQuery && queued && slot >= 0 && slot < NSLOT) {
+				// Actual ownership is armed by rfConnFlushRelay at RF transmit time.
+				g_slot[slot].pendingQueryFailed = 0;
 				queryArmed = true;
 			}
 		}
@@ -406,24 +461,29 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 		// GET(rid=1), seeing pendingQueryCmd==0, would silently hand Steam stale/wrong data instead of
 		// a defined answer. Same echo shape the old always-run `default:` switch case used.
 		if (!queryArmed) {
-			S.resp[0] = cmd;
-			S.resp[1] = len;
-			if (pln)
-				memcpy(S.resp + 2, pl, pln > 60 ? 60 : pln);
-			S.resp_len = 63;
+			if (relayQuery && queryGeneration != 0u) {
+				uint32_t pm = __get_PRIMASK();
+				__disable_irq();
+				S.queryConsumedGeneration = queryGeneration;
+				__set_PRIMASK(pm);
+			}
+			// Ordinary RID1 writes may still relay, but a completed controller query
+			// owns S.resp until its first matching GET consumes it.
+			uint32_t pm = __get_PRIMASK();
+			__disable_irq();
+			if (!S.queryResponseReady) {
+				S.resp[0] = cmd;
+				S.resp[1] = len;
+				if (pln)
+					memcpy(S.resp + 2, pl,
+					       pln > 60 ? 60 : pln);
+				S.resp_len = 63;
+			}
+			__set_PRIMASK(pm);
 		}
 	}
-#if OPK_LOG
-	// Diagnostic-build only -- see the OUTPUT-path note: no Serial.printf on the 800B usbd-task stack in
-	// production (LOCKUP mitigation). The feature SET is already captured to the OPK_LOG ring above.
-	if (Serial.availableForWrite() > 80) {
-		Serial.printf("# SET if%d rid=%02X cmd=%02X len=%u:", slot, rid,
-			      cmd, len);
-		for (uint16_t i = 0; i < n && i < 14; i++)
-			Serial.printf(" %02X", b[i]);
-		Serial.println();
-	}
-#endif
+	// Diagnostic-build only -- see the OUTPUT-path note: no formatted Serial output on the 800-byte usbd-task
+	// stack in production. The feature SET is already captured to the OPK_LOG ring above and drained in loop().
 	if (rid == 2) {
 		memset(S.resp, 0, sizeof S.resp);
 		S.resp_len = 0;
@@ -442,32 +502,56 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 		break;
 	case IBEX_CMD_GET_STRING_ATTRIBUTE: { // 0xAE
 		uint8_t idx = pln > 0 ? pl[0] : 1;
-		// Report-id 1 = string attributes of the bonded CONTROLLER, not the puck. Not handled here, this request
-		// will have been forwarded to the controller by earlier code.
 		S.resp[0] = IBEX_CMD_GET_STRING_ATTRIBUTE;
-		S.resp[1] = 0x14; // todo: is this correct?
+		S.resp[1] =
+
+			// 20 value bytes: selector + at most 19 text bytes
+			0x14;
 		S.resp[2] = idx;
 		memset(S.resp + 3, 0, 60);
-		// Any other idx -> "NA".
-		const char *s = (idx == 0 || idx == 4) ? g_board :
-				(idx == 1)	       ? g_unit :
-				(idx == 3)	       ? "OpenPuck " :
-							 "NA";
-		memcpy(S.resp + 3, s, strlen(s));
 		if (idx == 3) {
 			// The official puck has a 12-character GIT commit hash of the firmware in here.
-			// Since I doubt any official process is ever going to parse / use this,
-			// looks like the perfect place to put the OpenPuck version number.
-			char *off = (char *)(S.resp + 3 + strlen(s));
-			memcpy(off, OPK_BUILD_VERSION,
-			       strlen(OPK_BUILD_VERSION));
-			off += strlen(OPK_BUILD_VERSION);
-			memcpy(off, " ", 1);
-			memcpy(off + 1, OPK_GIT_HASH, strlen(OPK_GIT_HASH));
-			if (OPK_GIT_DIRTY != 0) {
-				off += 1 + strlen(OPK_GIT_HASH);
-				memcpy(off, "-dirty", 6);
+			// OpenPuck uses the same slot for its build version plus an 8-character Git hash.
+			// Reserve the complete OpenPuck hash; truncate only version text.
+			const size_t textCap = 19u;
+			const char *hash = OPK_GIT_HASH;
+			size_t hashLen = strlen(hash);
+			if (hashLen > 8u)
+				hashLen = 8u;
+			size_t used = 0u;
+			memcpy(S.resp + 3, "OPK-", 4u);
+			used = 4u;
+			if (OPK_BUILD_VERSION[0] != '\0') {
+				size_t reserve = hashLen ? 1u + hashLen : 0u;
+				size_t room = textCap - used;
+				size_t versionCap =
+					room > reserve ? room - reserve : 0u;
+				size_t versionLen = strlen(OPK_BUILD_VERSION);
+				if (versionLen > versionCap)
+					versionLen = versionCap;
+				if (versionLen) {
+					memcpy(S.resp + 3 + used,
+					       OPK_BUILD_VERSION, versionLen);
+					used += versionLen;
+				}
+				if (hashLen && used < textCap)
+					S.resp[3 + used++] = ' ';
 			}
+			if (hashLen && used < textCap) {
+				size_t n = textCap - used;
+				if (n > hashLen)
+					n = hashLen;
+				memcpy(S.resp + 3 + used, hash, n);
+			}
+		} else {
+			// Any other idx -> "NA".
+			const char *value = (idx == 0 || idx == 4) ? g_board :
+					    (idx == 1)		   ? g_unit :
+								     "NA";
+			size_t n = strlen(value);
+			if (n > 19u)
+				n = 19u;
+			memcpy(S.resp + 3, value, n);
 		}
 		S.resp_len = 63;
 		break;
@@ -492,9 +576,7 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 	case IBEX_CMD_ENABLE_PAIRING: // 0xAD
 		// TODO: Check if this should be relayed?
 		g_pairing = (pln > 0 && pl[0] != 0);
-#if OPK_LOG
-		Serial.printf("# pairing %s\n", g_pairing ? "ON" : "off");
-#endif
+		// OPK_LOG: callback-safe binary capture only; formatted CDC output is deferred to loop().
 		S.resp[0] = IBEX_CMD_ENABLE_PAIRING;
 		S.resp[1] = 0;
 		S.resp_len = 63;
@@ -515,10 +597,7 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 					relayClearSlot((uint8_t)slot);
 			}
 			g_dirty = true;
-#if OPK_LOG
-			Serial.printf("# slot %d %s\n", slot,
-				      recEmpty(pl) ? "cleared" : "bonded");
-#endif
+			// OPK_LOG: callback-safe binary capture only; formatted CDC output is deferred to loop().
 		}
 		S.resp[0] = IBEX_CMD_TRITON_A2_OBSERVED_PAIRING_RECORD;
 		S.resp[1] = 0;
@@ -556,10 +635,8 @@ static uint16_t handleGet(int slot, uint8_t rid, hid_report_type_t type,
 	// GET-based stamp entirely; a read alone no longer suppresses lizard.
 	Slot &S = g_slot[slot];
 
-	// A feature-01 query (0x83/0xAE/0xED, relayed for real when rid==1 -- see handleSet's `relayQuery`)
-	// is still waiting on the controller's actual reply: `resp` only holds the local placeholder for it
-	// right now (pendingQueryCmd, bonds.h; cleared by rf_link.cpp when the real answer lands).
-	// STALL this GET so the host retries shortly after (-EPIPE), like the real Puck does.
+	// A feature-01 query (0x83/0xAE/0xED, relayed for real when rid==1) can still be waiting on the
+	// controller's actual reply. STALL this GET so the host retries shortly after (-EPIPE), like the real Puck.
 	//
 	// Returning plain 0 does NOT stall here: this device's reports are all NUMBERED (report id 1/2), and
 	// TinyUSB's callback (adafruit/Adafruit_TinyUSB_Arduino, src/class/hid/hid_device.c)
@@ -569,27 +646,71 @@ static uint16_t handleGet(int slot, uint8_t rid, hid_report_type_t type,
 	//   xferlen += tud_hid_get_report_cb(...);   // <- our return value lands here
 	//   TU_ASSERT(xferlen > 0);                  // stalls the control transfer iff this is false
 	// -- so xferlen is already 1 before we're even asked, and adding our 0 leaves it at 1: the assert
-	// never fires and TinyUSB happily ships that lone prepended report-id byte as a "successful" 1-byte
-	// reply.
+	// never fires and TinyUSB happily ships that lone prepended report-id byte as a "successful" 1-byte reply.
 	// This bug has been reported to upstream at https://github.com/hathach/tinyusb/issues/3814
 	//
 	// `xferlen` is uint16_t, so returning (uint16_t)-1 (0xFFFF) makes `1 + 0xFFFF` wrap to exactly 0
-	// -- landing on the SAME TU_ASSERT(xferlen > 0) failure a genuinely-empty callback would have hit,
-
-	// The additional check for rid is necessary so if the controller never replies, a new query for a
-	// puck feature can get the puck un-stuck.
-
+	// -- landing on the SAME TU_ASSERT(xferlen > 0) failure a genuinely-empty callback would have hit.
+	// The generation and pending-query guards below ensure a later independent feature query is not held
+	// behind an abandoned response.
 	// TODO: This is a very, very, very ugly solution and may break with library updates. Can we find a cleaner one?
-	if (rid == 1 && S.pendingQueryCmd != 0 && reqlen > 1) {
+	if (rid == 1 && reqlen > 1 && !S.queryResponseReady &&
+	    S.queryHostGeneration != S.queryConsumedGeneration) {
+		return 0xFFFF;
+	}
+	if (rid == 1 && reqlen > 1 && !S.queryResponseReady &&
+	    (S.pendingQueryCmd != 0 || S.pendingQueryFailed ||
+	     relayQueryPending((uint8_t)slot))) {
 		return 0xFFFF;
 	}
 
 	// rf_link.cpp will set pendingQueryCmd to 0 once the controller answered.
 
-	uint16_t n = S.resp_len ? S.resp_len : 63;
+	// Snapshot the completed response and consume ownership atomically. A
+	// ready response always wins over a later queued query; the queued query can TX
+	// only after this GET releases queryResponseReady.
+	uint16_t n;
+	uint32_t pm = __get_PRIMASK();
+	__disable_irq();
+	n = S.resp_len ? S.resp_len : 63;
 	if (n > reqlen)
 		n = reqlen;
+	bool consumeReady = false;
+	if (rid == 1 && S.queryResponseReady) {
+		bool generationOk = S.queryResponseGeneration != 0u &&
+				    S.queryResponseGeneration ==
+					    S.queryHostGeneration;
+		if (!generationOk) {
+			S.queryResponseReady = 0;
+			S.queryResponseCmd = 0;
+			S.queryResponseSelector = 0;
+			S.queryResponseSelectorValid = 0;
+			S.queryResponseGeneration = 0;
+			__set_PRIMASK(pm);
+			return 0xFFFF;
+		}
+		bool cmdOk = S.resp[0] == S.queryResponseCmd;
+		bool selectorOk =
+			!S.queryResponseSelectorValid ||
+			(S.queryResponseCmd == IBEX_CMD_GET_STRING_ATTRIBUTE &&
+			 S.resp[1] >= 1 &&
+			 S.resp[2] == S.queryResponseSelector);
+		consumeReady = cmdOk && selectorOk;
+		if (!consumeReady) {
+			__set_PRIMASK(pm);
+			return 0xFFFF;
+		}
+	}
 	memcpy(buf, S.resp, n);
+	if (consumeReady) {
+		S.queryConsumedGeneration = S.queryResponseGeneration;
+		S.queryResponseReady = 0;
+		S.queryResponseCmd = 0;
+		S.queryResponseSelector = 0;
+		S.queryResponseSelectorValid = 0;
+		S.queryResponseGeneration = 0;
+	}
+	__set_PRIMASK(pm);
 	// Flight recorder (every GET, un-deduped): a read STORM -- e.g. the "AE x39" identity hammering seen before
 	// the identity fix -- is itself a wedge signal, so we want it filling the post-mortem trail if it happens.
 	faultDiagTrace(FR_GET, (uint16_t)((rid << 8) | S.resp[0]));
@@ -615,21 +736,26 @@ static uint16_t handleGet(int slot, uint8_t rid, hid_report_type_t type,
 			// serial feature-command capture: what Steam READ on this interface + our answer
 			fcPush(1, slot, rid, S.resp[0], (uint8_t)n, S.resp + 2,
 			       10);
-#if OPK_LOG
-			// Diagnostic build only -- no Serial.printf on the 800B usbd-task stack in production (LOCKUP
-			// mitigation). The GET is captured to the OPK_LOG ring above for the WebUSB panel.
-			if (Serial.availableForWrite() > 80)
-				Serial.printf(
-					"# GET if%d rid=%02X reqlen=%u -> %02X %02X %02X (batt=%u%%)\n",
-					slot, rid, reqlen, S.resp[0], S.resp[1],
-					S.resp[2],
-					(slot >= 0 && slot < NSLOT) ?
-						g_battery[slot] :
-						0);
-#endif
+			// OPK_LOG: callback-safe binary capture only; formatted CDC output is deferred to loop().
 		}
 	}
 	return n;
+}
+
+// TinyUSB control SET_REPORT calls the callback with report ID separate from the body.
+// Interrupt OUT calls it as OUTPUT/rid=0 with the report ID in buffer[0]. Normalize
+// that transport difference while keeping handleSet() semantics unchanged.
+static void opkInterruptOutDispatchSet(int slot, uint8_t r, hid_report_type_t t,
+				       uint8_t const *b, uint16_t n)
+{
+	if (t == HID_REPORT_TYPE_OUTPUT && r == 0u) {
+		if (!b || n < 1u)
+			return;
+		handleSet(slot, b[0], HID_REPORT_TYPE_OUTPUT, b + 1,
+			  (uint16_t)(n - 1u));
+		return;
+	}
+	handleSet(slot, r, t, b, n);
 }
 
 // one callback pair per interface (the Adafruit core routes by interface to the matching object)
@@ -637,7 +763,7 @@ static uint16_t handleGet(int slot, uint8_t rid, hid_report_type_t type,
 	static void setcb##N(uint8_t r, hid_report_type_t t, uint8_t const *b, \
 			     uint16_t n)                                       \
 	{                                                                      \
-		handleSet(N, r, t, b, n);                                      \
+		opkInterruptOutDispatchSet(N, r, t, b, n);                     \
 	}                                                                      \
 	static uint16_t getcb##N(uint8_t r, hid_report_type_t t, uint8_t *bf,  \
 				 uint16_t rl)                                  \
@@ -681,7 +807,10 @@ void SteamPuckController::begin()
 	const uint16_t descLen = (g_usbMode == MODE_LIZARD) ?
 					 sizeof PUCK_LIZARD_HID_DESC :
 					 sizeof PUCK_HID_DESC;
+	// Steam slot HIDs expose interrupt OUT; Lizard remains descriptor-compatible IN-only.
+	const bool steamInterruptOut = (g_usbMode == MODE_STEAM);
 	for (int i = 0; i < NSLOT; i++) {
+		hid[i].enableOutEndpoint(steamInterruptOut);
 		hid[i].setReportDescriptor(desc, descLen);
 		hid[i].setReportCallback(GETCB[i], SETCB[i]);
 

--- a/OpenPuck/puck_hid_driver.cpp
+++ b/OpenPuck/puck_hid_driver.cpp
@@ -1,0 +1,119 @@
+#include "puck_hid_driver.h"
+
+#include "bonds.h"
+#include "config.h"
+#include "rf_link.h"
+#include <Arduino.h>
+#include <Adafruit_TinyUSB.h>
+
+extern "C" {
+#include "class/hid/hid_device.h"
+}
+
+// An inactive slot must reject FEATURE report 1 before accepting the control
+// transfer. Accepting it makes host discovery treat an empty slot as a live
+// controller; the ordinary set-report callback runs too late to reject SETUP.
+static int8_t g_puckSlotByInterface[CFG_TUD_INTERFACE_MAX];
+static uint8_t g_nextPuckSlot;
+
+static void puckHidMapReset(void)
+{
+	for (uint8_t i = 0; i < CFG_TUD_INTERFACE_MAX; i++)
+		g_puckSlotByInterface[i] = -1;
+	g_nextPuckSlot = 0;
+}
+
+static void puckHidDriverInit(void)
+{
+	puckHidMapReset();
+}
+
+static bool puckHidDriverDeinit(void)
+{
+	return true;
+}
+
+static void puckHidDriverReset(uint8_t rhport)
+{
+	(void)rhport;
+	puckHidMapReset();
+}
+
+static bool puckHidMode(void)
+{
+	return g_usbMode == MODE_STEAM || g_usbMode == MODE_LIZARD;
+}
+
+static bool puckHidSlotLive(int slot)
+{
+	if (slot < 0 || slot >= NSLOT || !g_slot[slot].used ||
+	    !g_connReplyMs[slot])
+		return false;
+
+	return (uint32_t)(millis() - g_connReplyMs[slot]) < 1200u;
+}
+
+static uint16_t puckHidDriverOpen(uint8_t rhport,
+				  tusb_desc_interface_t const *itf,
+				  uint16_t maxLen)
+{
+	if (!puckHidMode() || itf->bInterfaceClass != TUSB_CLASS_HID ||
+	    itf->bInterfaceSubClass != HID_SUBCLASS_NONE ||
+	    itf->bInterfaceProtocol != HID_ITF_PROTOCOL_NONE)
+		return 0;
+
+	if (g_nextPuckSlot >= NSLOT ||
+	    itf->bInterfaceNumber >= CFG_TUD_INTERFACE_MAX)
+		return 0;
+
+	uint16_t used = hidd_open(rhport, itf, maxLen);
+	if (!used)
+		return 0;
+
+	g_puckSlotByInterface[itf->bInterfaceNumber] = g_nextPuckSlot++;
+	return used;
+}
+
+static int puckHidSlotForRequest(tusb_control_request_t const *request)
+{
+	uint16_t itf = request->wIndex;
+	if (itf >= CFG_TUD_INTERFACE_MAX)
+		return -1;
+	return g_puckSlotByInterface[itf];
+}
+
+static bool puckHidDriverControl(uint8_t rhport, uint8_t stage,
+				 tusb_control_request_t const *request)
+{
+	if (stage == CONTROL_STAGE_SETUP &&
+	    request->bmRequestType_bit.type == TUSB_REQ_TYPE_CLASS &&
+	    request->bRequest == HID_REQ_CONTROL_SET_REPORT) {
+		uint8_t reportType = tu_u16_high(request->wValue);
+		uint8_t reportId = tu_u16_low(request->wValue);
+		int slot = puckHidSlotForRequest(request);
+
+		if (slot >= 0 && reportType == HID_REPORT_TYPE_FEATURE &&
+		    reportId == 1 && !puckHidSlotLive(slot))
+			return false;
+	}
+
+	return hidd_control_xfer_cb(rhport, stage, request);
+}
+
+static const usbd_class_driver_t g_puckHidDriver = {
+#if CFG_TUSB_DEBUG >= 2
+	.name = "PUCK-HID",
+#endif
+	.init = puckHidDriverInit,
+	.deinit = puckHidDriverDeinit,
+	.reset = puckHidDriverReset,
+	.open = puckHidDriverOpen,
+	.control_xfer_cb = puckHidDriverControl,
+	.xfer_cb = hidd_xfer_cb,
+	.sof = NULL,
+};
+
+const usbd_class_driver_t *puckHidClassDriver(void)
+{
+	return &g_puckHidDriver;
+}

--- a/OpenPuck/puck_hid_driver.h
+++ b/OpenPuck/puck_hid_driver.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "device/usbd_pvt.h"
+
+const usbd_class_driver_t *puckHidClassDriver(void);

--- a/OpenPuck/rf_link.cpp
+++ b/OpenPuck/rf_link.cpp
@@ -4,6 +4,8 @@
 #include "config.h"
 #include "triton.h"
 #include "haptics.h"
+#include "rf_timing.h"
+#include "steam_commands.h"
 #include "puck_hid.h" // g_cmdCapture (suppress I45 during feature-command capture)
 #include "controllers.h"
 #include "status_led.h"
@@ -11,6 +13,8 @@
 #include "usb_mount.h" // modeSwitchReboot()
 #include <Adafruit_TinyUSB.h>
 #include <Arduino.h>
+#include <nrf.h>
+#include <nrf_sdm.h>
 #include <string.h>
 
 bool g_rfHost = true;
@@ -51,6 +55,12 @@ bool g_connVerbose = false;
 // field, and doing so silently starves the poll cycle. Any persisted/old value is ignored.
 const uint32_t g_rxWin = 1200;
 unsigned long g_connCooldown = 0;
+
+static inline bool connCooldownDone()
+{
+	// Zero means no post-disconnect cooldown.
+	return g_connCooldown == 0 || millis() - g_connCooldown > 2500u;
+}
 
 uint8_t g_connSt = 0; // 0=announce awake, 1=poll loop
 uint8_t g_connStep = 0; // repeat counter within a state
@@ -291,11 +301,37 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 	NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk |
 			    RADIO_SHORTS_ADDRESS_RSSISTART_Msk |
 			    RADIO_SHORTS_DISABLED_RSSISTOP_Msk;
+	// Clear sticky packet-event latches before arming the bounded feature-response
+	// timer so captures belong to this RX window.
+	NRF_RADIO->EVENTS_ADDRESS = 0;
+	NRF_RADIO->EVENTS_PAYLOAD = 0;
+	NRF_RADIO->EVENTS_CRCOK = 0;
+	NRF_RADIO->EVENTS_CRCERROR = 0;
+	NRF_RADIO->EVENTS_RSSIEND = 0;
 	NRF_RADIO->EVENTS_END = 0;
+	// RX window (tunable 'r'; or relay override)
+	// The bounded timing guard below decides whether a late radio END still belongs to this transaction.
+	const bool timingArmed = rfTimingArm();
 	NRF_RADIO->TASKS_RXEN = 1;
-	uint32_t t0 = micros();
-	while (!NRF_RADIO->EVENTS_END && (micros() - t0) < win) {
-	} // RX window (tunable 'r'; or relay override)
+	const uint32_t rxStartUs = micros();
+	while (!NRF_RADIO->EVENTS_END &&
+	       (uint32_t)(micros() - rxStartUs) < win) {
+	}
+	if (timingArmed)
+		rfTimingCaptureDecision();
+
+	uint32_t completionDeadline = 0;
+	bool completionGuard = false;
+	if (timingArmed && !NRF_RADIO->EVENTS_END &&
+	    rfTimingBeginCompletionGuard(400u, &completionDeadline)) {
+		completionGuard = true;
+		while (!NRF_RADIO->EVENTS_END &&
+		       !rfTimingCompletionDeadlineReached(completionDeadline)) {
+		}
+	}
+	if (timingArmed && !completionGuard && !NRF_RADIO->EVENTS_END)
+		rfTimingWaitForAcquisition(100u, 400u, 250u);
+
 	uint8_t rxlen = 0;
 	if (NRF_RADIO->EVENTS_END) {
 		NRF_RADIO->EVENTS_END = 0;
@@ -366,8 +402,10 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 								  8u) :
 							rs;
 			}
-			if (rtype == 0xF1)
+			if (rtype == 0xF1) {
 				g_stF1[slot]++;
+				g_connF1++;
+			}
 			// controller disconnecting/powering off -> back off 2.5s so we don't immediately re-wake it.
 			// BUT only when no OTHER slot is still live: g_connCooldown is global and gates ALL polling +
 			// beacons, so backing off because ONE controller powered off would drop every other connected
@@ -420,7 +458,6 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 			if (isF1 && (g_curSlot < 0 || g_curSlot >= NSLOT))
 				isF1 = false;
 			if (isF1) {
-				g_connF1++;
 				// walk ALL type6 TLVs (= HID report 0x45); taking only [0] halves the rate. idx is INT,
 				// not uint8_t: tlen 0xFE would make idx+=tlen+2 wrap mod-256 -> infinite loop -> USB hang.
 				int idx = 3, end = rxlen + 2;
@@ -618,13 +655,19 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 								uint8_t)(TB_A |
 									 TB_B |
 									 TB_X |
-									 TB_Y);
+									 TB_Y |
+									 TB_R4);
 							((uint8_t *)rep)[3] &= ~(
-								uint8_t)((TB_DDN |
+								uint8_t)((TB_R5 |
+									  TB_DDN |
 									  TB_DRT |
 									  TB_DLF |
 									  TB_DUP) >>
 									 8);
+							((uint8_t *)rep)[4] &= ~(
+								uint8_t)((TB_L4 |
+									  TB_L5) >>
+									 16);
 						}
 						// Hand the report to the active controller. STREAM modes ignore it (they emit from task() reading
 						// g_in); PUSH modes (Xbox, puck/lizard) build + send their host report here.
@@ -694,44 +737,215 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 					} else if ((ttype == 2 || ttype == 4) &&
 						   tlen >= 1 &&
 						   (size_t)(idx + 2) + tlen <=
-							   sizeof(rfrx)) {
-						// tag 0x02 ("control/status field") and tag 0x04 ("bulk data blob") --
-						// docs/PROTOCOL.md sec 7.3. CONFIRMED from a real puck<->controller capture
-						// (2026-08-10): tag-2 (`00 00 00 00`) is an immediate "request received" ack
-						// for a landed feature-01 query; tag-4, arriving on a LATER poll, carries the
-						// query's real answer as `[echoed report_id][len][payload]`. This is the reply
-						// channel for the feature-01 queries (0x83/0xAE/0xED) puck_hid.cpp now relays
-						// for real when rid==1 -- route it into whichever slot is waiting on exactly
-						// this cmd (pendingQueryCmd, bonds.h), so a stray/late/mismatched tag-4 can't
-						// clobber a slot that has moved on to a different query.
+							   sizeof(rfrx) &&
+						   g_curSlot >= 0 &&
+						   g_curSlot < NSLOT) {
+						// Type-2 is transaction status; Type-4 carries a
+						// feature reply as [cmd][len][payload]. Type-4 may
+						// arrive on a later poll, so acceptance must match
+						// the pending command, selector, and generation.
 						const uint8_t *rec =
 							&rfrx[idx + 2];
-						if (ttype == 4 && tlen >= 2 &&
-						    rec[0] != 0 &&
-						    (uint16_t)(2 + rec[1]) <=
-							    tlen &&
-						    rec[1] <= 61 &&
-						    g_curSlot >= 0 &&
-						    g_curSlot < NSLOT &&
-						    g_slot[g_curSlot].pendingQueryCmd ==
-							    rec[0]) {
-							// `resp`/`resp_len` are also written from handleSet (switch(cmd)) and
-							// read from handleGet -- both on the usbd task. Match the PRIMASK-guard
-							// pattern the rest of this file uses for usbd<->loop shared state
-							// (relayEnqueue/hapLogAdd/fcPush) so a GET_FEATURE can't observe a torn
-							// write mid-memcpy.
-							Slot &S =
-								g_slot[g_curSlot];
-							uint32_t pm =
-								__get_PRIMASK();
-							__disable_irq();
-							S.resp[0] = rec[0];
-							S.resp[1] = rec[1];
-							memcpy(S.resp + 2,
-							       rec + 2, rec[1]);
-							S.resp_len = 63;
-							S.pendingQueryCmd = 0;
-							__set_PRIMASK(pm);
+						Slot &S = g_slot[g_curSlot];
+						if (ttype == 4) {
+							uint8_t reason = 0;
+							if (tlen < 2)
+								reason |= 0x01;
+							else {
+								if (rec[0] == 0)
+									reason |=
+										0x02;
+								if ((uint16_t)(2 +
+									       rec[1]) >
+								    tlen)
+									reason |=
+										0x04;
+								if (rec[1] > 61)
+									reason |=
+										0x08;
+								if (!S.pendingQueryCmd)
+									reason |=
+										0x10;
+								else if (S.pendingQueryCmd !=
+									 rec[0])
+									reason |=
+										0x20;
+								if (rfConnFeatureFetchPending(
+									    (uint8_t)
+										    g_curSlot))
+									reason |=
+
+										// explicit FETCH not complete
+										0x80;
+								if (S.pendingQuerySelectorValid &&
+								    S.pendingQueryCmd ==
+									    IBEX_CMD_GET_STRING_ATTRIBUTE &&
+								    rec[0] ==
+									    S.pendingQueryCmd &&
+								    (rec[1] <
+									     1 ||
+								     tlen < 3 ||
+								     rec[2] !=
+									     S.pendingQuerySelector))
+									reason |=
+										0x40;
+							}
+
+							// Observation only; response acceptance below remains authoritative.
+							rfConnFeatureObserveType4(
+								(uint8_t)
+									g_curSlot,
+								tlen ? rec[0] :
+								       0,
+								reason);
+							rfConnFeatureObserveType4DuringDelayedProbe(
+								(uint8_t)
+									g_curSlot);
+							rfConnFeatureObserveType4AfterStaleReplay(
+								(uint8_t)
+									g_curSlot,
+								tlen ? rec[0] :
+								       0,
+								reason);
+							rfConnFeatureObserveType4DuringPostStaleSilence(
+								(uint8_t)
+									g_curSlot);
+							rfConnFeatureObserveType4AfterNoType4Replay(
+								(uint8_t)
+									g_curSlot,
+								tlen ? rec[0] :
+								       0,
+								reason);
+							rfConnFeatureObserveType4ForPostNoType4Stale(
+								(uint8_t)
+									g_curSlot,
+								tlen ? rec[0] :
+								       0,
+								reason);
+						}
+						if (ttype == 2 && tlen == 4) {
+							// Type-2 is transaction status, never feature data. T1-T3
+							// hardware validation observed zero ACKs and 0xFFFFFFEA rejection.
+							uint32_t raw =
+								(uint32_t)
+									rec[0] |
+								((uint32_t)rec[1]
+								 << 8) |
+								((uint32_t)rec[2]
+								 << 16) |
+								((uint32_t)rec[3]
+								 << 24);
+
+							uint32_t now = millis();
+							bool shutdownOwned =
+								S.shutdownStatusOwnerMs &&
+								(uint32_t)(now -
+									   S.shutdownStatusOwnerMs) <=
+									SHUTDOWN_STATUS_OWNER_MS;
+							if (shutdownOwned) {
+								S.shutdownStatusOwnerMs =
+									0;
+							} else if (S.pendingQueryCmd &&
+								   raw != 0) {
+								uint32_t pm =
+									__get_PRIMASK();
+								__disable_irq();
+								S.pendingQueryCmd =
+									0;
+								S.pendingQueryGeneration =
+									0;
+								S.pendingQueryDeadlineMs =
+									0;
+								S.pendingQuerySelectorValid =
+									0;
+								S.pendingQueryFailed =
+									1;
+								__set_PRIMASK(
+									pm);
+							}
+						} else if (
+							ttype == 4 &&
+							!rfConnFeatureFetchPending(
+								(uint8_t)
+									g_curSlot) &&
+							tlen >= 2 &&
+							rec[0] != 0 &&
+							(uint16_t)(2 +
+								   rec[1]) <=
+								tlen &&
+							rec[1] <= 61 &&
+							S.pendingQueryCmd ==
+								rec[0]) {
+							bool selectorOk =
+								!S.pendingQuerySelectorValid ||
+								(S.pendingQueryCmd ==
+									 IBEX_CMD_GET_STRING_ATTRIBUTE &&
+								 rec[1] >= 1 &&
+								 rec[2] ==
+									 S.pendingQuerySelector);
+							if (selectorOk) {
+								uint32_t pm =
+									__get_PRIMASK();
+								__disable_irq();
+								S.resp[0] =
+									rec[0];
+								S.resp[1] =
+									rec[1];
+								// `resp`/`resp_len` are also written from handleSet (switch(cmd)) and
+								// read from handleGet -- both on the usbd task. Match the PRIMASK-guard
+								// pattern the rest of this file uses for usbd<->loop shared state
+								// (relayEnqueue/hapLogAdd/fcPush) so a GET_FEATURE can't observe a torn
+								// write mid-memcpy. Response ownership metadata stays in the same guard.
+								memcpy(S.resp +
+									       2,
+								       rec + 2,
+								       rec[1]);
+								S.resp_len = 63;
+								// The RF response remains transport-valid, but only the generation
+								// belonging to the latest response-bearing host SET may become GET-ready.
+								uint32_t responseGeneration =
+									S.pendingQueryGeneration;
+								bool generationCurrent =
+									responseGeneration !=
+										0u &&
+									responseGeneration ==
+										S.queryHostGeneration;
+								if (generationCurrent) {
+									S.queryResponseReady =
+										1;
+									S.queryResponseCmd =
+										rec[0];
+									S.queryResponseSelectorValid =
+										S.pendingQuerySelectorValid;
+									S.queryResponseSelector =
+										S.pendingQuerySelector;
+									S.queryResponseGeneration =
+										responseGeneration;
+								} else {
+									S.queryResponseReady =
+										0;
+									S.queryResponseCmd =
+										0;
+									S.queryResponseSelector =
+										0;
+									S.queryResponseSelectorValid =
+										0;
+									S.queryResponseGeneration =
+										0;
+								}
+								S.pendingQueryCmd =
+									0;
+								S.pendingQueryGeneration =
+									0;
+								S.pendingQueryFailed =
+									0;
+								S.pendingQueryDeadlineMs =
+									0;
+								S.pendingQuerySelectorValid =
+									0;
+								__set_PRIMASK(
+									pm);
+							}
 						}
 					}
 
@@ -833,6 +1047,7 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 		g_stNoRx[slot]++;
 		g_qosBad++;
 	}
+	rfTimingFinish();
 	NRF_RADIO->TASKS_DISABLE = 1;
 	RWAIT_DISABLED();
 	NRF_RADIO->EVENTS_DISABLED = 0;
@@ -898,7 +1113,10 @@ static void rfConnStep()
 	// controllers per cycle. Polling one-slot-per-call instead tied the per-slot rate to the
 	// loop frequency AND split it across slots, collapsing 2 controllers to ~90 Hz.
 	uint32_t nowUs = micros();
-	if ((uint32_t)(nowUs - g_lastPollUs) < (uint32_t)g_pollUs)
+	bool pcmFastCycle = pcmAnyActive();
+	uint32_t pollCycleUs = pcmFastCycle ? (uint32_t)PCM_ACTIVE_CYCLE_US :
+					      (uint32_t)g_pollUs;
+	if ((uint32_t)(nowUs - g_lastPollUs) < pollCycleUs)
 		return;
 	{
 		// Cycle period stat: time between gate fires (= each slot's poll period, intended g_pollUs).
@@ -909,8 +1127,8 @@ static void rfConnStep()
 		}
 		lastCycleUs = nowUs;
 	}
-	g_lastPollUs += g_pollUs;
-	if ((uint32_t)(nowUs - g_lastPollUs) >= (uint32_t)g_pollUs)
+	g_lastPollUs += pollCycleUs;
+	if ((uint32_t)(nowUs - g_lastPollUs) >= pollCycleUs)
 		g_lastPollUs = nowUs; // catch-up reset when a cycle overran
 
 	unsigned long nowMs = millis();
@@ -926,30 +1144,74 @@ static void rfConnStep()
 			rfConnTx(ch, 0x01, pa, 3, 600);
 		}
 		rfConnQueueHapticRelay();
-		{
-			uint8_t rs1 =
-				(uint8_t)((((g_relayPid[k]++) & 3) << 1) | 1);
-			if (rfConnFlushRelay(ch, rs1))
-				g_stRelay[k]++;
-		}
 		// per-slot PID cycle so each bonded controller's polls stay distinct
 		uint8_t pidv = g_pollPid[k]++;
 		uint8_t s1 = (g_e3mode == 1) ?
 				     (uint8_t)(((pidv & 3) << 1) | 1) :
 			     (g_e3mode == 2) ? (uint8_t)((pidv & 3) << 1) :
 					       0x07;
-		uint8_t rx;
-		if (g_pollGet) {
-			// legacy: E3 + TLV [len=02][subtype=01 GET][id=0x45][param]
-			uint8_t p[5] = { 0xE3, 0x02, 0x01, 0x45, g_getParam };
-			rx = rfConnTx(ch, s1, p, 5);
+		uint8_t rx = 0;
+		bool forceOrdinaryFeaturePoll =
+			rfConnFeatureForceOrdinaryPoll((uint8_t)k);
+		bool featureFetchEligible =
+			rfConnFeatureFetchEligible((uint8_t)k);
+		bool featureTurnConsumed = false;
+		bool featureOrPcmNeedsStandalone =
+			pcmRelayNeedsStandalone((uint8_t)k) ||
+			featureFetchEligible;
+		bool pcmActive = pcmSessionActive((uint8_t)k);
+		bool pcmPending = pcmRelayPending((uint8_t)k);
+		// Response-bearing feature queries must run in their own RF turn.
+		// Fire-and-forget relay traffic can wait behind an active PCM stream.
+		bool deferRelayForPcm = pcmActive && pcmPending &&
+					!featureOrPcmNeedsStandalone;
+		if (!forceOrdinaryFeaturePoll && !featureOrPcmNeedsStandalone &&
+		    rfConnFlushPcm(ch, s1, &rx)) {
+			g_stRelay[k]++;
 		} else {
-			// real puck: BARE E3 (just the opcode) -- the controller streams F1 to any E3 ack
-			uint8_t p[1] = { 0xE3 };
-			rx = rfConnTx(ch, s1, p, 1);
+			if (!forceOrdinaryFeaturePoll && !deferRelayForPcm) {
+				uint8_t rs1 = (uint8_t)((((g_relayPid[k]++) & 3)
+							 << 1) |
+							1);
+				if (rfConnFlushRelay(ch, rs1))
+					g_stRelay[k]++;
+				featureTurnConsumed =
+					rfConnFeatureTurnConsumed((uint8_t)k);
+			}
+			if (!featureTurnConsumed) {
+				bool coframeWaitPollAuth =
+					rfConnFeatureCoframeWaitPollAuthBegin(
+						(uint8_t)k);
+				bool lateWaitPollAuth =
+					!coframeWaitPollAuth &&
+					rfConnFeatureLateWaitPollAuthBegin(
+						(uint8_t)k);
+
+				// Only ordinary E3 polls contribute to link-quality evidence;
+				// relay/feature transactions have different reply semantics.
+				if (g_pollGet) {
+					// legacy: E3 + TLV [len=02][subtype=01 GET][id=0x45][param]
+					uint8_t p[5] = { 0xE3, 0x02, 0x01, 0x45,
+							 g_getParam };
+					rx = rfConnTx(ch, s1, p, sizeof p);
+				} else {
+					// real puck: BARE E3 (just the opcode) -- the controller streams F1 to any E3 ack
+					uint8_t p[1] = { 0xE3 };
+					rx = rfConnTx(ch, s1, p, sizeof p);
+				}
+				if (coframeWaitPollAuth)
+					rfConnFeatureCoframeWaitPollAuthEnd(
+						(uint8_t)k);
+				else if (lateWaitPollAuth)
+					rfConnFeatureLateWaitPollAuthEnd(
+						(uint8_t)k);
+				else
+					rfConnFeaturePollCompleted((uint8_t)k);
+			}
 		}
 		if (rx)
 			g_chF1[0]++;
+
 		g_stPoll[k]++; // one true poll cycle for this slot
 		g_connPoll++;
 	};
@@ -1009,7 +1271,7 @@ void rfLinkTask()
 	// Poll before beacons: the cycle gate must fire as close to its
 	// 4 ms deadline as possible; beacon TX (up to 3.6 ms for 4 slots)
 	// runs after so it never delays the current poll.
-	if (g_connOn && millis() - g_connCooldown > 2500) {
+	if (g_connOn && connCooldownDone()) {
 		rfConnStep();
 	} // connected-mode: poll controller, read input
 
@@ -1017,7 +1279,7 @@ void rfLinkTask()
 	// real puck's per-hop-cycle announce) to stay synced and keep answering polls at full rate; suppressing it
 	// drops the reply rate from ~210/s to ~38/s. Paused only during the post-disconnect cooldown so a controller
 	// that's powering off isn't immediately re-woken/reconnected.
-	if (g_rfHost && millis() - g_connCooldown > 2500) {
+	if (g_rfHost && connCooldownDone()) {
 		bool connNow = anySlotLinkUp();
 		// session keepalive on the clean channel: every loop while connecting (fast), every 25ms once connected
 		// (every-loop beaconing also hammers the session ch and steals reply slots from the poll). The real puck
@@ -1087,7 +1349,7 @@ void rfLinkTask()
 	// connected slot being stalled, so one controller walking off (others still live) never trips it; the
 	// cooldown gate keeps it from firing while a controller is intentionally powering off; rate-limited so it
 	// cannot thrash. g_rfStallRecover is surfaced to the panel so the wedge -- and its recovery -- is observable.
-	if (g_connOn && g_curSlot >= 0 && millis() - g_connCooldown > 2500) {
+	if (g_connOn && g_curSlot >= 0 && connCooldownDone()) {
 		static unsigned long lastRecoverMs = 0;
 		static uint8_t consecStall = 0;
 		unsigned long nowMs2 = millis();

--- a/OpenPuck/rf_timing.cpp
+++ b/OpenPuck/rf_timing.cpp
@@ -1,0 +1,200 @@
+#include "rf_timing.h"
+
+#include <nrf.h>
+
+#define RF_TIMING_PPI_READY 13u
+#define RF_TIMING_PPI_ADDRESS 14u
+#define RF_TIMING_PPI_PAYLOAD 15u
+#define RF_TIMING_PPI_END 16u
+#define RF_TIMING_PPI_MASK                                             \
+	((1u << RF_TIMING_PPI_READY) | (1u << RF_TIMING_PPI_ADDRESS) | \
+	 (1u << RF_TIMING_PPI_PAYLOAD) | (1u << RF_TIMING_PPI_END))
+#define RF_TIMING_SENTINEL 0xFFFFFFFFu
+#define RF_TIMING_TICKS_PER_US 16u
+
+struct RfTimingState {
+	bool armed;
+	uint32_t baseTicks;
+	uint32_t decisionTicks;
+	uint32_t addressAtDecisionTicks;
+};
+
+static RfTimingState g_rfTiming = {};
+static bool g_rfTimingReady = false;
+static bool g_rfTimingConflict = false;
+static bool g_featureResponseTiming = false;
+
+void rfTimingBeginFeatureResponse()
+{
+	g_featureResponseTiming = true;
+}
+
+void rfTimingEndFeatureResponse()
+{
+	g_featureResponseTiming = false;
+}
+
+static void rfTimingInitHardware()
+{
+	if (g_rfTimingReady || g_rfTimingConflict)
+		return;
+
+	// These channels are reserved for RF timing. If another subsystem owns any
+	// of them, fall back to the ordinary RX window instead of stealing hardware.
+	if ((NRF_PPI->CHEN & RF_TIMING_PPI_MASK) || NRF_TIMER3->SHORTS ||
+	    NRF_TIMER3->INTENSET) {
+		g_rfTimingConflict = true;
+		return;
+	}
+	const uint8_t channels[] = { RF_TIMING_PPI_READY, RF_TIMING_PPI_ADDRESS,
+				     RF_TIMING_PPI_PAYLOAD, RF_TIMING_PPI_END };
+	for (uint8_t channel : channels) {
+		if (NRF_PPI->CH[channel].EEP || NRF_PPI->CH[channel].TEP) {
+			g_rfTimingConflict = true;
+			return;
+		}
+	}
+
+	NRF_TIMER3->TASKS_STOP = 1;
+	NRF_TIMER3->MODE = TIMER_MODE_MODE_Timer << TIMER_MODE_MODE_Pos;
+	NRF_TIMER3->BITMODE = TIMER_BITMODE_BITMODE_32Bit
+			      << TIMER_BITMODE_BITMODE_Pos;
+	NRF_TIMER3->PRESCALER = 0; // 16 MHz, 62.5 ns per tick.
+	NRF_TIMER3->TASKS_CLEAR = 1;
+	NRF_TIMER3->TASKS_START = 1;
+
+	NRF_PPI->CH[RF_TIMING_PPI_READY].EEP =
+		(uint32_t)&NRF_RADIO->EVENTS_READY;
+	NRF_PPI->CH[RF_TIMING_PPI_READY].TEP =
+		(uint32_t)&NRF_TIMER3->TASKS_CAPTURE[0];
+	NRF_PPI->CH[RF_TIMING_PPI_ADDRESS].EEP =
+		(uint32_t)&NRF_RADIO->EVENTS_ADDRESS;
+	NRF_PPI->CH[RF_TIMING_PPI_ADDRESS].TEP =
+		(uint32_t)&NRF_TIMER3->TASKS_CAPTURE[1];
+	NRF_PPI->CH[RF_TIMING_PPI_PAYLOAD].EEP =
+		(uint32_t)&NRF_RADIO->EVENTS_PAYLOAD;
+	NRF_PPI->CH[RF_TIMING_PPI_PAYLOAD].TEP =
+		(uint32_t)&NRF_TIMER3->TASKS_CAPTURE[2];
+	NRF_PPI->CH[RF_TIMING_PPI_END].EEP = (uint32_t)&NRF_RADIO->EVENTS_END;
+	NRF_PPI->CH[RF_TIMING_PPI_END].TEP =
+		(uint32_t)&NRF_TIMER3->TASKS_CAPTURE[3];
+	NRF_PPI->CHENCLR = RF_TIMING_PPI_MASK;
+	g_rfTimingReady = true;
+}
+
+bool rfTimingArm()
+{
+	if (!g_featureResponseTiming)
+		return false;
+	rfTimingInitHardware();
+	if (!g_rfTimingReady || g_rfTiming.armed)
+		return false;
+
+	NRF_PPI->CHENCLR = RF_TIMING_PPI_MASK;
+	for (uint8_t capture = 0; capture < 4; capture++)
+		NRF_TIMER3->CC[capture] = RF_TIMING_SENTINEL;
+	NRF_TIMER3->TASKS_CAPTURE[4] = 1;
+	g_rfTiming.baseTicks = NRF_TIMER3->CC[4];
+	g_rfTiming.decisionTicks = g_rfTiming.baseTicks;
+	g_rfTiming.addressAtDecisionTicks = RF_TIMING_SENTINEL;
+	g_rfTiming.armed = true;
+	NRF_PPI->CHENSET = RF_TIMING_PPI_MASK;
+	return true;
+}
+
+void rfTimingCaptureDecision()
+{
+	if (!g_rfTiming.armed)
+		return;
+	NRF_TIMER3->TASKS_CAPTURE[4] = 1;
+	g_rfTiming.decisionTicks = NRF_TIMER3->CC[4];
+	const uint32_t address = NRF_TIMER3->CC[1];
+	if (address != RF_TIMING_SENTINEL &&
+	    (int32_t)(g_rfTiming.decisionTicks - address) >= 0)
+		g_rfTiming.addressAtDecisionTicks = address;
+	else
+		g_rfTiming.addressAtDecisionTicks = RF_TIMING_SENTINEL;
+}
+
+bool rfTimingBeginCompletionGuard(uint16_t maxAfterAddressUs,
+				  uint32_t *deadlineTicks)
+{
+	if (!g_rfTiming.armed || !deadlineTicks || !maxAfterAddressUs ||
+	    g_rfTiming.addressAtDecisionTicks == RF_TIMING_SENTINEL)
+		return false;
+
+	const uint32_t maxTicks =
+		(uint32_t)maxAfterAddressUs * RF_TIMING_TICKS_PER_US;
+	const uint32_t elapsed =
+		g_rfTiming.decisionTicks - g_rfTiming.addressAtDecisionTicks;
+	if (elapsed >= maxTicks)
+		return false;
+	*deadlineTicks = g_rfTiming.addressAtDecisionTicks + maxTicks;
+	return true;
+}
+
+bool rfTimingCompletionDeadlineReached(uint32_t deadlineTicks)
+{
+	if (!g_rfTiming.armed)
+		return true;
+	NRF_TIMER3->TASKS_CAPTURE[4] = 1;
+	return (int32_t)(NRF_TIMER3->CC[4] - deadlineTicks) >= 0;
+}
+
+bool rfTimingWaitForAcquisition(uint16_t afterReadyUs,
+				uint16_t packetAfterAddressUs,
+				uint16_t readyFailsafeFromBaseUs)
+{
+	if (!g_rfTiming.armed || !afterReadyUs || !packetAfterAddressUs ||
+	    !readyFailsafeFromBaseUs ||
+	    g_rfTiming.addressAtDecisionTicks != RF_TIMING_SENTINEL)
+		return false;
+
+	const uint32_t readyWindowTicks =
+		(uint32_t)afterReadyUs * RF_TIMING_TICKS_PER_US;
+	const uint32_t packetWindowTicks =
+		(uint32_t)packetAfterAddressUs * RF_TIMING_TICKS_PER_US;
+	const uint32_t readyFailsafeTicks =
+		g_rfTiming.baseTicks +
+		(uint32_t)readyFailsafeFromBaseUs * RF_TIMING_TICKS_PER_US;
+
+	uint32_t ready = NRF_TIMER3->CC[0];
+	if (ready != RF_TIMING_SENTINEL &&
+	    (int32_t)(g_rfTiming.decisionTicks - (ready + readyWindowTicks)) >=
+		    0)
+		return false;
+
+	while (!NRF_RADIO->EVENTS_END) {
+		const uint32_t address = NRF_TIMER3->CC[1];
+		if (address != RF_TIMING_SENTINEL) {
+			const uint32_t packetDeadline =
+				address + packetWindowTicks;
+			while (!NRF_RADIO->EVENTS_END) {
+				NRF_TIMER3->TASKS_CAPTURE[4] = 1;
+				if ((int32_t)(NRF_TIMER3->CC[4] -
+					      packetDeadline) >= 0)
+					break;
+			}
+			break;
+		}
+
+		ready = NRF_TIMER3->CC[0];
+		NRF_TIMER3->TASKS_CAPTURE[4] = 1;
+		const uint32_t now = NRF_TIMER3->CC[4];
+		if (ready != RF_TIMING_SENTINEL) {
+			if ((int32_t)(now - (ready + readyWindowTicks)) >= 0)
+				break;
+		} else if ((int32_t)(now - readyFailsafeTicks) >= 0) {
+			break;
+		}
+	}
+	return true;
+}
+
+void rfTimingFinish()
+{
+	if (!g_rfTiming.armed)
+		return;
+	NRF_PPI->CHENCLR = RF_TIMING_PPI_MASK;
+	g_rfTiming.armed = false;
+}

--- a/OpenPuck/rf_timing.h
+++ b/OpenPuck/rf_timing.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdint.h>
+
+// Marks a short controller feature transaction whose reply may need the
+// hardware-bounded acquisition/completion extension used by rfConnTx().
+void rfTimingBeginFeatureResponse();
+void rfTimingEndFeatureResponse();
+
+bool rfTimingArm();
+void rfTimingCaptureDecision();
+bool rfTimingBeginCompletionGuard(uint16_t maxAfterAddressUs,
+				  uint32_t *deadlineTicks);
+bool rfTimingCompletionDeadlineReached(uint32_t deadlineTicks);
+bool rfTimingWaitForAcquisition(uint16_t afterReadyUs,
+				uint16_t packetAfterAddressUs,
+				uint16_t readyFailsafeFromBaseUs);
+void rfTimingFinish();

--- a/OpenPuck/usb_app_drivers.cpp
+++ b/OpenPuck/usb_app_drivers.cpp
@@ -3,6 +3,7 @@
 extern "C" const usbd_class_driver_t *usbd_app_driver_get_cb(uint8_t *count)
 {
 	static const usbd_class_driver_t drivers[] = {
+		*puckHidClassDriver(),
 		*xinputClassDriver(),
 		*xboxOgClassDriver(),
 	};

--- a/OpenPuck/usb_app_drivers.h
+++ b/OpenPuck/usb_app_drivers.h
@@ -5,5 +5,6 @@ extern "C" {
 #include "device/usbd_pvt.h"
 }
 
+const usbd_class_driver_t *puckHidClassDriver(void);
 const usbd_class_driver_t *xinputClassDriver(void);
 const usbd_class_driver_t *xboxOgClassDriver(void);

--- a/OpenPuck/wake_hid.cpp
+++ b/OpenPuck/wake_hid.cpp
@@ -47,6 +47,59 @@ bool wakeHidMove(int8_t dx, int8_t dy)
 	return true;
 }
 
+// A device-level resume can be accepted
+// yet still fail to wake some Windows hosts until a real input report arrives on
+// the HID interface the host armed as a wake source. Emit a harmless net-zero
+// boot-mouse nudge after resume. Strict-console personalities omit this interface,
+// so this state machine stays inert there.
+#define NUDGE_JIGGLE_PX 10
+#define NUDGE_STEP_MS 15u
+#define NUDGE_EXPIRE_MS 5000u
+static uint8_t g_wakeNudgeStep = 0; // 0=idle, 1=+X, 2=-X
+static unsigned long g_wakeNudgeArmMs = 0;
+static unsigned long g_wakeNudgeStepMs = 0;
+
+void wakeHidArmNudge()
+{
+	if (!g_wakeHidPresent)
+		return; // intentional strict-console/debug-CDC exception
+	g_wakeNudgeStep = 1;
+	g_wakeNudgeArmMs = millis();
+	g_wakeNudgeStepMs = 0;
+}
+
+void wakeHidTask()
+{
+	if (!g_wakeNudgeStep)
+		return;
+	if (!g_wakeHidPresent) {
+		g_wakeNudgeStep = 0;
+		return;
+	}
+	unsigned long now = millis();
+	if (now - g_wakeNudgeArmMs > NUDGE_EXPIRE_MS) {
+		g_wakeNudgeStep = 0;
+		return;
+	}
+	if (USBDevice.suspended() || !wakeHidReady())
+
+		// wait until the bus has actually resumed and the HID can accept input
+		return;
+	if (g_wakeNudgeStepMs && now - g_wakeNudgeStepMs < NUDGE_STEP_MS)
+		return;
+	int8_t dx = (g_wakeNudgeStep == 1) ? NUDGE_JIGGLE_PX : -NUDGE_JIGGLE_PX;
+	if (!wakeHidMove(dx, 0))
+		return;
+	g_wakeNudgeStepMs = now;
+	if (g_wakeNudgeStep == 1)
+		g_wakeNudgeStep = 2;
+	else
+		g_wakeNudgeStep =
+
+			// +10 then -10: net-zero cursor displacement, no clicks
+			0;
+}
+
 void wakeHidAddInterface()
 {
 	TinyUSBDevice.addInterface(g_wakeHid);

--- a/OpenPuck/wake_hid.h
+++ b/OpenPuck/wake_hid.h
@@ -33,3 +33,9 @@ bool wakeHidReady();
 // send one boot-mouse movement report (buttons=0). This is the input that actually wakes the host: it rides the
 // interface Windows armed as the wake source, unlike a gamepad-slot report. Returns false if not ready.
 bool wakeHidMove(int8_t dx, int8_t dy);
+
+// Arm and service a harmless post-resume net-zero mouse nudge.
+// If this boot intentionally omitted the wake HID (strict console / debug exception),
+// wakeHidArmNudge() is a no-op; Steam's existing puck-HID fallback remains separate.
+void wakeHidArmNudge();
+void wakeHidTask();


### PR DESCRIPTION
Improvements to the core runtime path to closely better follow the official Steam puck, including USB/reliability handling, controller-backed identity and bond management, haptics/PCM output, and Steam HID transport.

Fixes #61 #192 #214 #218 #258 
Steam Haptics Player isn't absolutely perfect just yet, though. Or maybe my ears deceive me.

**Changes:**

- Uses the steady-state bare `E3` polling path at the fixed controller polling cadence.
- Serializes feature queries and haptic traffic per controller so replies remain associated with the correct host request.
- Adds bounded high-resolution RF response timing using TIMER3/PPI.
- Adds the Steam HID interrupt-OUT path required by HardwareUpdater while retaining SET_REPORT compatibility and the existing Steam USB identity. This fixes the issue with Steam being unable to alert you to a Puck or Controller update.
- Expands Steam haptic handling, including rumble shaping, PCM/output processing, autonomous-pad control, reconnect safety, and stuck-rumble protection.
- Keeps Lizard HID transport behavior separate from the Steam interrupt-OUT path.
- Preserves bond/controller identity behavior across the updated transport.
- Suppresses the complete mode-switch chord from the host-facing report while continuing to forward partial combinations normally.
- Hardens RF cold-start behavior, USB startup, watchdog/reset handling, callback-safe logging, and suspend/resume wake behavior.
- Routes haptic and PCM OUTPUT reports to the correct live controller. Before, if you had multiple controllers active on the puck, like for a co-op game, it would at times, albeit rarely, route haptics to the wrong controller.