### PR TITLE
Expand Lizard input mapping

### DIFF
--- a/OpenPuck/lizard_map.cpp
+++ b/OpenPuck/lizard_map.cpp
@@ -9,7 +9,32 @@ LizardMap g_lizardMap;
 
 #define LZ_FILE "/lizard_map.bin"
 #define LZ_MAGIC 0xB1u
-#define LZ_VERSION 1u
+#define LZ_VERSION 2u
+
+// Version-1 records use 32-bit masks and borrow bits 28..31 for virtual
+// left-stick directions. The current format stores those directions above the physical word.
+struct LizardBindingV1 {
+	uint8_t outType;
+	uint8_t outData[7];
+	uint32_t trigMask;
+	uint32_t holdMask;
+};
+static_assert(sizeof(LizardBindingV1) == 16,
+	      "version-1 lizard binding layout changed");
+
+static uint64_t lizardMaskFromV1(uint32_t m)
+{
+	uint64_t out = (uint64_t)(m & 0x0FFFFFFFu);
+	if (m & 0x10000000u)
+		out |= LZ_BTN_LSTICK_RT;
+	if (m & 0x20000000u)
+		out |= LZ_BTN_LSTICK_LF;
+	if (m & 0x40000000u)
+		out |= LZ_BTN_LSTICK_DN;
+	if (m & 0x80000000u)
+		out |= LZ_BTN_LSTICK_UP;
+	return out;
+}
 
 // KB modifier bits (from TinyUSB hid.h)
 #define KM_LCTRL 0x01u
@@ -18,8 +43,8 @@ LizardMap g_lizardMap;
 #define KM_LGUI 0x08u
 
 // Helper: append a binding to g_lizardMap
-static void addBind(uint8_t type, const uint8_t *od7, uint32_t trig,
-		    uint32_t hold)
+static void addBind(uint8_t type, const uint8_t *od7, uint64_t trig,
+		    uint64_t hold)
 {
 	if (g_lizardMap.count >= LZ_MAX_BINDINGS)
 		return;
@@ -41,23 +66,23 @@ static inline void addScroll(uint8_t src)
 	uint8_t d[7] = { src, 0, 0, 0, 0, 0, 0 };
 	addBind(LZ_OUT_SCROLL, d, 0, 0);
 }
-static inline void addMouseBtn(uint8_t btn, uint32_t trig, uint32_t hold)
+static inline void addMouseBtn(uint8_t btn, uint64_t trig, uint64_t hold)
 {
 	uint8_t d[7] = { btn, 0, 0, 0, 0, 0, 0 };
 	addBind(LZ_OUT_MOUSE_BTN, d, trig, hold);
 }
-static inline void addKey(uint8_t mod, uint8_t k0, uint32_t trig, uint32_t hold)
+static inline void addKey(uint8_t mod, uint8_t k0, uint64_t trig, uint64_t hold)
 {
 	uint8_t d[7] = { mod, k0, 0, 0, 0, 0, 0 };
 	addBind(LZ_OUT_KBD_CHORD, d, trig, hold);
 }
 static inline void addKey3(uint8_t mod, uint8_t k0, uint8_t k1, uint8_t k2,
-			   uint32_t trig, uint32_t hold)
+			   uint64_t trig, uint64_t hold)
 {
 	uint8_t d[7] = { mod, k0, k1, k2, 0, 0, 0 };
 	addBind(LZ_OUT_KBD_CHORD, d, trig, hold);
 }
-static inline void addConsumer(uint8_t bits, uint32_t trig, uint32_t hold)
+static inline void addConsumer(uint8_t bits, uint64_t trig, uint64_t hold)
 {
 	uint8_t d[7] = { bits, 0, 0, 0, 0, 0, 0 };
 	addBind(LZ_OUT_CONSUMER, d, trig, hold);
@@ -133,23 +158,50 @@ void saveLizardMap()
 
 void loadLizardMap()
 {
+	bool migrated = false;
 	File f(InternalFS);
 	if (f.open(LZ_FILE, FILE_O_READ)) {
 		uint8_t hdr[3] = { 0, 0, 0 };
 		if (f.read(hdr, 3) == 3 && hdr[0] == LZ_MAGIC &&
-		    hdr[1] == LZ_VERSION && hdr[2] <= LZ_MAX_BINDINGS) {
+		    hdr[2] <= LZ_MAX_BINDINGS) {
 			uint8_t cnt = hdr[2];
 			g_lizardMap.count = 0;
-			int got = f.read((uint8_t *)g_lizardMap.bindings,
-					 cnt * sizeof(LizardBinding));
-			if (got == (int)(cnt * sizeof(LizardBinding)))
-				g_lizardMap.count = cnt;
+			if (hdr[1] == LZ_VERSION) {
+				int got =
+					f.read((uint8_t *)g_lizardMap.bindings,
+					       cnt * sizeof(LizardBinding));
+				if (got == (int)(cnt * sizeof(LizardBinding)))
+					g_lizardMap.count = cnt;
+			} else if (hdr[1] == 1u) {
+				static LizardBindingV1 old[LZ_MAX_BINDINGS];
+				int got = f.read((uint8_t *)old,
+						 cnt * sizeof(LizardBindingV1));
+				if (got ==
+				    (int)(cnt * sizeof(LizardBindingV1))) {
+					for (uint8_t i = 0; i < cnt; i++) {
+						LizardBinding &b =
+							g_lizardMap.bindings[i];
+						b.outType = old[i].outType;
+						memcpy(b.outData,
+						       old[i].outData,
+						       sizeof b.outData);
+						b.trigMask = lizardMaskFromV1(
+							old[i].trigMask);
+						b.holdMask = lizardMaskFromV1(
+							old[i].holdMask);
+					}
+					g_lizardMap.count = cnt;
+					migrated = true;
+				}
+			}
 		}
 		f.close();
 	}
 	// If nothing loaded, install + persist defaults
 	if (g_lizardMap.count == 0) {
 		defaultLizardMap();
+		saveLizardMap();
+	} else if (migrated) {
 		saveLizardMap();
 	}
 }

--- a/OpenPuck/lizard_map.h
+++ b/OpenPuck/lizard_map.h
@@ -39,26 +39,27 @@
 #define LZ_GYRO_BTN 3u
 
 // ---- virtual stick-deflection trigger bits (usable in trigMask / holdMask) ----
-// These reuse bits 28..31 of the button word, which the SC2 *does* use in its 0x45 report (bit 28 =
-// right grip touch, bit 29 = left grip touch; PROTOCOL.md §8). To avoid grip-touch firing these,
-// lizardButtons() masks the controller's top 4 bits off before OR-ing in the deflection flags below,
-// so in MODE_LIZARD these bits mean ONLY stick deflection (grips are not a bindable lizard input).
-#define LZ_BTN_LSTICK_RT 0x10000000u // lx >  12000
-#define LZ_BTN_LSTICK_LF 0x20000000u // lx < -12000
-#define LZ_BTN_LSTICK_DN 0x40000000u // ly < -12000
-#define LZ_BTN_LSTICK_UP 0x80000000u // ly >  12000
-
-// ---- binding (16 bytes, naturally 4-byte aligned) ----
-// trigMask: (buttons & trigMask) != 0 activates the binding.
-// holdMask: ALL bits must also be set at the same time (AND-guard).
+// Low 32 bits preserve the complete native Triton button word. Virtual
+// analog-direction triggers live above it and cannot alias physical buttons.
+#define LZ_BTN_LSTICK_RT (1ULL << 32) // lx >  12000
+#define LZ_BTN_LSTICK_LF (1ULL << 33) // lx < -12000
+#define LZ_BTN_LSTICK_DN (1ULL << 34) // ly < -12000
+#define LZ_BTN_LSTICK_UP (1ULL << 35) // ly >  12000
+#define LZ_BTN_RSTICK_RT (1ULL << 36) // rx >  12000
+#define LZ_BTN_RSTICK_LF (1ULL << 37) // rx < -12000
+#define LZ_BTN_RSTICK_DN (1ULL << 38) // ry < -12000
+#define LZ_BTN_RSTICK_UP (1ULL << 39) // ry >  12000
+// ---- binding v2 (24 bytes) ----
+// trigMask: any matching bit activates the binding.
+// holdMask: all matching bits must also be held.
 // MOUSE_AXIS and SCROLL bindings ignore trigMask/holdMask; the analog source drives them.
 struct LizardBinding {
 	uint8_t outType; // LZ_OUT_*
 	uint8_t outData[7]; // type-specific payload (see constants above)
-	uint32_t trigMask; // physical/virtual button bits: any-of (OR)
-	uint32_t holdMask; // physical/virtual button bits: all-of (AND guard)
+	uint64_t trigMask; // physical/virtual button bits: any-of (OR)
+	uint64_t holdMask; // physical/virtual button bits: all-of (AND guard)
 };
-
+static_assert(sizeof(LizardBinding) == 24, "LizardBinding v2 layout changed");
 #define LZ_MAX_BINDINGS 32u
 
 struct LizardMap {

--- a/OpenPuck/mode_lizard.cpp
+++ b/OpenPuck/mode_lizard.cpp
@@ -7,14 +7,14 @@
 // Evaluate the binding table for ONE controller's button word, merging its keyboard/mouse-button/
 // consumer outputs into the shared accumulators. Pulled out of rfLizard so every bonded controller can
 // feed the same outputs. doRpadMouse/doLpadScroll are map-level (set if such a binding exists at all).
-static void lizardEvalSlot(uint32_t buttons, uint8_t &outMod,
+static void lizardEvalSlot(uint64_t buttons, uint8_t &outMod,
 			   uint8_t outKeys[6], uint8_t &nKeys, uint8_t &outMBtn,
 			   uint8_t &consumerBits, bool &doRpadMouse,
 			   bool &doLpadScroll)
 {
 	// kbdConsumed (per controller): trig bits claimed by a hold-modifier binding so simpler
 	// single-button bindings sharing those bits are suppressed for THIS controller.
-	uint32_t kbdConsumed = 0;
+	uint64_t kbdConsumed = 0;
 	for (uint8_t i = 0; i < g_lizardMap.count; i++) {
 		const LizardBinding &b = g_lizardMap.bindings[i];
 		if (b.outType == LZ_OUT_NONE)
@@ -75,9 +75,9 @@ static void lizardEvalSlot(uint32_t buttons, uint8_t &outMod,
 // grip touch, bit 29 = left grip touch (PROTOCOL.md §8). Merely holding the controller sets the grip
 // bits, which would masquerade as an L-stick deflection and fire the bound key. Clear the top 4 bits of
 // the physical word (grips are not a bindable lizard input) so these flags reflect ONLY stick deflection.
-static uint32_t lizardButtons(const PuckInput &in)
+static uint64_t lizardButtons(const PuckInput &in)
 {
-	uint32_t buttons = in.buttons & 0x0FFFFFFFu;
+	uint64_t buttons = (uint64_t)in.buttons;
 	if (in.lx > 12000)
 		buttons |= LZ_BTN_LSTICK_RT;
 	if (in.lx < -12000)
@@ -86,6 +86,14 @@ static uint32_t lizardButtons(const PuckInput &in)
 		buttons |= LZ_BTN_LSTICK_DN;
 	if (in.ly > 12000)
 		buttons |= LZ_BTN_LSTICK_UP;
+	if (in.rx > 12000)
+		buttons |= LZ_BTN_RSTICK_RT;
+	if (in.rx < -12000)
+		buttons |= LZ_BTN_RSTICK_LF;
+	if (in.ry < -12000)
+		buttons |= LZ_BTN_RSTICK_DN;
+	if (in.ry > 12000)
+		buttons |= LZ_BTN_RSTICK_UP;
 	return buttons;
 }
 

--- a/OpenPuck/webusb_config.cpp
+++ b/OpenPuck/webusb_config.cpp
@@ -550,6 +550,34 @@ void webusbInit(void)
 //   [0xAA][count][ per binding (16B): outType, outData[0..6], trigMask LE(4), holdMask LE(4) ]
 // Total = 2 + count*16 (max 2 + 32*16 = 514). The panel reads byte[1]=count and accumulates
 // transferIn packets until it has the full frame.
+static uint64_t webusbLizardMaskFromLegacy(uint32_t m)
+{
+	uint64_t out = (uint64_t)(m & 0x0FFFFFFFu);
+	if (m & 0x10000000u)
+		out |= LZ_BTN_LSTICK_RT;
+	if (m & 0x20000000u)
+		out |= LZ_BTN_LSTICK_LF;
+	if (m & 0x40000000u)
+		out |= LZ_BTN_LSTICK_DN;
+	if (m & 0x80000000u)
+		out |= LZ_BTN_LSTICK_UP;
+	return out;
+}
+
+static uint32_t webusbLizardMaskToLegacy(uint64_t m)
+{
+	uint32_t out = (uint32_t)(m & 0x0FFFFFFFu);
+	if (m & LZ_BTN_LSTICK_RT)
+		out |= 0x10000000u;
+	if (m & LZ_BTN_LSTICK_LF)
+		out |= 0x20000000u;
+	if (m & LZ_BTN_LSTICK_DN)
+		out |= 0x40000000u;
+	if (m & LZ_BTN_LSTICK_UP)
+		out |= 0x80000000u;
+	return out;
+}
+
 static void webusbSendLizard()
 {
 	if (!usb_web.connected())
@@ -569,16 +597,43 @@ static void webusbSendLizard()
 		q[0] = b.outType;
 		for (int k = 0; k < 7; k++)
 			q[1 + k] = b.outData[k];
-		q[8] = (uint8_t)b.trigMask;
-		q[9] = (uint8_t)(b.trigMask >> 8);
-		q[10] = (uint8_t)(b.trigMask >> 16);
-		q[11] = (uint8_t)(b.trigMask >> 24);
-		q[12] = (uint8_t)b.holdMask;
-		q[13] = (uint8_t)(b.holdMask >> 8);
-		q[14] = (uint8_t)(b.holdMask >> 16);
-		q[15] = (uint8_t)(b.holdMask >> 24);
+		uint32_t trig = webusbLizardMaskToLegacy(b.trigMask);
+		uint32_t hold = webusbLizardMaskToLegacy(b.holdMask);
+		q[8] = (uint8_t)trig;
+		q[9] = (uint8_t)(trig >> 8);
+		q[10] = (uint8_t)(trig >> 16);
+		q[11] = (uint8_t)(trig >> 24);
+		q[12] = (uint8_t)hold;
+		q[13] = (uint8_t)(hold >> 8);
+		q[14] = (uint8_t)(hold >> 16);
+		q[15] = (uint8_t)(hold >> 24);
 	}
 	usb_web.write(f, (uint16_t)(2 + count * 16));
+	usb_web.flush();
+}
+
+static void webusbSendLizardV2()
+{
+	if (!usb_web.connected())
+		return;
+	uint8_t count = g_lizardMap.count;
+	if (count > LZ_MAX_BINDINGS)
+		count = LZ_MAX_BINDINGS;
+	static uint8_t f[2 + LZ_MAX_BINDINGS * 24];
+	f[0] = 0xAA;
+	f[1] = count;
+	for (uint8_t i = 0; i < count; i++) {
+		const LizardBinding &b = g_lizardMap.bindings[i];
+		uint8_t *q = &f[2 + i * 24];
+		q[0] = b.outType;
+		for (int k = 0; k < 7; k++)
+			q[1 + k] = b.outData[k];
+		for (int k = 0; k < 8; k++) {
+			q[8 + k] = (uint8_t)(b.trigMask >> (k * 8));
+			q[16 + k] = (uint8_t)(b.holdMask >> (k * 8));
+		}
+	}
+	usb_web.write(f, (uint16_t)(2 + count * 24));
 	usb_web.flush();
 }
 #if OPK_LOG
@@ -654,7 +709,7 @@ void webusbPoll()
 			uint8_t op = buf[0];
 			// 0x16 = test rumble (v21); extend this range whenever a new opcode is added, or the
 			// parser drops it as garbage and the handler below never runs.
-			if ((op < 0x01 || op > 0x16) &&
+			if ((op < 0x01 || op > 0x1A) &&
 			    (op < 0x20 || op > 0x25)) { // resync: drop one byte
 				memmove(buf, buf + 1, --n);
 				continue;
@@ -675,6 +730,7 @@ void webusbPoll()
 			uint8_t need =
 				(op == 0x0D) ? 27 :
 				(op == 0x12) ? 18 :
+				(op == 0x18) ? 26 :
 				(op == 0x02) ? 3 :
 				(op == 0x03 || op == 0x05 || op == 0x0E ||
 				 op == 0x0F || op == 0x10 || op == 0x13) ?
@@ -824,8 +880,8 @@ void webusbPoll()
 				// which the pre-merge branch had collided with. The panel JS uses the same 0x11..0x15.
 				// 0x11: dump the current map as a 0xAA frame.
 			} else if (op == 0x11) {
+				// Compatibility dump for panels using the compact map encoding.
 				webusbSendLizard();
-
 				// 0x13 [count]: BEGIN a map edit -- set the binding count (clamped). The
 				// panel then sends one 0x12 per binding (0..count-1) and a 0x14 to persist.
 			} else if (op == 0x13) {
@@ -833,9 +889,9 @@ void webusbPoll()
 					(buf[1] <= LZ_MAX_BINDINGS) ?
 						buf[1] :
 						LZ_MAX_BINDINGS;
-
 				// 0x12 [idx][outType][od0..6][trig LE4][hold LE4]: set one binding.
 			} else if (op == 0x12) {
+				// Compatibility 16-byte binding. Translate virtual L-stick bits.
 				uint8_t idx = buf[1];
 				if (idx < LZ_MAX_BINDINGS) {
 					LizardBinding &b =
@@ -843,26 +899,60 @@ void webusbPoll()
 					b.outType = buf[2];
 					for (int k = 0; k < 7; k++)
 						b.outData[k] = buf[3 + k];
-					b.trigMask = (uint32_t)buf[10] |
-						     ((uint32_t)buf[11] << 8) |
-						     ((uint32_t)buf[12] << 16) |
-						     ((uint32_t)buf[13] << 24);
-					b.holdMask = (uint32_t)buf[14] |
-						     ((uint32_t)buf[15] << 8) |
-						     ((uint32_t)buf[16] << 16) |
-						     ((uint32_t)buf[17] << 24);
+					uint32_t trig =
+						(uint32_t)buf[10] |
+						((uint32_t)buf[11] << 8) |
+						((uint32_t)buf[12] << 16) |
+						((uint32_t)buf[13] << 24);
+					uint32_t hold =
+						(uint32_t)buf[14] |
+						((uint32_t)buf[15] << 8) |
+						((uint32_t)buf[16] << 16) |
+						((uint32_t)buf[17] << 24);
+					b.trigMask = webusbLizardMaskFromLegacy(
+						trig);
+					b.holdMask = webusbLizardMaskFromLegacy(
+						hold);
 				}
-
 				// 0x14: COMMIT the edited map to flash and echo it back.
 			} else if (op == 0x14) {
 				saveLizardMap();
 				webusbSendLizard();
-
 				// 0x15: reset the map to the built-in defaults, persist, echo back.
 			} else if (op == 0x15) {
 				defaultLizardMap();
 				saveLizardMap();
 				webusbSendLizard();
+			} else if (op == 0x17) {
+				// Native lizard-map dump: 24-byte records with uint64 masks.
+				webusbSendLizardV2();
+			} else if (op == 0x18) {
+				// [idx][outType][od0..6][trig LE8][hold LE8]
+				uint8_t idx = buf[1];
+				if (idx < LZ_MAX_BINDINGS) {
+					LizardBinding &b =
+						g_lizardMap.bindings[idx];
+					b.outType = buf[2];
+					for (int k = 0; k < 7; k++)
+						b.outData[k] = buf[3 + k];
+					b.trigMask = 0;
+					b.holdMask = 0;
+					for (int k = 0; k < 8; k++) {
+						b.trigMask |=
+							(uint64_t)buf[10 + k]
+							<< (k * 8);
+						b.holdMask |=
+							(uint64_t)buf[18 + k]
+							<< (k * 8);
+					}
+				}
+			} else if (op == 0x19) {
+				saveLizardMap();
+				webusbSendLizardV2();
+			} else if (op == 0x1A) {
+				defaultLizardMap();
+				saveLizardMap();
+				webusbSendLizardV2();
 
 				// 0x20..0x24: staged firmware update (see fw_update.h). Each op is acked with an 0xAB
 				// frame from the usbd task; the panel ping-pongs on those acks, so at most one command

--- a/docs/index.html
+++ b/docs/index.html
@@ -599,7 +599,8 @@ const LZ_BTNS = [
   [0x2000,"D-pad Up"],[0x400,"D-pad Down"],[0x1000,"D-pad Left"],[0x800,"D-pad Right"],
   [0x400000,"Right pad click"],[0x4000000,"Left pad click"],
   [0x200000,"Right pad touch"],[0x2000000,"Left pad touch"],
-  [0x10000000,"L-stick → right"],[0x20000000,"L-stick → left"],[0x40000000,"L-stick → down"],[0x80000000,"L-stick → up"],
+  [Math.pow(2,32),"L-stick → right"],[Math.pow(2,33),"L-stick → left"],[Math.pow(2,34),"L-stick → down"],[Math.pow(2,35),"L-stick → up"],
+[Math.pow(2,36),"R-stick → right"],[Math.pow(2,37),"R-stick → left"],[Math.pow(2,38),"R-stick → down"],[Math.pow(2,39),"R-stick → up"],
 ];
 // Keyboard modifier bits (od[0] for KBD output).
 const LZ_MODS = [[0x01,"Ctrl"],[0x02,"Shift"],[0x04,"Alt"],[0x08,"Win/⌘"]];
@@ -617,7 +618,7 @@ const LZ_AXIS_SRC = [[0,"Right trackpad"],[1,"Left stick"],[2,"Gyro"]];
 const LZ_GYRO_ACT = [[0,"Always"],[1,"While right pad touched"],[2,"While left stick deflected"],[3,"While hold-button held"]];
 const LZ_CONSUMER = [[1,"Volume +"],[2,"Volume −"]];
 
-function lzBtnLabel(mask){ const m=LZ_BTNS.find(b=>b[0]===(mask>>>0)); return m?m[1]:(mask?("0x"+(mask>>>0).toString(16)):""); }
+function lzBtnLabel(mask){ const v=Number(mask)||0; const m=LZ_BTNS.find(b=>Number(b[0])===v); return m?m[1]:(v?("0x"+v.toString(16)):""); }
 let lizardBindings = [];   // [{outType, od:[7], trig, hold}]
 let lizardBusy = false;
 let lizardLoaded = false;  // one-shot: the lizard map is fetched lazily, only once the connected puck proves it speaks v16+
@@ -905,7 +906,7 @@ function applyBlob(p){
   // Lazy, capability-gated lizard-map load: only after a blob proves the puck speaks v16+ (the op-0x11 dump).
   // On older firmware 0x11 is dropped silently and readLizard() would block the endpoint forever, so we must
   // NEVER send it blind at connect. One-shot per connection (reset in openDevice).
-  if(!lizardLoaded && p[0]>=16){ lizardLoaded=true; loadLizard(); }
+  if(!lizardLoaded && p[0]>=16){ lizardLoaded=true; lzV2Load(); }
   const mode=p[1], mDiv=p[2], mFric=p[3]; // p[4..11] mirror the active type (per-type block below is authoritative)
   const slot=p[10], up=p[11], f1=(p[12]|(p[13]<<8));
   const newps=(p.length>16?(p[15]|(p[16]<<8)):0), persistMode=(p.length>22?p[22]:0);
@@ -2324,6 +2325,212 @@ updateUf2UI();
 updateFwGate(); // start gated: stays inert until the first status blob proves the firmware speaks v15+
 if(!("usb" in navigator)) $("#connectBtn").outerHTML='<b style="color:var(--bad)">WebUSB not supported — use Chrome or Edge.</b>';
 else autoConnect(); // reopen an already-authorized puck on load, no picker (first-ever connect still needs the button)
+
+// OPENPUCK_LIZARD_MAP_V2_R_STICK
+// Binding-v2 format appeared at protocol 20. Protocol 21 (upstream #224)
+// claimed 0x16 for rumble-test, so the v2 map transport shifts one slot.
+const LZ_MAP_V2_PROTOCOL = 20;
+const LZ_MAP_V2_SHIFTED_OPS_PROTOCOL = 21;
+const LZ_V1_LOW_MASK = 0x0fffffff;
+const lzPow2 = bit => Math.pow(2, bit);
+
+function lzReadLE(d,o,n){
+	let v=0;
+	for(let i=n-1;i>=0;i--) v=v*256+d[o+i];
+	return v;
+}
+function lzWriteLE(out,v,n){
+	v=Number(v)||0;
+	for(let i=0;i<n;i++) out.push(Math.floor(v/Math.pow(2,8*i))&0xff);
+}
+function lzLegacyMaskToV2(v){
+	v=Number(v)>>>0;
+	let out=v&LZ_V1_LOW_MASK;
+	if(v&0x10000000) out+=lzPow2(32);
+	if(v&0x20000000) out+=lzPow2(33);
+	if(v&0x40000000) out+=lzPow2(34);
+	if(v&0x80000000) out+=lzPow2(35);
+	return out;
+}
+function lzV2MaskToLegacy(v){
+	v=Number(v)||0;
+	let out=(v%lzPow2(28))>>>0;
+	if(Math.floor(v/lzPow2(32))&1) out|=0x10000000;
+	if(Math.floor(v/lzPow2(33))&1) out|=0x20000000;
+	if(Math.floor(v/lzPow2(34))&1) out|=0x40000000;
+	if(Math.floor(v/lzPow2(35))&1) out|=0x80000000;
+	return out>>>0;
+}
+function lzPanelV2(){ return !!(lastP&&lastP[0]>=LZ_MAP_V2_PROTOCOL); }
+function lzV2Ops(){
+	const shifted=!!(lastP&&lastP[0]>=LZ_MAP_V2_SHIFTED_OPS_PROTOCOL);
+	return shifted
+		? {dump:0x17,set:0x18,save:0x19,reset:0x1A}
+		: {dump:0x16,set:0x17,save:0x18,reset:0x19};
+}
+function lzHasRStickVirtual(v){ return Number(v||0)>=lzPow2(36); }
+
+function lzV2Select(options,value,onchange,noneLabel){
+	const s=document.createElement("select");
+	if(noneLabel!==undefined){
+		const o=document.createElement("option"); o.value="0"; o.textContent=noneLabel; s.appendChild(o);
+	}
+	for(const [v,label] of options){
+		const o=document.createElement("option"); o.value=String(v); o.textContent=label; s.appendChild(o);
+	}
+	s.value=String(Number(value)||0);
+	s.onchange=()=>onchange(Number(s.value));
+	return s;
+}
+function lzV2Render(){
+	const host=document.getElementById("lizardList");
+	if(!host) return;
+	host.innerHTML="";
+	lizardBindings.forEach((b,idx)=>{
+		if(!b.od) b.od=[0,0,0,0,0,0,0];
+		while(b.od.length<7) b.od.push(0);
+		const box=document.createElement("div");
+		box.style.cssText="border:1px solid #232a3a;border-radius:8px;padding:9px;margin:7px 0;background:#0e1017";
+		const top=document.createElement("div");
+		top.className="row"; top.style.flexWrap="wrap";
+
+		const trig=lzV2Select(LZ_BTNS,b.trig,v=>b.trig=v,"— trigger —");
+		const hold=lzV2Select(LZ_BTNS,b.hold,v=>b.hold=v,"— no hold —");
+		const types=Object.keys(LZ_OUT_LABELS).map(Number).map(v=>[v,LZ_OUT_LABELS[v]]);
+		const typ=lzV2Select(types,b.outType,v=>{b.outType=v;lzV2Render();});
+		top.append("Input ",trig," Hold ",hold," → ",typ);
+
+		const del=document.createElement("button"); del.textContent="Remove";
+		del.style.marginLeft="auto";
+		del.onclick=()=>{lizardBindings.splice(idx,1);lzV2Render();};
+		top.appendChild(del); box.appendChild(top);
+
+		const detail=document.createElement("div");
+		detail.className="row"; detail.style.cssText="margin-top:7px;flex-wrap:wrap";
+		if(b.outType===LZO.KBD){
+			detail.append("Modifiers ");
+			for(const [bit,label] of LZ_MODS){
+				const c=document.createElement("input"); c.type="checkbox"; c.checked=!!(b.od[0]&bit);
+				c.onchange=()=>{ if(c.checked)b.od[0]|=bit;else b.od[0]&=~bit; };
+				const l=document.createElement("label"); l.style.marginRight="7px"; l.append(c," "+label); detail.appendChild(l);
+			}
+			for(let k=1;k<7;k++){
+				detail.append(" Key "+k+" ");
+				detail.appendChild(lzV2Select(LZ_KEYS,b.od[k],v=>b.od[k]=v));
+			}
+		}else if(b.outType===LZO.MBTN){
+			detail.append("Mouse ");
+			detail.appendChild(lzV2Select(LZ_MBTNS,b.od[0],v=>b.od[0]=v));
+		}else if(b.outType===LZO.AXIS){
+			detail.append("Source ");
+			detail.appendChild(lzV2Select(LZ_AXIS_SRC,b.od[0],v=>{b.od[0]=v;lzV2Render();}));
+			if(b.od[0]===2){
+				detail.append(" Gyro activation ");
+				detail.appendChild(lzV2Select(LZ_GYRO_ACT,b.od[1],v=>b.od[1]=v));
+			}
+			trig.disabled=true; hold.disabled=true;
+		}else if(b.outType===LZO.SCROLL){
+			detail.append("Source: Left trackpad");
+			b.od[0]=0; trig.disabled=true; hold.disabled=true;
+		}else if(b.outType===LZO.CONSUMER){
+			detail.append("Media ");
+			detail.appendChild(lzV2Select(LZ_CONSUMER,b.od[0],v=>b.od[0]=v));
+		}
+		box.appendChild(detail); host.appendChild(box);
+	});
+}
+
+async function lzV2ReadMap(op){
+	await send([op]);
+	const recSize=lzPanelV2()?24:16;
+	let buf=[];
+	let expected=0;
+	for(;;){
+		const r=await dev.transferIn(epIn,256);
+		if(r.status!=="ok") throw new Error("lizard-map read failed");
+		const d=new Uint8Array(r.data.buffer);
+		for(const x of d) buf.push(x);
+		if(!expected){
+			let start=-1;
+			for(let i=0;i+1<buf.length;i++){
+				if(buf[i]===0xAA && buf[i+1]<=LZ_MAX){ start=i; break; }
+			}
+			if(start<0){ if(buf.length>1024)buf=[]; continue; }
+			if(start) buf=buf.slice(start);
+			expected=2+buf[1]*recSize;
+		}
+		if(buf.length>=expected) break;
+	}
+	const count=buf[1], out=[];
+	for(let i=0;i<count;i++){
+		const q=2+i*recSize, od=[];
+		for(let k=0;k<7;k++) od.push(buf[q+1+k]||0);
+		const trig=recSize===24?lzReadLE(buf,q+8,8):lzLegacyMaskToV2(lzReadLE(buf,q+8,4));
+		const hold=recSize===24?lzReadLE(buf,q+16,8):lzLegacyMaskToV2(lzReadLE(buf,q+12,4));
+		out.push({outType:buf[q]||0,od,trig,hold});
+	}
+	return out;
+}
+async function lzV2Load(){
+	if(lizardBusy||!dev)return;
+	lizardBusy=true;
+	try{
+		const ops=lzV2Ops();
+		lizardBindings=await lzV2ReadMap(lzPanelV2()?ops.dump:0x11);
+		lzV2Render();
+		const st=document.getElementById("lzStatus");
+		if(st)st.textContent="loaded "+lizardBindings.length+" binding(s)"+(lzPanelV2()?" · map v2":" · legacy map");
+	}catch(e){ log("lizard load failed: "+e.message); }
+	finally{lizardBusy=false;}
+}
+async function lzV2Save(){
+	if(lizardBusy||!dev)return;
+	lizardBusy=true;
+	try{
+		const v2=lzPanelV2(), ops=lzV2Ops();
+		if(!v2&&lizardBindings.some(b=>lzHasRStickVirtual(b.trig)||lzHasRStickVirtual(b.hold)))
+			throw new Error("R-stick directions require firmware protocol v20+");
+		const count=Math.min(LZ_MAX,lizardBindings.length);
+		await send([0x13,count]);
+		for(let i=0;i<count;i++){
+			const b=lizardBindings[i], cmd=[v2?ops.set:0x12,i,b.outType||0];
+			for(let k=0;k<7;k++)cmd.push((b.od&&b.od[k])||0);
+			if(v2){lzWriteLE(cmd,b.trig,8);lzWriteLE(cmd,b.hold,8);}
+			else{lzWriteLE(cmd,lzV2MaskToLegacy(b.trig),4);lzWriteLE(cmd,lzV2MaskToLegacy(b.hold),4);}
+			await send(cmd);
+		}
+		lizardBindings=await lzV2ReadMap(v2?ops.save:0x14);
+		lzV2Render();
+		const st=document.getElementById("lzStatus"); if(st)st.textContent="saved "+count+" binding(s)";
+	}catch(e){const st=document.getElementById("lzStatus");if(st)st.textContent="save failed: "+e.message;log("lizard save failed: "+e.message);}
+	finally{lizardBusy=false;}
+}
+async function lzV2Reset(){
+	if(lizardBusy||!dev)return;
+	lizardBusy=true;
+	try{
+		const ops=lzV2Ops();
+		lizardBindings=await lzV2ReadMap(lzPanelV2()?ops.reset:0x15);
+		lzV2Render();
+		const st=document.getElementById("lzStatus");if(st)st.textContent="reset to defaults";
+	}catch(e){log("lizard reset failed: "+e.message);}
+	finally{lizardBusy=false;}
+}
+function lzV2InstallHandlers(){
+	for(const id of ["lzAdd","lzSave","lzReload","lzReset"]){
+		const old=document.getElementById(id); if(!old)continue;
+		const fresh=old.cloneNode(true); old.replaceWith(fresh);
+	}
+	const add=document.getElementById("lzAdd");
+	const save=document.getElementById("lzSave");
+	const reload=document.getElementById("lzReload");
+	const reset=document.getElementById("lzReset");
+	if(add)add.onclick=()=>{if(lizardBindings.length<LZ_MAX){lizardBindings.push({outType:1,od:[0,0,0,0,0,0,0],trig:0,hold:0});lzV2Render();}};
+	if(save)save.onclick=lzV2Save;
+	if(reload)reload.onclick=lzV2Load;
+	if(reset)reset.onclick=lzV2Reset;
+}
+lzV2InstallHandlers();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Extends Lizard mode with right-stick directional inputs and carries the expanded mapping through the WebUSB configuration/status path.

Fixes #142 

**Changes:**

- Add right-stick up/down/left/right virtual Lizard inputs.
- Extend Lizard mapping state to represent the new inputs.
- Update the WebUSB mapping/status protocol for the expanded input set.