### PR TITLE
Add Makerdiary MDK USB Dongle support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install adafruit-nrfutil
         # The Adafruit nRF52 build recipe shells out to adafruit-nrfutil to
         # package the DFU .zip; it is not bundled with the core on the runner.
-        run: pip install adafruit-nrfutil
+        run: pip install adafruit-nrfutil intelhex
 
       - name: Install Adafruit nRF52 core
         run: |
@@ -94,6 +94,15 @@ jobs:
       - name: Compile MDBT50Q-CX-40
         run: make build-raytac
 
+      - name: Compile Makerdiary MDK USB Dongle
+        run: make build-mdk
+
+      - name: Build and verify Makerdiary bootloader
+        run: make build-mdk-bootloader
+
+      - name: Generate UF2 (Makerdiary MDK application)
+        run: ./gen_uf2.sh build/mdk/OpenPuck.ino.hex build/mdk/OpenPuck-MDK-application.uf2
+
       - name: Generate UF2 (OpenPuck)
         # The Adafruit nRF52 core leaves its UF2 objcopy recipe commented out in
         # platform.txt, so arduino-cli only emits .hex/.zip. Convert the .hex to
@@ -127,6 +136,26 @@ jobs:
           retention-days: 7
           if-no-files-found: error
           path: build/openpuck/OpenPuck.ino.hex
+
+      - name: Upload Makerdiary MDK application artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: OpenPuck-${{ steps.build_version.outputs.artifact_version }}-mdk-application
+          retention-days: 7
+          if-no-files-found: error
+          path: |
+            build/mdk/OpenPuck.ino.hex
+            build/mdk/OpenPuck-MDK-application.uf2
+
+      - name: Upload Makerdiary bootloader artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: OpenPuck-${{ steps.build_version.outputs.artifact_version }}-mdk-bootloader
+          retention-days: 7
+          if-no-files-found: error
+          path: |
+            build/mdk-bootloader/OpenPuck-MDK-bootloader-0.7.1-openpuck.zip
+            build/mdk-bootloader/Adafruit_nRF52_Bootloader/_build/build-mdk_nrf52840_dongle/mdk_nrf52840_dongle_bootloader-0.7.1-openpuck.hex
 
       - name: Upload ReversePuckFirmware UF2 artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install adafruit-nrfutil
-        run: pip install adafruit-nrfutil
+        run: pip install adafruit-nrfutil intelhex
 
       - name: Install Adafruit nRF52 core
         run: |
@@ -111,6 +111,35 @@ jobs:
         run: |
           mkdir -p build/openpuck build/cache/openpuck
           make build BUILD_PATH=build/cache/openpuck OUTPUT_DIR=build/openpuck
+
+      - name: Compile Makerdiary MDK USB Dongle
+        run: make build-mdk
+
+      - name: Generate UF2 (Makerdiary MDK application)
+        run: ./gen_uf2.sh build/mdk/OpenPuck.ino.hex build/mdk/OpenPuck-MDK-application.uf2
+
+      - name: Extract S140 6.1.1 provisioning image
+        run: |
+          COMBINED="$(find "$HOME/.arduino15/packages/adafruit/hardware/nrf52" -path '*/bootloader/feather_nrf52840_express/*_s140_6.1.1.hex' -print -quit)"
+          test -n "$COMBINED"
+          python3 - "$COMBINED" build/mdk/s140-6.1.1.hex <<'PY'
+          from intelhex import IntelHex
+          import sys
+          source, output = sys.argv[1:]
+          ih = IntelHex(source)
+          out = IntelHex()
+          for start, end in ih.segments():
+              lo, hi = max(start, 0), min(end, 0x26000)
+              for addr in range(lo, hi):
+                  out[addr] = ih[addr]
+          out.write_hex_file(output)
+          PY
+
+      - name: Package Makerdiary first-install UF2
+        run: make package-mdk-first-install SOFTDEVICE_HEX=build/mdk/s140-6.1.1.hex
+
+      - name: Build and verify Makerdiary bootloader
+        run: make build-mdk-bootloader
 
       - name: Generate UF2 (standard)
         run: ./gen_uf2.sh build/openpuck/OpenPuck.ino.hex build/openpuck/OpenPuck.ino.uf2
@@ -160,6 +189,16 @@ jobs:
             ext="${f##*.}"
             cp "$f" "release_assets/ReversePuckFirmware-${VERSION}.${ext}"
           done
+          cp build/mdk/OpenPuck-MDK-application.uf2 \
+            "release_assets/OpenPuck-${VERSION}-mdk-application.uf2"
+          cp build/mdk/OpenPuck.ino.hex \
+            "release_assets/OpenPuck-${VERSION}-mdk-application.hex"
+          cp build/mdk/OpenPuck-MDK-first-install-S140.uf2 \
+            "release_assets/OpenPuck-${VERSION}-mdk-first-install-S140.uf2"
+          cp build/mdk-bootloader/OpenPuck-MDK-bootloader-0.7.1-openpuck.zip \
+            "release_assets/OpenPuck-${VERSION}-mdk-bootloader.zip"
+          cp build/mdk-bootloader/Adafruit_nRF52_Bootloader/_build/build-mdk_nrf52840_dongle/mdk_nrf52840_dongle_bootloader-0.7.1-openpuck.hex \
+            "release_assets/OpenPuck-${VERSION}-mdk-bootloader.hex"
           test -n "$(find release_assets -maxdepth 1 -type f -print -quit)"
           ls -la release_assets
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ UF2_OUTPUT_DIR ?= build/openpuck
 # (No auto-detect -- uploading to a guessed serial port risks writing to the wrong device. List with
 # `arduino-cli board list`.) FLASH_PORT = whatever goal isn't one of our real targets; the catch-all rule at
 # the bottom swallows it so make doesn't try to build the port path as a target.
-FLASH_PORT := $(filter-out format format-check check build build-raytac \
+FLASH_PORT := $(filter-out format format-check check build build-mdk \
+	build-mdk-bootloader package-mdk-first-install package-mdk-release build-raytac \
 	package-raytac flash-raytac deploy-raytac provision-raytac-softdevice \
 	build-recovery reversepuck reversepuck-flash reversepuck-deploy flash deploy,$(MAKECMDGOALS))
 UPLOAD = arduino-cli upload -b $(FQBN) -p "$(FLASH_PORT)" OpenPuck
@@ -72,7 +73,8 @@ UPLOAD = arduino-cli upload -b $(FQBN) -p "$(FLASH_PORT)" OpenPuck
 RP_USB_FLAGS = -DNRF52840_XXAA {build.flags.usb} -DCFG_TUD_TASK_QUEUE_SZ=$(CFG_TUD_TASK_QUEUE_SZ) -DCFG_TUD_VENDOR_TX_BUFSIZE=$(CFG_TUD_VENDOR_TX_BUFSIZE) $(EXTRA_FLAGS)
 RP_UPLOAD = arduino-cli upload -b $(FQBN) -p "$(FLASH_PORT)" ReversePuckFirmware
 
-.PHONY: format format-check check build build-raytac uf2 package-raytac \
+.PHONY: format format-check check build build-mdk build-mdk-bootloader \
+	package-mdk-first-install package-mdk-release build-raytac uf2 package-raytac \
 	flash-raytac deploy-raytac provision-raytac-softdevice build-recovery \
 	reversepuck reversepuck-flash reversepuck-deploy flash deploy
 
@@ -186,3 +188,38 @@ format-check:
 
 ## Everything CI gates on.
 check: format-check
+
+# Makerdiary/GeeekPi nRF52840 MDK USB Dongle. This define is explicit by
+# design; normal builds must never acquire MDK GPIO/reset behavior.
+MDK_BOARD_FLAGS ?= -DOPK_BOARD_MDK_USB_DONGLE=1
+MDK_BUILD_PATH ?= build/cache/mdk
+MDK_OUTPUT_DIR ?= build/mdk
+MDK_BOOTLOADER_WORKDIR ?= build/mdk-bootloader
+
+build-mdk:
+	mkdir -p $(MDK_BUILD_PATH) $(MDK_OUTPUT_DIR)
+	arduino-cli compile --clean -b adafruit:nrf52:feather52840 \
+		--build-path $(MDK_BUILD_PATH) --output-dir $(MDK_OUTPUT_DIR) \
+		--build-property "build.extra_flags=$(USB_EXTRA_FLAGS) $(MDK_BOARD_FLAGS)" \
+		--build-property "compiler.c.elf.extra_flags=$(OPENPUCK_LINK_FLAGS)" OpenPuck
+
+build-mdk-bootloader:
+	./bootloader/makerdiary/build_mdk_bootloader.sh \
+		--work-dir "$(MDK_BOOTLOADER_WORKDIR)"
+
+package-mdk-first-install:
+	@test -f "$(SOFTDEVICE_HEX)" || { \
+		echo "set SOFTDEVICE_HEX to a pure Nordic S140 6.1.1 HEX"; exit 1; }
+	@test -f $(MDK_OUTPUT_DIR)/OpenPuck.ino.hex || { \
+		echo "run 'make build-mdk' first"; exit 1; }
+	python3 tools/make_mdk_first_install.py \
+		--softdevice "$(SOFTDEVICE_HEX)" \
+		--application $(MDK_OUTPUT_DIR)/OpenPuck.ino.hex \
+		--output $(MDK_OUTPUT_DIR)/OpenPuck-MDK-first-install-S140.uf2
+
+package-mdk-release:
+	$(MAKE) build-mdk
+	./gen_uf2.sh $(MDK_OUTPUT_DIR)/OpenPuck.ino.hex \
+		$(MDK_OUTPUT_DIR)/OpenPuck-MDK-application.uf2
+	$(MAKE) package-mdk-first-install SOFTDEVICE_HEX="$(SOFTDEVICE_HEX)"
+	$(MAKE) build-mdk-bootloader

--- a/OpenPuck/OpenPuck.ino
+++ b/OpenPuck/OpenPuck.ino
@@ -118,7 +118,19 @@ void modeSwitchReboot(uint8_t mode)
 		USBDevice.detach();
 	delay(60); // let the host see the disconnect before the pullup returns on reset
 	faultDiagArmIntentionalReset();
+#if defined(OPK_BOARD_MDK_USB_DONGLE)
+	// MDK physically connects P0.16 to the P0.18 nRESET line.
+	// A hardware reset is required because the nRF52840 WDT survives
+	// NVIC_SystemReset(). The openpuck bootloader configures P0.18 as nRESET.
+	const uint32_t selfResetPin = NRF_GPIO_PIN_MAP(0, 16);
+	nrf_gpio_pin_clear(selfResetPin);
+	nrf_gpio_cfg_output(selfResetPin);
+	while (true) {
+		// P0.16 drives P0.18 low; reset should occur immediately.
+	}
+#else
 	NVIC_SystemReset();
+#endif
 }
 
 void setup()
@@ -235,12 +247,23 @@ void setup()
 
 		// SDL3's Proteus/Triton HIDAPI driver only binds slot HIDs on USB interfaces 2..5. Register WebUSB (IF 0)
 		// and the wake mouse (IF 1) before the four puck slots so hid[0..3] land on IF 2..5 like the real puck.
+#if defined(OPK_BOARD_MDK_USB_DONGLE)
+		if (puckMode && !keepCdc)
+			usb_web.begin();
+#else
 		if (puckMode)
 			usb_web.begin();
+#endif
 		if (puckMode && !keepCdc)
 			wakeHidBegin();
 
 		g_active->begin();
+#if defined(OPK_BOARD_MDK_USB_DONGLE)
+		// The MDK debug boot keeps CDC on IF0/IF1, then places WebUSB after
+		// the puck slot HIDs so the slot interface numbers remain stable.
+		if (puckMode && keepCdc)
+			usb_web.begin();
+#endif
 
 		// Boot-mouse wake interface for clean (non-puck) modes, and for puck on the one-shot debug boot (CDC on,
 		// no endpoint room for wake mouse on a normal puck boot -- wake is registered above instead). Skipped for PS

--- a/OpenPuck/board_config.h
+++ b/OpenPuck/board_config.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#if defined(OPK_BOARD_MDBT50Q_CX_40)
+#if defined(OPK_BOARD_MDK_USB_DONGLE)
+// Makerdiary/GeeekPi MDK USB Dongle uses the Adafruit-format
+// settings page and S140 6.1.1 layout expected by OpenPuck WebUSB.
+#define OPK_HAS_ADAFRUIT_DFU 1
+#elif defined(OPK_BOARD_MDBT50Q_CX_40)
 // The staged updater rewrites an Adafruit-format bootloader settings page.
 #define OPK_HAS_ADAFRUIT_DFU 0
 #else

--- a/OpenPuck/fault_diag.cpp
+++ b/OpenPuck/fault_diag.cpp
@@ -753,6 +753,18 @@ void clockDiagBoot()
 
 void clockDiagTick()
 {
+#if defined(OPK_BOARD_MDK_USB_DONGLE)
+	// MDK can begin on LFRC while its application clock policy settles. Refresh
+	// the diagnostic source fields without changing either clock's state.
+	{
+		uint32_t lf = NRF_CLOCK->LFCLKSTAT;
+		uint32_t hf = NRF_CLOCK->HFCLKSTAT;
+		bool lfrun = (lf & CLOCK_LFCLKSTAT_STATE_Msk) != 0;
+		uint8_t lfsrc = (uint8_t)(lf & CLOCK_LFCLKSTAT_SRC_Msk);
+		g_clkLf = lfrun ? (uint8_t)(lfsrc + 1) : 0;
+		g_clkHf = (hf & CLOCK_HFCLKSTAT_SRC_Msk) ? 2 : 0;
+	}
+#endif
 	// Cross-check the two time bases: count micros() (HFCLK-derived) elapsed over a ~1s millis() (LFCLK/RTC)
 	// window. usPerMs = micros-delta / millis-delta; 1000 = the clocks agree. A clone whose HFCLK runs fast vs
 	// its LFCLK reads >1000 here -- the exact signature behind "poll rate too high, delivered too low".

--- a/OpenPuck/status_led.cpp
+++ b/OpenPuck/status_led.cpp
@@ -1,8 +1,11 @@
 #include "status_led.h"
 #include <Arduino.h>
 
-#if defined(OPK_BOARD_MDBT50Q_CX_40)
+#if defined(OPK_BOARD_MDBT50Q_CX_40) || defined(OPK_BOARD_MDK_USB_DONGLE)
 #include <nrf_gpio.h>
+#endif
+
+#if defined(OPK_BOARD_MDBT50Q_CX_40)
 
 // The borrowed RX variant does not map the CX-40's active-low P0.08 LED.
 #define WAKE_LED_PIN NRF_GPIO_PIN_MAP(0, 8)
@@ -10,6 +13,17 @@
 #define WAKE_LED_ON LOW
 #endif
 
+#if defined(OPK_BOARD_MDK_USB_DONGLE)
+// The MDK RGB channels are active LOW. Keep blue for normal operation and
+// replace it with red during the 500 ms USB remote-wake pulse.
+#define OPK_MDK_LED_RED_PIN NRF_GPIO_PIN_MAP(0, 23)
+#define OPK_MDK_LED_GREEN_PIN NRF_GPIO_PIN_MAP(0, 22)
+#define OPK_MDK_LED_BLUE_PIN NRF_GPIO_PIN_MAP(0, 24)
+#define OPK_MDK_LED_ON LOW
+#define OPK_MDK_LED_OFF HIGH
+#undef WAKE_LED_ON
+#define WAKE_LED_ON OPK_MDK_LED_ON
+#endif
 #define WAKE_LED_OFF ((WAKE_LED_ON) == HIGH ? LOW : HIGH)
 #define PULSE_MS 500u // wake flash duration
 
@@ -18,7 +32,14 @@ static bool g_lit = false;
 
 static void ledWrite(int level)
 {
-#if defined(OPK_BOARD_MDBT50Q_CX_40)
+#if defined(OPK_BOARD_MDK_USB_DONGLE)
+	const bool active = (level == WAKE_LED_ON);
+	nrf_gpio_pin_write(OPK_MDK_LED_BLUE_PIN,
+			   active ? OPK_MDK_LED_OFF : OPK_MDK_LED_ON);
+	nrf_gpio_pin_write(OPK_MDK_LED_RED_PIN,
+			   active ? OPK_MDK_LED_ON : OPK_MDK_LED_OFF);
+	nrf_gpio_pin_write(OPK_MDK_LED_GREEN_PIN, OPK_MDK_LED_OFF);
+#elif defined(OPK_BOARD_MDBT50Q_CX_40)
 	nrf_gpio_pin_write(WAKE_LED_PIN, level);
 #else
 	digitalWrite(WAKE_LED_PIN_A, level);
@@ -28,7 +49,11 @@ static void ledWrite(int level)
 
 void ledInit()
 {
-#if defined(OPK_BOARD_MDBT50Q_CX_40)
+#if defined(OPK_BOARD_MDK_USB_DONGLE)
+	nrf_gpio_cfg_output(OPK_MDK_LED_BLUE_PIN);
+	nrf_gpio_cfg_output(OPK_MDK_LED_RED_PIN);
+	nrf_gpio_cfg_output(OPK_MDK_LED_GREEN_PIN);
+#elif defined(OPK_BOARD_MDBT50Q_CX_40)
 	nrf_gpio_cfg_output(WAKE_LED_PIN);
 #else
 	pinMode(WAKE_LED_PIN_A, OUTPUT);

--- a/bootloader/makerdiary/0001-Makerdiary-reset-UICR.patch
+++ b/bootloader/makerdiary/0001-Makerdiary-reset-UICR.patch
@@ -1,0 +1,75 @@
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -303,9 +303,11 @@ ifeq (,$(findstring unrecognized,$(shell $(CC) $(CFLAGS) -fno-ipa-modref 2>&1)))
+ CFLAGS += -fno-ipa-modref
+ endif
+
+ # Defined Symbol (MACROS)
+ CFLAGS += -D__HEAP_SIZE=0
+-CFLAGS += -DCONFIG_GPIO_AS_PINRESET
++ifneq ($(CONFIG_GPIO_AS_PINRESET),no)
++  CFLAGS += -DCONFIG_GPIO_AS_PINRESET
++endif
+
+ # Skip defining CONFIG_NFCT_PINS_AS_GPIOS if the device uses the NFCT.
+ ifneq ($(USE_NFCT),yes)
+diff --git a/src/boards/mdk_nrf52840_dongle/board.mk b/src/boards/mdk_nrf52840_dongle/board.mk
+--- a/src/boards/mdk_nrf52840_dongle/board.mk
++++ b/src/boards/mdk_nrf52840_dongle/board.mk
+@@ -1 +1,4 @@
+ MCU_SUB_VARIANT = nrf52840
++
++# P0.18 is configured conservatively by the OpenPuck board-specific hook.
++CONFIG_GPIO_AS_PINRESET = no
+diff --git a/src/boards/mdk_nrf52840_dongle/pinconfig.c b/src/boards/mdk_nrf52840_dongle/pinconfig.c
+--- a/src/boards/mdk_nrf52840_dongle/pinconfig.c
++++ b/src/boards/mdk_nrf52840_dongle/pinconfig.c
+@@ -1,5 +1,47 @@
+ #include "boards.h"
+ #include "uf2/configkeys.h"
++
++#define OPENPUCK_RESET_PIN 18U
++#define OPENPUCK_UICR_ERASED 0xFFFFFFFFUL
++
++static void nvmc_wait_ready(void)
++{
++  while (NRF_NVMC->READY == NVMC_READY_READY_Busy)
++  {
++  }
++}
++
++static void ensure_reset_pin_configured(void)
++{
++  uint32_t const reset0 = NRF_UICR->PSELRESET[0];
++  uint32_t const reset1 = NRF_UICR->PSELRESET[1];
++
++  if ((reset0 == OPENPUCK_RESET_PIN) && (reset1 == OPENPUCK_RESET_PIN))
++  {
++    return;
++  }
++
++  if ((reset0 != OPENPUCK_UICR_ERASED) || (reset1 != OPENPUCK_UICR_ERASED))
++  {
++    return;
++  }
++
++  NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
++  nvmc_wait_ready();
++  NRF_UICR->PSELRESET[0] = OPENPUCK_RESET_PIN;
++  nvmc_wait_ready();
++  NRF_UICR->PSELRESET[1] = OPENPUCK_RESET_PIN;
++  nvmc_wait_ready();
++  NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
++  nvmc_wait_ready();
++
++  NVIC_SystemReset();
++}
++
++void board_init2(void)
++{
++  ensure_reset_pin_configured();
++}
+
+ __attribute__((used, section(".bootloaderConfig")))
+ const uint32_t bootloaderConfig[] =

--- a/bootloader/makerdiary/0002-OpenPuck-app-handoff.patch
+++ b/bootloader/makerdiary/0002-OpenPuck-app-handoff.patch
@@ -1,0 +1,15 @@
+--- a/src/main.c
++++ b/src/main.c
+@@ -222,6 +222,12 @@ int main(void)
+     // clear in case we kept DFU_DBL_RESET_APP there
+     (*dbl_reset_mem) = 0;
+
++    // Leave the application free to establish its configured LF clock source.
++    // The bootloader runs LFCLK from RC, while OpenPuck expects its own clock
++    // policy to take effect after handoff.
++    NRF_CLOCK->TASKS_LFCLKSTOP = 1UL;
++    while (NRF_CLOCK->LFCLKSTAT & CLOCK_LFCLKSTAT_STATE_Msk) { }
++
+     // start application
+     bootloader_app_start();
+   }

--- a/bootloader/makerdiary/README.md
+++ b/bootloader/makerdiary/README.md
@@ -1,0 +1,72 @@
+# Makerdiary nRF52840 MDK USB Dongle
+
+OpenPuck supports the Makerdiary/GeeekPi nRF52840 MDK USB Dongle through an
+explicit `OPK_BOARD_MDK_USB_DONGLE` build. The MDK path is intentionally
+compile-time isolated: ordinary OpenPuck builds do not auto-detect the board and
+must not acquire MDK GPIO, reset, USB-ordering, or clock-diagnostic behavior.
+
+## Build
+
+Run `make build-mdk`. This keeps the normal Adafruit nRF52840/S140 memory layout
+and adds only the MDK board definition. Routine MDK updates use the resulting
+application-only UF2 and leave S140, InternalFS, and the bootloader untouched.
+
+## First Install
+
+Older/factory MDK units may contain S132 5.1.0. OpenPuck requires S140 6.1.1 and
+an application linked at `0x26000`. For those boards:
+
+1. Build the MDK application with `make build-mdk`.
+2. Set `SOFTDEVICE_HEX` to Nordic S140 6.1.1.
+3. Run `make package-mdk-first-install`.
+4. Flash the generated first-install UF2 through the existing UF2 bootloader.
+5. Use the normal (non-first-install) MDK application UF2 for all future upgrades.
+
+`tools/make_mdk_first_install.py` refuses SoftDevice/application overlap and
+refuses any generated block at or above the Makerdiary bootloader base
+`0xF4000`. The OpenPuck InternalFS range `0xED000..0xF3FFF` is not populated.
+
+## Bootloader
+
+GitHub Actions installs the bootloader Python dependencies explicitly. For a
+local Linux/macOS build, install the same utilities before running the target:
+
+```sh
+python3 -m pip install adafruit-nrfutil intelhex
+```
+
+The Adafruit nRF52 Arduino core supplies the ARM GCC toolchain used by the
+bootloader build. `build_mdk_bootloader.sh` also accepts `--arm-gcc-prefix` when
+the compiler is installed elsewhere.
+
+The repository does not vendor Adafruit's bootloader source. The build recipe
+pins Adafruit_nRF52_Bootloader commit
+`c87ea51b86b96f9b19458abfc6b37d4cb52e160b`, applies exactly two OpenPuck
+compatibility changes, and builds the UF2 bootloader as `0.7.1-openpuck`.
+
+- conservatively configure P0.18 as nRESET.
+- stop LFCLK before application handoff, allowing OpenPuck to establish its
+  application clock policy.
+
+No OpenPuck watchdog patch is applied: the pinned Adafruit bootloader already
+reloads active watchdog channels.
+
+`tools/verify_mdk_bootloader_hex.py` accepts programmed bootloader/config bytes
+only in `0xF4000..<0xFE000`, plus the standard Adafruit UICR words at
+`0x10001014` (`0x000F4000`) and `0x10001018` (`0x000FE000`). It rejects
+application, SoftDevice, settings-page, and unexpected UICR writes.
+
+Run `make build-mdk-bootloader` from a Linux/macOS shell to clone the pinned
+source, apply the local patches, build, validate, and generate a bootloader-only
+S140 DFU ZIP with `adafruit-nrfutil`. GitHub Actions uses this same Make target.
+The optional `bootloader/makerdiary/flash_mdk_bootloader.sh` helper requires an
+explicit serial port and never guesses a device.
+
+## Release
+
+The MDK release path carries four distinct artifacts:
+
+- application-only MDK UF2 for normal updates;
+- one-time S140 6.1.1 + current MDK application UF2 for legacy factory boards;
+- OpenPuck bootloader HEX;
+- bootloader-only S140 DFU ZIP.

--- a/bootloader/makerdiary/build_mdk_bootloader.sh
+++ b/bootloader/makerdiary/build_mdk_bootloader.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PINNED_COMMIT=c87ea51b86b96f9b19458abfc6b37d4cb52e160b
+BUILD_LABEL=0.7.1-openpuck
+
+usage()
+{
+	cat <<'USAGE'
+Usage: build_mdk_bootloader.sh [--work-dir DIR] [--arm-gcc-prefix PREFIX]
+USAGE
+}
+
+die()
+{
+	echo "error: $*" >&2
+	exit 1
+}
+
+need()
+{
+	command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+work_dir="$repo_root/build/mdk-bootloader"
+arm_gcc_prefix="${ARM_GCC_PREFIX:-}"
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--work-dir)
+		[ "$#" -ge 2 ] || die "--work-dir requires a value"
+		work_dir=$2
+		shift 2
+		;;
+	--arm-gcc-prefix)
+		[ "$#" -ge 2 ] || die "--arm-gcc-prefix requires a value"
+		arm_gcc_prefix=$2
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+
+need git
+need make
+need python3
+need adafruit-nrfutil
+need sha256sum
+python3 -c 'import intelhex' >/dev/null 2>&1 || \
+	die "Python package intelhex is required"
+
+resolve_arm_prefix()
+{
+	local gcc
+
+	if [ -n "$arm_gcc_prefix" ]; then
+		printf '%s\n' "$arm_gcc_prefix"
+		return
+	fi
+
+	if command -v arm-none-eabi-gcc >/dev/null 2>&1; then
+		gcc=$(command -v arm-none-eabi-gcc)
+		printf '%s\n' "${gcc%gcc}"
+		return
+	fi
+
+	gcc=$(
+		for root in \
+			"$HOME/.arduino15/packages/adafruit/tools/arm-none-eabi-gcc" \
+			"$HOME/.arduino15/packages/arduino/tools/arm-none-eabi-gcc"; do
+			[ -d "$root" ] || continue
+			find "$root" -type f \
+				-path '*/bin/arm-none-eabi-gcc' -print
+		done | sort -V | tail -n1
+	)
+	[ -n "$gcc" ] || die "arm-none-eabi-gcc was not found"
+	printf '%s\n' "${gcc%gcc}"
+}
+
+arm_gcc_prefix=$(resolve_arm_prefix)
+patch_reset="$script_dir/0001-Makerdiary-reset-UICR.patch"
+patch_handoff="$script_dir/0002-OpenPuck-app-handoff.patch"
+verify="$repo_root/tools/verify_mdk_bootloader_hex.py"
+repo="$work_dir/Adafruit_nRF52_Bootloader"
+
+mkdir -p "$work_dir"
+if [ ! -d "$repo/.git" ]; then
+	git clone https://github.com/adafruit/Adafruit_nRF52_Bootloader.git "$repo"
+fi
+
+git -C "$repo" fetch --all --tags
+git -C "$repo" reset --hard
+git -C "$repo" clean -fdx
+git -C "$repo" checkout --detach "$PINNED_COMMIT"
+git -C "$repo" submodule sync
+git -C "$repo" submodule update --init --force lib/nrfx lib/tinyusb lib/uf2
+
+git -C "$repo" apply --check --ignore-whitespace "$patch_reset"
+git -C "$repo" apply --ignore-whitespace "$patch_reset"
+git -C "$repo" apply --check --ignore-whitespace "$patch_handoff"
+git -C "$repo" apply --ignore-whitespace "$patch_handoff"
+
+# The upstream Makefile packs the numeric 0.7.1 prefix while the complete
+# marker remains visible to UF2 hosts as 0.7.1-openpuck.
+make -C "$repo" BOARD=mdk_nrf52840_dongle GIT_VERSION="$BUILD_LABEL" \
+	CROSS_COMPILE="$arm_gcc_prefix"
+
+boot_hex="$repo/_build/build-mdk_nrf52840_dongle/mdk_nrf52840_dongle_bootloader-$BUILD_LABEL.hex"
+out_zip="$work_dir/OpenPuck-MDK-bootloader-$BUILD_LABEL.zip"
+
+[ -f "$boot_hex" ] || die "expected bootloader HEX missing: $boot_hex"
+python3 "$verify" "$boot_hex"
+rm -f "$out_zip"
+adafruit-nrfutil dfu genpkg --dev-type 0x0052 --dev-revision 52840 \
+	--sd-req 0xB6 --bootloader "$boot_hex" "$out_zip"
+
+sha256sum "$boot_hex" "$out_zip"
+printf 'Bootloader HEX: %s\n' "$boot_hex"
+printf 'Bootloader DFU: %s\n' "$out_zip"

--- a/bootloader/makerdiary/flash_mdk_bootloader.sh
+++ b/bootloader/makerdiary/flash_mdk_bootloader.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage()
+{
+	cat <<'USAGE'
+Usage: flash_mdk_bootloader.sh PORT [PACKAGE] [BAUD]
+USAGE
+}
+
+die()
+{
+	echo "error: $*" >&2
+	exit 1
+}
+
+[ "$#" -ge 1 ] && [ "$#" -le 3 ] || {
+	usage >&2
+	exit 2
+}
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+port=$1
+package=${2:-$repo_root/build/mdk-bootloader/OpenPuck-MDK-bootloader-0.7.1-openpuck.zip}
+baud=${3:-115200}
+
+command -v adafruit-nrfutil >/dev/null 2>&1 || \
+	die "adafruit-nrfutil is required"
+[ -f "$package" ] || die "bootloader package not found: $package"
+
+printf 'This writes only the OpenPuck-compatible bootloader package.\n'
+printf 'Port: %s\n' "$port"
+printf 'Package: %s\n' "$package"
+adafruit-nrfutil dfu serial --package "$package" -p "$port" -b "$baud" \
+	--singlebank

--- a/docs/index.html
+++ b/docs/index.html
@@ -131,7 +131,7 @@
   <span id="updAvail" class="pill hide" title="A newer OpenPuck release is available — click to open the Firmware update tab">…</span>
   <span class="spacer"></span>
   <button id="betaBtn" class="beta" title="Show beta features warning and enable beta UI">Beta</button>
-  <button id="debugCdc" title="Reboot ONCE with the CDC serial console enabled (WebUSB goes away for that boot); auto-reverts on the next boot">Debug CDC</button>
+  <button id="debugCdc" title="Reboot ONCE with the CDC serial console enabled; WebUSB remains available on the debug-boot interface. Auto-reverts on the next boot.">Debug CDC</button>
   <button id="dfuSerial" title="Reboot into serial DFU (adafruit-nrfutil), then replug">Serial DFU</button>
   <button id="dfuUf2" title="Reboot into the UF2 mass-storage bootloader; drop a .uf2 on the drive">UF2 DFU</button>
   <button id="factoryErase" class="danger" title="Wipe ALL bonds + settings and reboot to defaults. You must re-pair. Cannot be undone.">⚠ Factory erase</button>

--- a/tools/make_mdk_first_install.py
+++ b/tools/make_mdk_first_install.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Create a one-time UF2 that installs:
+  - Nordic S140 6.1.1 / MBR below 0x26000
+  - an OpenPuck application linked for 0x26000..0xECFFF
+
+It deliberately does NOT include:
+  - 0xED000..0xF3FFF (OpenPuck InternalFS)
+  - 0xF4000..0xFFFFF (Makerdiary UF2 bootloader/config/settings)
+
+This is intended for Makerdiary/GeeekPi nRF52840 MDK USB Dongles whose
+factory INFO_UF2.TXT reports S132 5.1.0. The existing UF2 bootloader remains
+the recovery mechanism.
+
+The input application must already be compiled with:
+  - FQBN adafruit:nrf52:feather52840
+  - -DOPK_BOARD_MDK_USB_DONGLE=1
+  - OpenPuck's required TinyUSB flags
+"""
+
+from __future__ import annotations
+import argparse
+import struct
+from pathlib import Path
+
+UF2_MAGIC_START0 = 0x0A324655
+UF2_MAGIC_START1 = 0x9E5D5157
+UF2_MAGIC_END = 0x0AB16F30
+UF2_FLAG_FAMILY_ID_PRESENT = 0x00002000
+NRF52840_FAMILY_ID = 0xADA52840
+
+APP_BASE = 0x26000
+APP_END = 0xED000
+BOOTLOADER_BASE = 0xF4000
+PAYLOAD_SIZE = 256
+
+
+def parse_ihex(path: Path) -> dict[int, int]:
+    mem: dict[int, int] = {}
+    linear_base = 0
+    segment_base = 0
+    mode = "linear"
+
+    for lineno, raw in enumerate(path.read_text(encoding="ascii").splitlines(), 1):
+        line = raw.strip()
+        if not line:
+            continue
+        if not line.startswith(":"):
+            raise ValueError(f"{path}:{lineno}: not Intel HEX")
+        rec = bytes.fromhex(line[1:])
+        if len(rec) < 5:
+            raise ValueError(f"{path}:{lineno}: short record")
+
+        count = rec[0]
+        addr16 = (rec[1] << 8) | rec[2]
+        rectype = rec[3]
+        data = rec[4:4 + count]
+        checksum = rec[4 + count]
+
+        if (sum(rec[:5 + count]) & 0xFF) != 0:
+            raise ValueError(f"{path}:{lineno}: checksum mismatch")
+
+        if rectype == 0x00:
+            base = linear_base if mode == "linear" else segment_base
+            addr = base + addr16
+            for b in data:
+                old = mem.get(addr)
+                if old is not None and old != b:
+                    raise ValueError(f"{path}:{lineno}: conflicting byte at 0x{addr:08X}")
+                mem[addr] = b
+                addr += 1
+        elif rectype == 0x01:
+            break
+        elif rectype == 0x02:
+            segment_base = int.from_bytes(data, "big") << 4
+            mode = "segment"
+        elif rectype == 0x04:
+            linear_base = int.from_bytes(data, "big") << 16
+            mode = "linear"
+        elif rectype in (0x03, 0x05):
+            # Start-address metadata; not flash contents.
+            pass
+        else:
+            raise ValueError(f"{path}:{lineno}: unsupported record type 0x{rectype:02X}")
+    return mem
+
+
+def pages_from_memory(mem: dict[int, int]) -> dict[int, bytearray]:
+    pages: dict[int, bytearray] = {}
+    for addr, value in mem.items():
+        base = addr & ~(PAYLOAD_SIZE - 1)
+        page = pages.setdefault(base, bytearray(b"\xFF" * PAYLOAD_SIZE))
+        page[addr - base] = value
+    return pages
+
+
+def encode_uf2(pages: dict[int, bytearray]) -> bytes:
+    addresses = sorted(pages)
+    total = len(addresses)
+    blocks = []
+    for block_no, addr in enumerate(addresses):
+        data = bytes(pages[addr])
+        header = struct.pack(
+            "<IIIIIIII",
+            UF2_MAGIC_START0,
+            UF2_MAGIC_START1,
+            UF2_FLAG_FAMILY_ID_PRESENT,
+            addr,
+            PAYLOAD_SIZE,
+            block_no,
+            total,
+            NRF52840_FAMILY_ID,
+        )
+        padding = b"\x00" * (512 - 32 - PAYLOAD_SIZE - 4)
+        blocks.append(header + data + padding + struct.pack("<I", UF2_MAGIC_END))
+    return b"".join(blocks)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--softdevice", type=Path, required=True)
+    ap.add_argument("--application", type=Path, required=True)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+
+    sd = parse_ihex(args.softdevice)
+    app = parse_ihex(args.application)
+
+    if not sd:
+        raise SystemExit("SoftDevice HEX contains no flash data")
+    if not app:
+        raise SystemExit("Application HEX contains no flash data")
+
+    sd_min, sd_max = min(sd), max(sd)
+    app_min, app_max = min(app), max(app)
+
+    # S140 6.1.1 must stay entirely below the Adafruit application base.
+    if sd_min != 0:
+        raise SystemExit(f"SoftDevice/MBR does not begin at 0x000000 (got 0x{sd_min:06X})")
+    if sd_max >= APP_BASE:
+        raise SystemExit(
+            f"SoftDevice writes at/above 0x{APP_BASE:06X} (highest 0x{sd_max:06X}); refusing"
+        )
+
+    # The compiled OpenPuck image must be a pure application using the standard
+    # S140/Adafruit layout. Reject accidental SoftDevice/bootloader-containing HEXes.
+    if app_min < APP_BASE:
+        raise SystemExit(
+            f"Application writes below 0x{APP_BASE:06X} (lowest 0x{app_min:06X}); refusing"
+        )
+    if app_max >= APP_END:
+        raise SystemExit(
+            f"Application reaches 0x{app_max:06X}, outside OpenPuck app region ending "
+            f"at 0x{APP_END - 1:06X}; refusing"
+        )
+
+    overlap = set(sd).intersection(app)
+    if overlap:
+        first = min(overlap)
+        raise SystemExit(f"SoftDevice/application overlap at 0x{first:06X}; refusing")
+
+    merged = dict(sd)
+    merged.update(app)
+    pages = pages_from_memory(merged)
+
+    if any(addr >= BOOTLOADER_BASE for addr in pages):
+        raise SystemExit("Generated image would touch the Makerdiary bootloader; refusing")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    uf2 = encode_uf2(pages)
+    args.output.write_bytes(uf2)
+
+    print(f"Wrote {args.output}")
+    print(f"UF2 blocks: {len(pages)}")
+    print(f"S140/MBR bytes: 0x{sd_min:06X}..0x{sd_max:06X}")
+    print(f"OpenPuck bytes: 0x{app_min:06X}..0x{app_max:06X}")
+    print(f"Protected bootloader starts at: 0x{BOOTLOADER_BASE:06X}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_mdk_bootloader_hex.py
+++ b/tools/verify_mdk_bootloader_hex.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Validate the OpenPuck Makerdiary bootloader Intel HEX before DFU packaging.
+
+The Adafruit nRF52840 bootloader HEX intentionally contains two UICR words:
+  0x10001014  UICR_BOOTLOADER      -> 0x000F4000
+  0x10001018  UICR_MBR_PARAM_PAGE -> 0x000FE000
+
+Those are part of Adafruit's standard nRF52840 linker layout and are required
+for the MBR/bootloader arrangement.  No other UICR or out-of-flash addresses
+are accepted by this validator.
+"""
+
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+BOOTLOADER_BASE = 0x000F4000
+BOOTLOADER_DATA_END = 0x000FE000  # exclusive; MBR params/settings are NOLOAD
+EXPECTED_UF2_MARKER = b"UF2 Bootloader 0.7.1-openpuck"
+
+UICR_BOOTLOADER = 0x10001014
+UICR_MBR_PARAM_PAGE = 0x10001018
+
+EXPECTED_UICR_WORDS = {
+    UICR_BOOTLOADER: BOOTLOADER_BASE,
+    UICR_MBR_PARAM_PAGE: 0x000FE000,
+}
+
+ALLOWED_UICR_BYTES = {
+    addr
+    for word_addr in EXPECTED_UICR_WORDS
+    for addr in range(word_addr, word_addr + 4)
+}
+
+
+def parse_ihex(path: Path):
+    mem = {}
+    upper = 0
+    mode = "linear"
+    segment = 0
+
+    for n, line in enumerate(path.read_text(encoding="ascii").splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        if not line.startswith(":"):
+            raise ValueError(f"{path}:{n}: invalid Intel HEX")
+
+        rec = bytes.fromhex(line[1:])
+        count, a_hi, a_lo, typ = rec[:4]
+        data = rec[4:4 + count]
+
+        if len(rec) != 5 + count:
+            raise ValueError(f"{path}:{n}: malformed Intel HEX record")
+        if (sum(rec) & 0xFF) != 0:
+            raise ValueError(f"{path}:{n}: checksum mismatch")
+
+        addr16 = (a_hi << 8) | a_lo
+
+        if typ == 0:
+            base = upper if mode == "linear" else segment
+            for i, b in enumerate(data):
+                addr = base + addr16 + i
+                previous = mem.get(addr)
+                if previous is not None and previous != b:
+                    raise ValueError(
+                        f"{path}:{n}: conflicting data at 0x{addr:08X}"
+                    )
+                mem[addr] = b
+        elif typ == 1:
+            break
+        elif typ == 2:
+            segment = int.from_bytes(data, "big") << 4
+            mode = "segment"
+        elif typ == 4:
+            upper = int.from_bytes(data, "big") << 16
+            mode = "linear"
+        elif typ in (3, 5):
+            # Start-segment/start-linear metadata, not programmed bytes.
+            pass
+        else:
+            raise ValueError(
+                f"{path}:{n}: unsupported HEX record type 0x{typ:02X}"
+            )
+
+    return mem
+
+
+def read_le_word(mem, address):
+    present = [address + i in mem for i in range(4)]
+    if not any(present):
+        return None
+    if not all(present):
+        missing = [address + i for i, ok in enumerate(present) if not ok]
+        raise SystemExit(
+            "ERROR: partial UICR word at "
+            f"0x{address:08X}; missing "
+            + ", ".join(f"0x{x:08X}" for x in missing)
+        )
+    return int.from_bytes(bytes(mem[address + i] for i in range(4)), "little")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("hex", type=Path)
+    args = ap.parse_args()
+
+    mem = parse_ihex(args.hex)
+    if not mem:
+        raise SystemExit("ERROR: HEX contains no data")
+
+    flash_addrs = [
+        a for a in mem
+        if BOOTLOADER_BASE <= a < BOOTLOADER_DATA_END
+    ]
+    uicr_addrs = [a for a in mem if a in ALLOWED_UICR_BYTES]
+    unexpected = [
+        a for a in mem
+        if not (BOOTLOADER_BASE <= a < BOOTLOADER_DATA_END)
+        and a not in ALLOWED_UICR_BYTES
+    ]
+
+    if not flash_addrs:
+        raise SystemExit(
+            f"ERROR: no bootloader flash data found at/above 0x{BOOTLOADER_BASE:08X}"
+        )
+
+    if unexpected:
+        raise SystemExit(
+            "ERROR: HEX contains data outside the permitted bootloader/UICR "
+            f"regions; first unexpected address 0x{min(unexpected):08X}"
+        )
+
+    for address, expected in EXPECTED_UICR_WORDS.items():
+        value = read_le_word(mem, address)
+        if value is None:
+            print(
+                f"NOTE: UICR word 0x{address:08X} is not present in this HEX."
+            )
+            continue
+        if value != expected:
+            raise SystemExit(
+                f"ERROR: UICR word 0x{address:08X} = 0x{value:08X}; "
+                f"expected 0x{expected:08X}"
+            )
+        print(
+            f"OK: UICR 0x{address:08X} = 0x{value:08X}"
+        )
+
+    flash_lo = min(flash_addrs)
+    flash_hi = max(flash_addrs)
+
+    if flash_lo != BOOTLOADER_BASE:
+        raise SystemExit(
+            f"ERROR: bootloader flash starts at 0x{flash_lo:08X}; "
+            f"expected 0x{BOOTLOADER_BASE:08X}"
+        )
+
+    # Search only programmed flash bytes for the OpenPuck build marker. Sparse gaps are
+    # filled with 0xFF so address ordering is preserved.
+    blob = bytearray(b"\xFF" * (flash_hi - flash_lo + 1))
+    for addr in flash_addrs:
+        blob[addr - flash_lo] = mem[addr]
+
+    print(
+        f"OK: bootloader flash data range "
+        f"0x{flash_lo:08X}..0x{flash_hi:08X}"
+    )
+    print(
+        "OK: no SoftDevice/application/settings-page writes and no unexpected "
+        "UICR writes"
+    )
+
+    if EXPECTED_UF2_MARKER not in bytes(blob):
+        raise SystemExit(
+            "ERROR: expected UF2 bootloader identity marker not found: "
+            + EXPECTED_UF2_MARKER.decode("ascii")
+        )
+    print(
+        "OK: UF2 bootloader identity marker found: "
+        + EXPECTED_UF2_MARKER.decode("ascii")
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Resolves #181 

Adds support for the Makerdiary nRF52840 MDK USB Dongle.

This includes application build support, board-specific reset/LED behavior, bootloader support, first-install tooling, and CI/release integration.

Fully tested with the actual dongle -- no issues on my end.

**Changes:**

- Adds Makerdiary bootloader build/flash support and first-install image generation.
- Adds an explicit Makerdiary MDK application build target.
- Adds the OPK_BOARD_MDK_USB_DONGLE board target.
- Supports the MDK dongle's P0.16-to-P0.18 hardware-reset wiring. (Credit to @stickman-dev)
- Adds active-low RGB status LED handling for the MDK board.
- Preserves WebUSB and Adafruit DFU behavior.
- Preserves the required USB interface ordering for normal and Debug CDC configurations.
- Allows Debug CDC to be used with WebUSB functional at the same time.

Massive credit to @stickman-dev for their MDK work.