### PR TITLE
Add Adaptive RF recovery (QoS)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,6 +180,9 @@ Two files in the nRF52 internal LittleFS:
 - `cfg.bin` (`config.cpp`) — USB mode, tunables, chord assignments, persistence policy. A magic byte versions
   the layout; a mismatch falls back to clean defaults.
 - `bonds.bin` (`bonds.cpp`) — the four bond records.
+- The RF channel-history journal uses two CRC/commit-protected flash pages at `0x86000–0x87FFF`. Official
+  application builds are link-guarded below that window and WebUSB update staging starts above it, so ordinary
+  firmware updates preserve learned RF history. A full-board wipe intentionally clears the journal too.
 
 Mode switches (chord, WebUSB, or CDC) call `saveMode()` then reboot so the next boot enumerates the right
 interface set. By default every cold boot returns to Steam mode unless "persist last mode" is enabled.

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,10 @@ EXTRA_FLAGS ?=
 # already defines to serve WebUSB. Original Xbox mode needs the XID requests that arrive on it.
 # Overriding the weak symbol would claim the whole hook and force a copy of Adafruit's WebUSB body,
 # so we wrap: webusb_config.cpp takes XID and passes everything else to __real_.
-OPENPUCK_LINK_FLAGS ?= -Wl,--wrap=tud_vendor_control_xfer_cb
+RF_JOURNAL_BASE ?= 0x86000
+OPENPUCK_LINK_FLAGS ?= -Wl,--wrap=tud_vendor_control_xfer_cb -Wl,--section-start=.rf_journal_guard=$(RF_JOURNAL_BASE)
 # {build.flags.usb} is expanded by arduino-cli (VID/PID/strings); pass it through verbatim.
-USB_EXTRA_FLAGS = -DNRF52840_XXAA {build.flags.usb} -DCFG_TUD_HID=$(CFG_TUD_HID) -DCFG_TUD_TASK_QUEUE_SZ=$(CFG_TUD_TASK_QUEUE_SZ) -DCFG_TUD_VENDOR_TX_BUFSIZE=$(CFG_TUD_VENDOR_TX_BUFSIZE) $(EXTRA_FLAGS)
+USB_EXTRA_FLAGS = -DNRF52840_XXAA {build.flags.usb} -DCFG_TUD_HID=$(CFG_TUD_HID) -DCFG_TUD_TASK_QUEUE_SZ=$(CFG_TUD_TASK_QUEUE_SZ) -DCFG_TUD_VENDOR_TX_BUFSIZE=$(CFG_TUD_VENDOR_TX_BUFSIZE) -DOPK_RF_JOURNAL_BASE=$(RF_JOURNAL_BASE) $(EXTRA_FLAGS)
 # When BUILD_PATH is set, --clean + path flags are injected; omitted for fast incremental dev builds.
 _PATH_FLAGS = $(if $(BUILD_PATH),--clean --build-path $(BUILD_PATH) --output-dir $(OUTPUT_DIR))
 

--- a/OpenPuck/OpenPuck.ino
+++ b/OpenPuck/OpenPuck.ino
@@ -151,6 +151,7 @@ void setup()
 	factoryResetOnce(OPK_GIT_HASH);
 #endif
 	loadCfg();
+	rfApplyStartupLastGoodChannel();
 	loadBonds();
 	// Lizard (desktop) keyboard/mouse binding table. Custom remapping applies ONLY in pure
 	// MODE_LIZARD: there we install the user's saved/editable map. In every other mode the

--- a/OpenPuck/config.cpp
+++ b/OpenPuck/config.cpp
@@ -111,12 +111,28 @@ struct Cfg {
 	// autonomous controller power-off on host sleep (see haptics.h g_suspendOff). 0/1; 0xFF (short
 	// pre-tail file) -> compiled default (on)
 	uint8_t suspendOff;
+	uint8_t ext[CFG_EXT_STORAGE_BYTES];
 }; // rsvd0 = ex-padSmooth, now the one-shot debug-CDC arm
 
 // Shortest cfg.bin we still accept: the layout as of CFG_MAGIC 0xCF, i.e. everything before the appended tail.
 // A file that stops anywhere in the tail leaves those bytes at the 0xFF prefill loadCfg() applies, which every
 // tail field treats as "unset" and replaces with its default.
 #define CFG_LEN_MIN (offsetof(struct Cfg, chordDpad))
+
+static uint8_t g_cfgExt[CFG_EXT_STORAGE_BYTES] = {
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+};
+
+uint8_t cfgExtRead(uint8_t index)
+{
+	return index < CFG_EXT_STORAGE_BYTES ? g_cfgExt[index] : 0xFFu;
+}
+
+void cfgExtWrite(uint8_t index, uint8_t value)
+{
+	if (index < CFG_EXT_STORAGE_BYTES)
+		g_cfgExt[index] = value;
+}
 
 void saveCfg()
 {
@@ -138,7 +154,9 @@ void saveCfg()
 		    g_chordDpad[3] },
 		  {},
 		  g_rumbleStyle,
-		  g_suspendOff };
+		  g_suspendOff,
+		  {} };
+	memcpy(c.ext, g_cfgExt, sizeof c.ext);
 	for (int i = 0; i < ET_COUNT; i++) {
 		c.type[i] = g_type[i];
 		c.padStick[i][0] = g_padStickCfg[i][0];
@@ -155,6 +173,7 @@ void saveCfg()
 void loadCfg()
 {
 	Cfg c;
+	memset(g_cfgExt, 0xFF, sizeof g_cfgExt);
 	// 0xFF prefill: bytes a SHORT (pre-tail) cfg.bin never wrote stay 0xFF, which is not a valid mode/flag, so
 	// each tail field below falls back to its compiled default instead of reading whatever was on the stack.
 	memset(&c, 0xFF, sizeof c);
@@ -166,6 +185,13 @@ void loadCfg()
 		// predating the tail keeps mode/paddles/chords instead of silently reverting to factory defaults.
 		// Anything shorter, or a stale magic, is a real layout change -> discard and use defaults.
 		if (got >= (int)CFG_LEN_MIN && c.magic == CFG_MAGIC) {
+			const int extOff = (int)offsetof(struct Cfg, ext);
+			if (got > extOff) {
+				int n = got - extOff;
+				if (n > (int)sizeof g_cfgExt)
+					n = sizeof g_cfgExt;
+				memcpy(g_cfgExt, c.ext, (size_t)n);
+			}
 			g_mDiv = c.mDiv ? c.mDiv : 64;
 			g_mFric = c.mFric;
 			for (int i = 0; i < ET_COUNT; i++)
@@ -209,8 +235,8 @@ void loadCfg()
 					if (c.padStick[i][k] <= PS_MAX)
 						g_padStickCfg[i][k] =
 							c.padStick[i][k];
-			// grow a short file to the current layout on the next save
-			if (got < (int)sizeof c)
+			// Missing extension bytes alone do not force a config rewrite.
+			if (got < (int)offsetof(struct Cfg, ext))
 				consume = true;
 
 			// lizard-suppression keepalive enable (0/1; anything else = a pre-0xCE cfg leaked
@@ -239,6 +265,7 @@ void loadCfg()
 			// suspend power-off enable (0xFF = a cfg.bin predating this tail field -> keep the on default)
 			if (c.suspendOff <= 1)
 				g_suspendOff = c.suspendOff;
+
 			// The poll RX window is now FIXED (g_rxWin is const) -- any persisted rxWin10 is ignored.
 		}
 		f.close();

--- a/OpenPuck/config.h
+++ b/OpenPuck/config.h
@@ -224,6 +224,10 @@ extern uint16_t g_loopPeriodUs;
 extern uint8_t g_loopWorst;
 extern uint16_t g_loopWorstUs;
 
+#define CFG_EXT_STORAGE_BYTES 10u
+uint8_t cfgExtRead(uint8_t index);
+void cfgExtWrite(uint8_t index, uint8_t value);
+
 void loadCfg();
 void saveCfg();
 // FULL factory wipe: reformat the internal LittleFS, erasing cfg.bin (modes/tunables/chords) AND bonds.bin

--- a/OpenPuck/fw_update.cpp
+++ b/OpenPuck/fw_update.cpp
@@ -2,6 +2,7 @@
 // meta-page commit arms it; the next boot applies it from RAM. See fw_update.h for the protocol and the
 // corruption-safety invariant every step here preserves.
 #include "fw_update.h"
+#include "rf_journal_layout.h"
 #include "fault_diag.h"
 #include <Arduino.h>
 #include <string.h>
@@ -19,9 +20,16 @@
 #define FWUP_FS_END 0xF4000UL
 #define FWUP_BL_SETTINGS 0xFF000UL
 #define FWUP_PAGE 4096UL
-// Image cap. Also what makes the apply copy safe from self-overlap: dst ends at most at 0x26000+0x60000 =
-// 0x86000, while the staged source starts at (0xEC000-size)&~0xFFF >= 0x8C000 -- disjoint by >=24 KiB.
-#define FWUP_MAX_IMG 0x60000UL
+// The normal application ends immediately before the fixed RF-journal window.
+// The largest staged image starts at 0x8C000, leaving 16 KiB between the
+// journal end (0x88000) and staging. This keeps both update source and target
+// disjoint from learned RF history.
+#define FWUP_MAX_IMG (RF_CHANNEL_JOURNAL_BASE - FWUP_APP_BASE)
+static_assert(FWUP_MAX_IMG == 0x60000UL,
+	      "RF journal layout changed the WebUSB application cap");
+static_assert(RF_CHANNEL_JOURNAL_END <=
+		      ((FWUP_META - FWUP_MAX_IMG) & ~(FWUP_PAGE - 1UL)),
+	      "RF journal overlaps staged WebUSB firmware storage");
 
 // Capability tag, searched for BY THE PANEL inside any .uf2 it is about to flash: an image without this
 // exact string predates panel updates, so flashing it silently locks future updates back to UF2-DFU
@@ -138,6 +146,8 @@ uint8_t fwupBegin(uint32_t size, uint32_t crc32)
 	if (size == 0 || size > FWUP_MAX_IMG || (size & 3))
 		return FWUP_ERR_BOUNDS;
 	uint32_t base = (FWUP_META - size) & ~(FWUP_PAGE - 1);
+	if (base < RF_CHANNEL_JOURNAL_END)
+		return FWUP_ERR_BOUNDS;
 	// keep a page of slack above the running image so staging can NEVER touch live code/rodata/.data-init
 	if (base < flashUsedEnd() + FWUP_PAGE)
 		return FWUP_ERR_BOUNDS;

--- a/OpenPuck/haptics.cpp
+++ b/OpenPuck/haptics.cpp
@@ -690,6 +690,30 @@ void hapticOnReconnect(int slot)
 // hapticSteamRumble() path (so g_rumbleStyle / g_rumbleScale / the per-type rumble toggle all apply), and
 // schedule the stop. Deadline 0 = idle; millis()+MS can be 0 only once every 49 days, so bias it off zero.
 static unsigned long g_rumbleTestStop = 0;
+static unsigned long g_rfJournalBuilderTickStop = 0;
+static uint8_t g_rfJournalBuilderTickMask = 0;
+
+static const uint8_t RF_JOURNAL_BUILDER_TICK_ON[3] = { 0x01, 0x01, 0xF7 };
+static const uint8_t RF_JOURNAL_BUILDER_TICK_OFF[3] = { 0x01, 0x01, 0x00 };
+
+void hapticRfJournalBuilderTick(uint8_t participantMask)
+{
+	g_rfJournalBuilderTickMask = 0;
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		const uint8_t bit = (uint8_t)(1u << s);
+		if ((participantMask & bit) && hapticLinkUp((int)s) &&
+		    relayEnqueue(0x82, RF_JOURNAL_BUILDER_TICK_ON,
+				 sizeof RF_JOURNAL_BUILDER_TICK_ON, true, s))
+			g_rfJournalBuilderTickMask |= bit;
+	}
+	if (!g_rfJournalBuilderTickMask) {
+		g_rfJournalBuilderTickStop = 0;
+		return;
+	}
+	g_rfJournalBuilderTickStop = millis() + RF_JOURNAL_BUILDER_TICK_MS;
+	if (!g_rfJournalBuilderTickStop)
+		g_rfJournalBuilderTickStop = 1;
+}
 
 void hapticTestRumble()
 {
@@ -709,6 +733,21 @@ void hapticTask()
 		for (uint8_t s = 0; s < NSLOT; s++)
 			hapticSteamRumble(0, 0, s);
 	}
+
+	// The journal-builder tick is outside the measured window. Queue explicit
+	// stops before the builder's inter-channel quiet guard expires.
+	if (g_rfJournalBuilderTickStop &&
+	    (long)(millis() - g_rfJournalBuilderTickStop) >= 0) {
+		g_rfJournalBuilderTickStop = 0;
+		const uint8_t mask = g_rfJournalBuilderTickMask;
+		g_rfJournalBuilderTickMask = 0;
+		for (uint8_t s = 0; s < NSLOT; s++)
+			if (mask & (uint8_t)(1u << s))
+				relayEnqueue(0x82, RF_JOURNAL_BUILDER_TICK_OFF,
+					     sizeof RF_JOURNAL_BUILDER_TICK_OFF,
+					     true, s);
+	}
+
 	// id9 steering (SET_SETTINGS index 9 = digital-mappings / the controller's AUTONOMOUS mapping+haptic
 	// engine, which is what generates the trackpad tick haptics). We decide per mode whether that autonomous
 	// engine should be ON, then either land id9=1 ONCE per connect episode (engine on) or hold id9=0 every

--- a/OpenPuck/haptics.h
+++ b/OpenPuck/haptics.h
@@ -57,6 +57,12 @@ extern uint8_t g_rumbleStyle; // RUMBLE_STYLE_*
 #define RUMBLE_TEST_MS 500u
 void hapticTestRumble();
 
+// Journal-builder progress tick. It is deliberately short and is emitted only
+// between measured channels, never inside a quality window. Hardware testing
+// showed that this 0x82 haptic does not reset the controller inactivity timer.
+#define RF_JOURNAL_BUILDER_TICK_MS 150u
+void hapticRfJournalBuilderTick(uint8_t participantMask);
+
 // ---- relay queue (written by puck_hid.cpp, mode_*.cpp, serial_console.cpp; drained by rf_link.cpp) ----
 // Enqueue one host->controller report. `slot` = bond slot (0..NSLOT-1) or 0xFF to broadcast to every
 // connected controller (used by hapticSendShutdown / hapticReinit / test haptics). ISR-safe (PRIMASK).

--- a/OpenPuck/puck_hid.cpp
+++ b/OpenPuck/puck_hid.cpp
@@ -494,7 +494,8 @@ static void handleSet(int slot, uint8_t rid, hid_report_type_t type,
 		// probe answered "still connected" and contradicted the disconnect we just pushed).
 		S.resp[2] = (slot >= 0 && slot < NSLOT && !g_xbox &&
 			     g_slot[slot].used && !slotPoweringOff(slot) &&
-			     (millis() - g_connReplyMs[slot] < 500)) ?
+			     ((millis() - g_connReplyMs[slot] < 500) ||
+			      rfChannelHandoffHostGrace(slot))) ?
 				    0x02 :
 				    0x01;
 		S.resp_len = 63;
@@ -983,7 +984,8 @@ void SteamPuckController::task()
 		// otherwise a stray dying reply bounces conn true -> a phantom 0x79=02 that Steam reads as a reconnect
 		// and answers by re-running its connect config (the "reappears for a split second").
 		bool conn = !slotPoweringOff(s) &&
-			    (millis() - g_connReplyMs[s] < 300);
+			    ((millis() - g_connReplyMs[s] < 300) ||
+			     rfChannelHandoffHostGrace(s));
 		// 0x79 connection state: on edge, then repeated every 750ms ONLY until Steam reacts (its first OUTPUT/
 		// settings write after the edge -- g_steamAliveMs). The real puck sends 0x79 ONCE, edge-triggered; an
 		// unconditional forever-resend re-triggers Steam's connect handling (connect chime) every 750ms before

--- a/OpenPuck/radio.cpp
+++ b/OpenPuck/radio.cpp
@@ -1,5 +1,6 @@
 #include "radio.h"
 #include "bonds.h" // g_slot[]
+#include "config.h"
 
 // Pairing rendezvous bytes from IBEX rodata. The 0x91A2A793 key preceding "ibex" is a DIFFERENT key,
 // NOT the discovery address.
@@ -10,6 +11,7 @@ uint8_t g_rfBase[4] = { 0x69, 0x62, 0x65, 0x78 }; // "ibex"
 // ch18: clean channel in the real puck's active hop set {18,2,80}; bad channels collide with trackpad
 // data bursts -> reply-rate crash. Tunable 'C'.
 uint8_t g_sessCh = 18;
+uint8_t g_rfStartupLastGoodChannel = 0;
 
 // Safe defaults; rfGenSessionAddr(slot) overwrites each used slot at boot. Discovery base "ibex" as a
 // degenerate starting point means an UN-bonded slot (and a not-yet-initialized one) won't accidentally
@@ -73,6 +75,30 @@ void rfGenSessionAddr(int slot)
 	    g_sessBase[slot][2] == g_rfBase[2] &&
 	    g_sessBase[slot][3] == g_rfBase[3])
 		g_sessBase[slot][0] ^= 0x80;
+}
+
+void rfApplyStartupLastGoodChannel()
+{
+	const uint8_t saved = cfgExtRead(0u);
+	g_rfStartupLastGoodChannel = (saved > 0u && saved <= 100u) ? saved : 0u;
+	cfgExtWrite(1u, 1u);
+	cfgExtWrite(2u, 1u);
+	if (g_rfStartupLastGoodChannel)
+		g_sessCh = g_rfStartupLastGoodChannel;
+}
+
+bool saveRfStartupLastGoodChannel(uint8_t channel)
+{
+	if (channel == 0u || channel > 100u)
+		return false;
+	if (g_rfStartupLastGoodChannel == channel)
+		return true;
+	g_rfStartupLastGoodChannel = channel;
+	cfgExtWrite(0u, channel);
+	cfgExtWrite(1u, 1u);
+	cfgExtWrite(2u, 1u);
+	saveCfg();
+	return true;
 }
 
 uint8_t rfrx[100], rftx[100];

--- a/OpenPuck/radio.h
+++ b/OpenPuck/radio.h
@@ -29,6 +29,9 @@ extern uint8_t g_rfCh; // current TX/RX channel (hopped during beacon/poll)
 extern uint8_t g_rfBase[4]; // "ibex"
 // connected-session channel: a CLEAN data channel off the congested adv ch2 (shared by all slots on a puck)
 extern uint8_t g_sessCh;
+extern uint8_t g_rfStartupLastGoodChannel;
+void rfApplyStartupLastGoodChannel();
+bool saveRfStartupLastGoodChannel(uint8_t channel);
 
 // Per-bond SESSION address (base+prefix). Discovery stays on the SHARED "ibex" address (g_rfBase) so any
 // controller can find us; the host frame advertises THIS slot's unique address and the controller adopts it

--- a/OpenPuck/rf_journal_layout.h
+++ b/OpenPuck/rf_journal_layout.h
@@ -1,0 +1,22 @@
+// Fixed flash layout for the RF channel-history journal.
+//
+// Normal application images are capped immediately below this window, while
+// staged WebUSB update data starts above it. Keeping the journal outside both
+// regions lets learned RF history survive ordinary firmware updates. A full
+// board wipe still erases this application-flash window intentionally.
+#pragma once
+#include <stdint.h>
+
+#define RF_CHANNEL_JOURNAL_PAGE_BYTES 4096u
+#define RF_CHANNEL_JOURNAL_PAGE_COUNT 2u
+#ifndef OPK_RF_JOURNAL_BASE
+#define OPK_RF_JOURNAL_BASE 0x86000UL
+#endif
+#define RF_CHANNEL_JOURNAL_BASE OPK_RF_JOURNAL_BASE
+#define RF_CHANNEL_JOURNAL_END     \
+	(RF_CHANNEL_JOURNAL_BASE + \
+	 RF_CHANNEL_JOURNAL_PAGE_BYTES * RF_CHANNEL_JOURNAL_PAGE_COUNT)
+
+static_assert((RF_CHANNEL_JOURNAL_BASE &
+	       (RF_CHANNEL_JOURNAL_PAGE_BYTES - 1u)) == 0u,
+	      "RF journal base must be page aligned");

--- a/OpenPuck/rf_link.cpp
+++ b/OpenPuck/rf_link.cpp
@@ -1,9 +1,11 @@
 #include "rf_link.h"
+#include "rf_journal_layout.h"
 #include "radio.h"
 #include "bonds.h"
 #include "config.h"
 #include "triton.h"
 #include "haptics.h"
+#include "steam_commands.h"
 #include "puck_hid.h" // g_cmdCapture (suppress I45 during feature-command capture)
 #include "controllers.h"
 #include "status_led.h"
@@ -58,12 +60,385 @@ uint16_t g_connPoll = 0; // poll counter (re-assert awake every 32nd)
 uint32_t g_connF1 = 0;
 uint8_t g_connF3v = 0xFF;
 
-uint8_t g_qos = 0;
-// clean, spread channels (from the puck's RSSI/PER scan)
-static const uint8_t g_hopCand[] = { 18, 46, 76, 22, 68 };
+uint8_t g_qos = 1;
 uint8_t g_hopIdx = 0;
 volatile uint16_t g_qosBad = 0;
 unsigned long g_qosCheckMs = 0, g_qosLastHopMs = 0;
+
+// clean, spread channels (from the puck's RSSI/PER scan)
+unsigned long g_linkQualityCheckMs = 0, g_lastChannelHopMs = 0;
+
+#define RF_LINK_QUALITY_WINDOW_MS 1000u
+#define RF_LINK_QUALITY_MIN_POLLS 150u
+// Three valid windows below this success threshold can request one recovery
+// attempt after the minimum channel residence.
+#define RF_LINK_QUALITY_BAD_SUCCESS_PERMILLE 550u
+#define RF_LINK_QUALITY_BAD_STREAK_WINDOWS 3u
+#define RF_LINK_QUALITY_MIN_RESIDENCY_MS 10000u
+#define RF_CHANNEL_RECOVERY_RETRY_COOLDOWN_MS 30000u
+static uint32_t g_linkQualityPolls[NSLOT] = {};
+static uint32_t g_linkQualityReplies[NSLOT] = {};
+static uint8_t g_linkQualityBadStreak[NSLOT] = {};
+
+// Recovery target state is session-only and explicit. Zero means disarmed.
+static uint8_t g_recoveryTargetChannel = 0;
+static uint8_t g_recoveryResidenceChannel = 0;
+static bool g_recoveryRequestedThisResidence = false;
+static unsigned long g_recoveryCooldownUntilMs = 0;
+static uint64_t g_recoveryFailedTargetMask = 0;
+static uint8_t g_recoveryLastFailedTarget = 0;
+
+#define RF_RECOVERY_CHANNEL_MIN 4u
+#define RF_RECOVERY_CHANNEL_MAX 80u
+#define RF_RECOVERY_CHANNEL_COUNT 39u
+#define RF_CHANNEL_EVIDENCE_WINDOWS 5u
+#define RF_CHANNEL_EVIDENCE_MIN_SUCCESS_PERMILLE 800u
+#define RF_CHANNEL_EVIDENCE_MAX_AGE_MS 120000u
+#define RF_CHANNEL_RECOVERY_MIN_IMPROVEMENT_PERMILLE 200u
+
+// Recovery evidence is per participant and target authority is cohort-wide.
+// The same selector is authoritative for cohorts of one through four participants.
+static uint8_t g_channelEvidenceGoodCount[NSLOT][RF_RECOVERY_CHANNEL_COUNT] = {};
+static uint32_t g_channelEvidenceGoodSum[NSLOT][RF_RECOVERY_CHANNEL_COUNT] = {};
+static uint16_t g_channelEvidenceMean[NSLOT][RF_RECOVERY_CHANNEL_COUNT] = {};
+static uint32_t g_channelEvidenceLastGoodMs[NSLOT]
+					   [RF_RECOVERY_CHANNEL_COUNT] = {};
+static uint8_t g_channelEvidenceParticipantMask = 0;
+static uint8_t g_channelEvidenceResidenceChannel = 0;
+static bool g_channelRecoveryDecidedThisResidence = false;
+
+// Progressive exploration: no full-band outage scan. One channel is learned
+// naturally whenever degradation already requires a migration.
+#define RF_CHANNEL_HISTORY_POOL_COUNT 14u
+#define RF_CHANNEL_HISTORY_GOOD_WINDOWS 5u
+#define RF_CHANNEL_HISTORY_GOOD_PERMILLE 800u
+#define RF_CHANNEL_HISTORY_BAD_PERMILLE 550u
+#define RF_CHANNEL_HISTORY_BAD_WINDOWS 3u
+#define RF_CHANNEL_HISTORY_PERSIST_MAX_WRITES_PER_BOOT 4u
+#define RF_CHANNEL_HISTORY_PERSIST_MIN_INTERVAL_MS 30000u
+#define RF_CHANNEL_JOURNAL_FORMAT 2u
+#define RF_CHANNEL_JOURNAL_WORD_INTERVAL_US 8000u
+#define RF_CHANNEL_JOURNAL_LIVE_WORD_MAX_US 250u
+#define RF_CHANNEL_JOURNAL_TIMER3_TICKS_PER_US 16u
+#define RF_CHANNEL_JOURNAL_OFFLINE_GUARD_MS 1000u
+#define RF_CHANNEL_JOURNAL_MAGIC 0x51323735u
+#define RF_CHANNEL_JOURNAL_COMMIT 0x51323743u
+static const uint8_t g_recoveryChannelPool[RF_CHANNEL_HISTORY_POOL_COUNT] = {
+	18, 20, 22, 34, 42, 46, 52, 56, 68, 70, 72, 74, 76, 80
+};
+
+// Persistent priors are loaded from the channel-history journal. Runtime evidence
+// always overrides these priors for operational target selection.
+static uint8_t
+	g_channelHistoryPersistentWorstPct[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t
+	g_channelHistoryPersistentMeanPct[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t
+	g_channelHistoryPersistentConfidence[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t
+	g_channelHistoryPersistentTrials[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t
+	g_channelHistoryPersistentPenalty[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t
+	g_channelHistoryPersistentRecentOrder[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t g_channelHistoryPersistentOrderCounter = 0;
+static bool g_channelHistoryPersistentLoaded = false;
+static bool g_channelHistoryPersistentDirty = false;
+static uint32_t g_channelHistoryPersistentGeneration = 0;
+static uint8_t g_channelHistoryPersistentWrites = 0;
+static unsigned long g_channelHistoryPersistentLastWriteMs = 0;
+
+// Ambient RSSI is diagnostic and can only rank channels that have never been
+// tried. Real packet-delivery evidence and learned journal history remain
+// authoritative for every explored channel.
+#define RF_AMBIENT_SURVEY_PASSES 3u
+#define RF_AMBIENT_SURVEY_SAMPLE_US 1200u
+#define RF_AMBIENT_SURVEY_STEP_MS 100u
+#define RF_AMBIENT_SURVEY_IDLE_GUARD_MS 10000u
+#define RF_AMBIENT_SURVEY_POST_HOP_GUARD_MS 30000u
+#define RF_AMBIENT_SURVEY_REFRESH_MS 60000u
+#define RF_AMBIENT_SURVEY_SAMPLE_RETRY_MAX 5u
+static uint8_t g_ambientStableRssi[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t g_ambientWorkRssi[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t g_ambientWorkSamples[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static bool g_ambientStableValid = false;
+static bool g_ambientSurveyRunning = false;
+static bool g_ambientSurveyPending = false;
+// An explicit WebUSB survey may borrow the radio while a controller is live.
+static bool g_ambientSurveyManual = false;
+static uint8_t g_ambientSurveyIndex = 0;
+static uint8_t g_ambientSurveyPass = 0;
+static uint8_t g_ambientSurveyChannel = 0;
+static uint16_t g_ambientSurveyGeneration = 0;
+static unsigned long g_ambientSurveyIdleSinceMs = 0;
+static unsigned long g_ambientSurveyLastStepMs = 0;
+static unsigned long g_ambientSurveyLastCompleteMs = 0;
+static unsigned long g_ambientSurveyLastAttemptMs = 0;
+static uint8_t g_ambientSurveySampleRetry = 0;
+static uint8_t g_ambientSurveyFailure = RF_AMBIENT_SURVEY_FAIL_NONE;
+static uint8_t g_ambientSurveyFailureChannel = 0;
+
+#define RF_JOURNAL_BUILDER_WINDOWS 60u
+#define RF_JOURNAL_BUILDER_SETTLE_MS 2000u
+#define RF_JOURNAL_BUILDER_BETWEEN_MS 400u
+#define RF_JOURNAL_BUILDER_RECONNECT_STABLE_MS 1000u
+#define RF_JOURNAL_BUILDER_HOP_ATTEMPTS 2u
+
+enum RfJournalBuilderFailure : uint8_t {
+	RF_JOURNAL_BUILDER_FAIL_NONE = 0,
+	RF_JOURNAL_BUILDER_FAIL_NO_CONTROLLERS = 1,
+	RF_JOURNAL_BUILDER_FAIL_BUSY = 2,
+	RF_JOURNAL_BUILDER_FAIL_JOURNAL_FULL = 3,
+	RF_JOURNAL_BUILDER_FAIL_NO_VALID_CHANNEL = 4,
+	RF_JOURNAL_BUILDER_FAIL_FINAL_HOP = 5,
+	RF_JOURNAL_BUILDER_FAIL_SAVE = 6,
+	RF_JOURNAL_BUILDER_FAIL_JOURNAL_WRITE_BUSY = 7,
+	RF_JOURNAL_BUILDER_FAIL_IDLE_TIMEOUT_QUERY = 8,
+	RF_JOURNAL_BUILDER_FAIL_STARTUP_SAVE = 9,
+	RF_JOURNAL_BUILDER_FAIL_AMBIENT_SURVEY = 10,
+};
+
+static uint8_t g_rfJournalBuilderPhase = RF_JOURNAL_BUILDER_IDLE;
+static uint8_t g_rfJournalBuilderResumePhase = RF_JOURNAL_BUILDER_IDLE;
+static uint8_t g_rfJournalBuilderParticipants = 0;
+static uint8_t g_rfJournalBuilderOriginChannel = 0;
+static uint8_t g_rfJournalBuilderIndex = 0;
+static uint8_t g_rfJournalBuilderChannel = 0;
+static uint8_t g_rfJournalBuilderBestChannel = 0;
+static uint8_t g_rfJournalBuilderFailure = RF_JOURNAL_BUILDER_FAIL_NONE;
+static uint8_t g_rfJournalBuilderHopAttempts = 0;
+static uint16_t g_rfJournalBuilderSurveyGeneration = 0;
+static unsigned long g_rfJournalBuilderPhaseMs = 0;
+static unsigned long g_rfJournalBuilderCohortStableMs = 0;
+static bool g_rfJournalBuilderCancelRequested = false;
+static bool g_rfJournalBuilderPromoted = false;
+static uint16_t
+	g_rfJournalBuilderWorstPermille[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint32_t
+	g_rfJournalBuilderMeanSumPermille[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t
+	g_rfJournalBuilderValidWindows[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t g_rfJournalBuilderBadWindows[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+
+// Builder keep-awake is crash-tolerant: read each frozen participant's live
+// inactivity timeout, then pulse that controller by one second and immediately
+// restore the exact captured value. Hardware proved that a same-value write does
+// not reset inactivity, while this +1 -> original transition does. No long-lived
+// timeout override exists for Complete/Cancel/Failure to clean up.
+#define RF_JOURNAL_BUILDER_IDLE_SETTING 50u
+#define RF_JOURNAL_BUILDER_IDLE_WRITE_REPS 3u
+#define RF_JOURNAL_BUILDER_IDLE_QUERY_RETRY_MS 500u
+#define RF_JOURNAL_BUILDER_IDLE_QUERY_TIMEOUT_MS 5000u
+#define RF_JOURNAL_BUILDER_IDLE_PULSE_INTERVAL_MS 60000u
+static uint8_t g_rfJournalBuilderIdleValueValidMask = 0;
+static uint16_t g_rfJournalBuilderIdleValueSeconds[NSLOT] = {};
+static unsigned long g_rfJournalBuilderIdleQueryStartedMs = 0;
+static unsigned long g_rfJournalBuilderIdleLastQueryMs[NSLOT] = {};
+static unsigned long g_rfJournalBuilderIdleLastPulseMs = 0;
+static bool g_rfJournalBuilderSurveyStarted = false;
+
+static void rfLinkQualityResetWindow(int slot);
+static void rfChannelEvidenceSyncResidence();
+static bool rfRecoveryTargetFailed(uint8_t ch);
+static bool rfChannelRecoveryCooldownActive(unsigned long now);
+static void rfChannelRecoveryAbandonAutomaticAttempt(uint8_t target,
+						     unsigned long now);
+static void rfChannelGroupAbort();
+static void rfAmbientSurveyAbort();
+static bool rfChannelGroupBegin(uint8_t oldCh, uint8_t newCh, uint8_t mask,
+				unsigned long now, bool manualImmediate);
+
+static bool rfJournalBuilderActive()
+{
+	return g_rfJournalBuilderPhase >= RF_JOURNAL_BUILDER_SURVEY &&
+	       g_rfJournalBuilderPhase <= RF_JOURNAL_BUILDER_PAUSED;
+}
+
+static uint8_t rfChannelLiveMask(unsigned long now);
+static void rfJournalBuilderResetQualityWindows()
+{
+	for (int s = 0; s < NSLOT; s++) {
+		rfLinkQualityResetWindow(s);
+		g_linkQualityBadStreak[s] = 0;
+	}
+	g_linkQualityCheckMs = millis();
+	g_qosCheckMs = g_linkQualityCheckMs;
+}
+
+// The journal occupies a fixed flash window outside the linked application
+// image. The WebUSB updater caps normal images below this address and stages
+// incoming data above the journal, so neither update path aliases learned RF
+// history. If a future build grows into the reserved window, persistence fails
+// closed instead of writing over live firmware.
+extern "C" {
+extern uint32_t __etext[];
+extern uint32_t __data_start__[];
+extern uint32_t __data_end__[];
+}
+static uintptr_t rfChannelJournalFlashUsedEnd()
+{
+	return (uintptr_t)__etext +
+	       ((uintptr_t)__data_end__ - (uintptr_t)__data_start__);
+}
+
+// This NOBITS section reserves the fixed journal window in the linker address
+// map without emitting bytes into HEX/UF2. The Makefile pins this section to
+// RF_CHANNEL_JOURNAL_BASE; if linked application data grows into the window,
+// GNU ld rejects the overlap before a firmware artifact can be produced. The
+// exported symbol is referenced by rfChannelJournalBase(), so --gc-sections
+// cannot discard the reservation as an otherwise-unreferenced input section.
+extern "C" uint8_t g_rfChannelJournalGuard[];
+__asm__(".section .rf_journal_guard,\"a\",%nobits\n"
+	".global g_rfChannelJournalGuard\n"
+	"g_rfChannelJournalGuard:\n"
+	".space 8192\n"
+	".previous\n");
+
+struct RfChannelJournalRecord {
+	uint32_t magic;
+	uint32_t sequence;
+	uint8_t format;
+	uint8_t poolCount;
+	uint8_t orderCounter;
+	uint8_t reserved;
+	uint8_t worstPct[RF_CHANNEL_HISTORY_POOL_COUNT];
+	uint8_t meanPct[RF_CHANNEL_HISTORY_POOL_COUNT];
+	uint8_t confidence[RF_CHANNEL_HISTORY_POOL_COUNT];
+	uint8_t trials[RF_CHANNEL_HISTORY_POOL_COUNT];
+	uint8_t penalty[RF_CHANNEL_HISTORY_POOL_COUNT];
+	uint8_t recentOrder[RF_CHANNEL_HISTORY_POOL_COUNT];
+	uint32_t crc32;
+	uint32_t commit;
+};
+static_assert(sizeof(RfChannelJournalRecord) == 104u,
+	      "channel journal record layout changed");
+#define RF_CHANNEL_JOURNAL_RECORDS_PER_PAGE \
+	(RF_CHANNEL_JOURNAL_PAGE_BYTES / sizeof(RfChannelJournalRecord))
+#define RF_CHANNEL_JOURNAL_TOTAL_RECORDS \
+	(RF_CHANNEL_JOURNAL_RECORDS_PER_PAGE * RF_CHANNEL_JOURNAL_PAGE_COUNT)
+
+static uint32_t g_channelJournalSequence = 0;
+static int16_t g_channelJournalLatestSlot = -1;
+static int16_t g_channelJournalFreeSlot = -1;
+static RfChannelJournalRecord g_channelJournalJob = {};
+static int16_t g_channelJournalJobSlot = -1;
+static uint8_t g_channelJournalJobWord = 0;
+static bool g_channelJournalJobActive = false;
+static uint32_t g_channelJournalJobGeneration = 0;
+static uint32_t g_channelJournalLastWordUs = 0;
+static uint32_t g_channelJournalNoLiveSinceMs = 0;
+static bool g_channelJournalSoftDeviceChecked = false;
+static bool g_channelJournalSoftDeviceEnabled = false;
+static bool g_channelJournalLiveWriteUnsafe = false;
+
+// Current-boot evidence. A historical score is a prior, never current proof.
+static uint8_t
+	g_channelHistoryRuntimeGoodStreak[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t
+	g_channelHistoryRuntimeBadStreak[RF_CHANNEL_HISTORY_POOL_COUNT] = {};
+static uint8_t g_channelHistoryResidenceChannel = 0xFFu;
+static bool g_channelHistoryResidenceOutcomeRecorded = false;
+
+#define RF_STARTUP_CHANNEL_READY_WINDOWS 5u
+#define RF_STARTUP_CHANNEL_SETTLE_WINDOWS 2u
+#define RF_STARTUP_CHANNEL_GOOD_SUCCESS_PERMILLE 800u
+
+struct RfStartupChannelObservation {
+	bool active;
+	bool settledGood;
+	uint8_t channel;
+	uint8_t validWindows;
+	uint8_t priorGoodChannel;
+};
+
+static bool g_startupWasUp[NSLOT] = {};
+static RfStartupChannelObservation g_startupChannelObservation[NSLOT] = {};
+static uint8_t g_startupLastGoodChannel[NSLOT] = {};
+
+#define RF_STARTUP_CHANNEL_AUTO_PERSIST_MAX_WRITES_PER_BOOT 4u
+static uint8_t g_startupPersistWrites = 0u;
+
+static void
+rfStartupChannelMaybePersist(const RfStartupChannelObservation &observation);
+static void rfLinkQualityResetWindow(int slot);
+
+#define RF_CHANNEL_HANDOFF_QUIESCENT_MS 250u
+#define RF_CHANNEL_HANDOFF_STICK_DEADZONE 2048
+#define RF_CHANNEL_HANDOFF_TRIGGER_THRESHOLD 8u
+#define RF_CHANNEL_HANDOFF_EARLY_SWITCH_MS 5u
+#define RF_CHANNEL_HANDOFF_TARGET_OBSERVE_MS 1200u
+#define RF_CHANNEL_HANDOFF_ROLLBACK_QUIET_MS 1000u
+#define RF_CHANNEL_HANDOFF_ROLLBACK_ACQUIRE_MS 650u
+#define RF_CHANNEL_HANDOFF_HOST_GRACE_MS 4000u
+#define RF_E4_RESPONSE_WAIT_US 2500u
+#define RF_E4_TIMING_CONTROL 0x50u
+
+enum RfChannelHandoffState : uint8_t {
+	RF_CH_IDLE = 0,
+	RF_CH_HOP_PENDING = 1,
+	RF_CH_QUIET_DWELL = 2,
+	RF_CH_ACQUIRE = 3,
+	RF_CH_ROLLBACK_QUIET_DWELL = 4,
+	RF_CH_ROLLBACK_ACQUIRE = 5,
+};
+
+enum RfE4ResponseKind : uint8_t {
+	RF_E4_RESP_NONE = 0,
+	RF_E4_RESP_ZERO = 1,
+	RF_E4_RESP_F1 = 2,
+	RF_E4_RESP_OTHER = 3,
+};
+
+static uint8_t g_rfChHandoffState = RF_CH_IDLE;
+static uint8_t g_rfChHandoffOld = 0;
+static uint8_t g_rfChHandoffTarget = 0;
+static uint8_t g_rfChHandoffMask = 0;
+static unsigned long g_rfChHandoffStartedMs = 0;
+// Separate from g_rfChHandoffStartedMs: authorization resets that timer for the
+// host-grace window. Accumulating loop-to-loop deltas keeps panel telemetry
+// correct across the 32-bit millis() wrap without affecting handoff admission.
+static uint64_t g_rfChHandoffTelemetryElapsedMs = 0;
+static uint32_t g_rfChHandoffTelemetryLastMs = 0;
+static unsigned long g_rfChHandoffPhaseMs = 0;
+static bool g_rfChHandoffRequireActivityCycle = true;
+static bool g_rfChHandoffManualImmediate = false;
+static uint32_t g_rfChHandoffReplyBaseline[NSLOT] = {};
+
+// Decode-time activity latch. Updated from fresh 0x42/0x45/0x47 controller input.
+static uint32_t g_rfHopInputSeq[NSLOT] = {};
+
+// Fresh-neutral proof state. Silence/staleness is never equivalent to neutral.
+#define RF_CHANNEL_HANDOFF_INPUT_REPORT_FRESH_MS 100u
+static uint32_t g_rfHopInputReportSeq[NSLOT] = {};
+static unsigned long g_rfHopInputLastReportMs[NSLOT] = {};
+static unsigned long g_rfHopInputNeutralSinceMs[NSLOT] = {};
+static uint8_t g_rfChHandoffWaitReason = RF_RECOVERY_WAIT_NONE;
+static uint16_t g_rfChHandoffNeutralMs = 0;
+
+// One group coordinator handles every frozen live-controller cohort, including a cohort of one.
+enum RfChannelGroupPhase : uint8_t {
+	RF_GROUP_IDLE = 0,
+	RF_GROUP_HOP_PENDING = 1,
+	RF_GROUP_AUTHORIZED_WAIT_SWITCH = 2,
+	RF_GROUP_TARGET_ACQUIRE = 3,
+	RF_GROUP_PARTIAL_WAIT_ROLLBACK = 4,
+	RF_GROUP_PARTIAL_ACQUIRE_OLD = 5,
+	RF_GROUP_ROLLBACK_WAIT_SWITCH = 6,
+	RF_GROUP_ROLLBACK_ACQUIRE_OLD = 7,
+};
+
+static bool g_rfChGroupActive = false;
+static uint8_t g_rfChGroupPhase = RF_GROUP_IDLE;
+static uint8_t g_rfChGroupParticipants = 0;
+static uint8_t g_rfChGroupNeutralSeenMask = 0;
+static bool g_rfChGroupSawActivitySincePending = false;
+static bool g_rfChGroupNeutralStartValid = false;
+static unsigned long g_rfChGroupNeutralStartMs = 0;
+static uint32_t g_rfChGroupActivitySeqSeen[NSLOT] = {};
+static uint32_t g_rfChGroupReportSeqSeen[NSLOT] = {};
+static uint8_t g_rfHopInputLastMask[NSLOT] = {};
+
+static void rfChannelNoteDecodedInput(int slot, uint32_t buttons);
 
 uint16_t g_f1ps = 0;
 uint16_t g_newps = 0;
@@ -241,22 +616,2705 @@ static void rfHostFrameOnce(int slot, bool discovery)
 	NRF_RADIO->EVENTS_DISABLED = 0;
 }
 
+static uint8_t rfChannelLiveMask(unsigned long now)
+{
+	uint8_t mask = 0;
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		if (!g_slot[s].used || !g_connReplyMs[s])
+			continue;
+		if ((uint32_t)(now - g_connReplyMs[s]) < 1200u)
+			mask |= (uint8_t)(1u << s);
+	}
+	return mask;
+}
+
+static int rfChannelMaskSlot(uint8_t mask)
+{
+	for (int s = 0; s < NSLOT; s++)
+		if (mask & (uint8_t)(1u << s))
+			return s;
+	return -1;
+}
+
+static void rfLinkQualityResetWindow(int slot)
+{
+	if (slot < 0 || slot >= NSLOT)
+		return;
+	g_linkQualityPolls[slot] = 0;
+	g_linkQualityReplies[slot] = 0;
+}
+
+static void rfLinkQualityNotePoll(int slot, bool reply)
+{
+	if (slot < 0 || slot >= NSLOT)
+		return;
+	g_linkQualityPolls[slot]++;
+	if (reply)
+		g_linkQualityReplies[slot]++;
+}
+
+static bool rfChannelRecoverySetTarget(uint8_t ch)
+{
+	if (ch != 0u && (ch < 4u || ch > 80u || (ch & 1u)))
+		return false;
+	if (g_recoveryTargetChannel != ch) {
+		g_recoveryTargetChannel = ch;
+		g_recoveryResidenceChannel = g_sessCh;
+		g_recoveryRequestedThisResidence = false;
+	}
+	return true;
+}
+
+static void rfChannelRecoverySyncResidence()
+{
+	if (g_recoveryResidenceChannel == g_sessCh)
+		return;
+	g_recoveryResidenceChannel = g_sessCh;
+	g_recoveryRequestedThisResidence = false;
+	g_recoveryCooldownUntilMs = 0;
+	g_recoveryFailedTargetMask = 0;
+	g_recoveryLastFailedTarget = 0;
+}
+
+static int rfRecoveryChannelIndex(uint8_t ch)
+{
+	if (ch < RF_RECOVERY_CHANNEL_MIN || ch > RF_RECOVERY_CHANNEL_MAX ||
+	    (ch & 1u))
+		return -1;
+	return (int)((ch - RF_RECOVERY_CHANNEL_MIN) >> 1);
+}
+
+static uint64_t rfRecoveryTargetBit(uint8_t ch)
+{
+	const int index = rfRecoveryChannelIndex(ch);
+	return index >= 0 ? ((uint64_t)1u << index) : 0;
+}
+
+static bool rfRecoveryTargetFailed(uint8_t ch)
+{
+	const uint64_t bit = rfRecoveryTargetBit(ch);
+	return bit && (g_recoveryFailedTargetMask & bit);
+}
+
+static bool rfChannelRecoveryCooldownActive(unsigned long now)
+{
+	return g_recoveryCooldownUntilMs &&
+	       (int32_t)(g_recoveryCooldownUntilMs - now) > 0;
+}
+
+static void rfChannelRecoveryAbandonAutomaticAttempt(uint8_t target,
+						     unsigned long now)
+{
+	const uint64_t bit = rfRecoveryTargetBit(target);
+	if (bit)
+		g_recoveryFailedTargetMask |= bit;
+	g_recoveryLastFailedTarget = target;
+	g_recoveryTargetChannel = 0;
+	g_recoveryResidenceChannel = g_sessCh;
+	g_recoveryRequestedThisResidence = false;
+	g_channelRecoveryDecidedThisResidence = false;
+	g_recoveryCooldownUntilMs = now + RF_CHANNEL_RECOVERY_RETRY_COOLDOWN_MS;
+	for (int s = 0; s < NSLOT; s++) {
+		rfLinkQualityResetWindow(s);
+		g_linkQualityBadStreak[s] = 0;
+	}
+	g_linkQualityCheckMs = now;
+	g_qosCheckMs = now;
+}
+
+static void rfStartupChannelBeginObservation(int slot)
+{
+	RfStartupChannelObservation &observation =
+		g_startupChannelObservation[slot];
+	memset(&observation, 0, sizeof observation);
+	observation.active = true;
+	observation.settledGood = true;
+	observation.channel = g_sessCh;
+	observation.priorGoodChannel = g_startupLastGoodChannel[slot];
+}
+
+static void rfStartupChannelTask()
+{
+	const unsigned long now = millis();
+	for (int slot = 0; slot < NSLOT; slot++) {
+		const bool up = g_slot[slot].used &&
+				g_connReplyMs[slot] != 0u &&
+				(uint32_t)(now - g_connReplyMs[slot]) < 300u;
+		if (up && !g_startupWasUp[slot])
+			rfStartupChannelBeginObservation(slot);
+		if (!up && g_startupWasUp[slot])
+			g_startupChannelObservation[slot].active = false;
+		g_startupWasUp[slot] = up;
+	}
+}
+
+static void rfStartupChannelObserveWindow(int slot, uint16_t successPermille,
+					  bool valid)
+{
+	if (!valid || slot < 0 || slot >= NSLOT)
+		return;
+	RfStartupChannelObservation &observation =
+		g_startupChannelObservation[slot];
+	if (!observation.active || observation.channel != g_sessCh ||
+	    observation.validWindows >= RF_STARTUP_CHANNEL_READY_WINDOWS)
+		return;
+
+	observation.validWindows++;
+	if (observation.validWindows > RF_STARTUP_CHANNEL_SETTLE_WINDOWS &&
+	    successPermille < RF_STARTUP_CHANNEL_GOOD_SUCCESS_PERMILLE)
+		observation.settledGood = false;
+
+	if (observation.validWindows != RF_STARTUP_CHANNEL_READY_WINDOWS)
+		return;
+
+	if (observation.settledGood)
+		g_startupLastGoodChannel[slot] = observation.channel;
+	rfStartupChannelMaybePersist(observation);
+}
+
+static void
+rfStartupChannelMaybePersist(const RfStartupChannelObservation &observation)
+{
+	if (!observation.settledGood ||
+	    observation.priorGoodChannel != observation.channel ||
+	    g_rfStartupLastGoodChannel == observation.channel ||
+	    g_startupPersistWrites >=
+		    RF_STARTUP_CHANNEL_AUTO_PERSIST_MAX_WRITES_PER_BOOT)
+		return;
+
+	if (saveRfStartupLastGoodChannel(observation.channel))
+		g_startupPersistWrites++;
+}
+
+static void rfChannelRecoveryRequest(bool wouldPending)
+{
+	rfChannelRecoverySyncResidence();
+	if (rfChannelRecoveryCooldownActive(millis()))
+		return;
+	if (!wouldPending || g_recoveryRequestedThisResidence)
+		return;
+	if (g_recoveryTargetChannel == 0u ||
+	    g_recoveryTargetChannel == g_sessCh)
+		return;
+	if (g_rfChHandoffState != RF_CH_IDLE)
+		return;
+
+	// Allow one autonomous request per independently demonstrated degradation
+	// episode. A failed stay-old result clears this latch only behind the retry
+	// cooldown and resets the bad-window streak, so retries require fresh proof.
+	g_recoveryRequestedThisResidence = true;
+	// Automatic admission uses the continuously maintained neutral duration.
+	// A fresh post-request report from every frozen participant is still required.
+	rfHopTo(g_recoveryTargetChannel);
+}
+
+static int rfChannelHistoryPoolIndex(uint8_t ch)
+{
+	for (uint8_t i = 0; i < RF_CHANNEL_HISTORY_POOL_COUNT; i++)
+		if (g_recoveryChannelPool[i] == ch)
+			return (int)i;
+	return -1;
+}
+
+static uint8_t rfAmbientMeasureChannel(uint8_t ch, uint16_t sampleUs)
+{
+	const uint8_t restoreCh = rfChannelLiveMask(millis()) ? g_sessCh :
+								g_rfCh;
+	rfConfig(ch);
+	NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk;
+	NRF_RADIO->EVENTS_READY = 0;
+	NRF_RADIO->EVENTS_RSSIEND = 0;
+	NRF_RADIO->TASKS_RXEN = 1;
+	const uint32_t readyUs = micros();
+	while (!NRF_RADIO->EVENTS_READY &&
+	       (uint32_t)(micros() - readyUs) < 1000u) {
+	}
+	if (!NRF_RADIO->EVENTS_READY) {
+		NRF_RADIO->TASKS_DISABLE = 1;
+		RWAIT_DISABLED();
+		NRF_RADIO->EVENTS_DISABLED = 0;
+		NRF_RADIO->SHORTS = 0;
+		rfConfig(restoreCh);
+		return 0;
+	}
+
+	uint8_t strongest = 0;
+	const uint32_t startUs = micros();
+	do {
+		NRF_RADIO->EVENTS_RSSIEND = 0;
+		NRF_RADIO->TASKS_RSSISTART = 1;
+		const uint32_t sampleStartUs = micros();
+		while (!NRF_RADIO->EVENTS_RSSIEND &&
+		       (uint32_t)(micros() - sampleStartUs) < 200u) {
+		}
+		if (NRF_RADIO->EVENTS_RSSIEND) {
+			const uint8_t sample =
+				(uint8_t)(NRF_RADIO->RSSISAMPLE & 0x7Fu);
+			if (sample && (!strongest || sample < strongest))
+				strongest = sample;
+		}
+		delayMicroseconds(80);
+	} while ((uint32_t)(micros() - startUs) < sampleUs);
+
+	NRF_RADIO->TASKS_DISABLE = 1;
+	RWAIT_DISABLED();
+	NRF_RADIO->EVENTS_DISABLED = 0;
+	NRF_RADIO->SHORTS = 0;
+	rfConfig(restoreCh);
+	return strongest;
+}
+
+bool rfRecoveryRequestAmbientSurvey()
+{
+	if (rfJournalBuilderActive())
+		return false;
+	// Re-clicking an already accepted explicit survey is idempotent. If the
+	// radio is instead running an autonomous scan, explicit user intent wins:
+	// discard that partial scan and restart from the first pool channel.
+	if (g_ambientSurveyManual &&
+	    (g_ambientSurveyRunning || g_ambientSurveyPending))
+		return true;
+	if (g_ambientSurveyRunning)
+		rfAmbientSurveyAbort();
+	g_ambientSurveyFailure = RF_AMBIENT_SURVEY_FAIL_NONE;
+	g_ambientSurveyFailureChannel = 0;
+	g_ambientSurveySampleRetry = 0;
+	g_ambientSurveyManual = true;
+	g_ambientSurveyPending = true;
+	return true;
+}
+
+static void rfJournalBuilderRequestAmbientSurvey()
+{
+	if (g_ambientSurveyRunning)
+		rfAmbientSurveyAbort();
+	g_ambientSurveyFailure = RF_AMBIENT_SURVEY_FAIL_NONE;
+	g_ambientSurveyFailureChannel = 0;
+	g_ambientSurveySampleRetry = 0;
+	g_ambientSurveyManual = true;
+	g_ambientSurveyPending = true;
+}
+
+static void rfAmbientSurveyAbort()
+{
+	g_ambientSurveyRunning = false;
+	g_ambientSurveyIndex = 0;
+	g_ambientSurveyPass = 0;
+	g_ambientSurveyChannel = 0;
+	g_ambientSurveySampleRetry = 0;
+	memset(g_ambientWorkRssi, 0, sizeof g_ambientWorkRssi);
+	memset(g_ambientWorkSamples, 0, sizeof g_ambientWorkSamples);
+}
+
+static void rfAmbientSurveyBegin(unsigned long now)
+{
+	memset(g_ambientWorkRssi, 0, sizeof g_ambientWorkRssi);
+	memset(g_ambientWorkSamples, 0, sizeof g_ambientWorkSamples);
+	g_ambientSurveyIndex = 0;
+	g_ambientSurveyPass = 0;
+	g_ambientSurveyChannel = g_recoveryChannelPool[0];
+	g_ambientSurveySampleRetry = 0;
+	g_ambientSurveyLastStepMs = now - RF_AMBIENT_SURVEY_STEP_MS;
+	g_ambientSurveyRunning = true;
+	g_ambientSurveyPending = false;
+}
+
+static bool rfAmbientSurveyComplete()
+{
+	for (uint8_t i = 0; i < RF_CHANNEL_HISTORY_POOL_COUNT; i++)
+		if (!g_ambientWorkSamples[i])
+			return false;
+	return true;
+}
+
+static void rfAmbientSurveyTask()
+{
+	const unsigned long now = millis();
+	const bool live = rfChannelLiveMask(now) != 0u;
+	const bool handoff = g_rfChHandoffState != RF_CH_IDLE ||
+			     g_rfChGroupActive;
+	if (handoff) {
+		g_ambientSurveyIdleSinceMs = 0;
+		if (g_ambientSurveyRunning) {
+			rfAmbientSurveyAbort();
+			if (g_ambientSurveyManual)
+				g_ambientSurveyPending = true;
+		}
+		return;
+	}
+	// Automatic ambient scanning must not compete with post-hop reacquisition.
+	// Explicit Survey and Builder surveys set g_ambientSurveyManual and bypass
+	// this grace deliberately. The existing idle guard starts only afterward.
+	if (!g_ambientSurveyManual && g_qosLastHopMs &&
+	    (uint32_t)(now - g_qosLastHopMs) <
+		    RF_AMBIENT_SURVEY_POST_HOP_GUARD_MS) {
+		g_ambientSurveyIdleSinceMs = 0;
+		if (g_ambientSurveyRunning)
+			rfAmbientSurveyAbort();
+		return;
+	}
+	if (live && !g_ambientSurveyManual) {
+		g_ambientSurveyIdleSinceMs = 0;
+		if (g_ambientSurveyRunning)
+			rfAmbientSurveyAbort();
+		return;
+	}
+	if (!g_ambientSurveyManual) {
+		if (!g_ambientSurveyIdleSinceMs)
+			g_ambientSurveyIdleSinceMs = now;
+		if ((uint32_t)(now - g_ambientSurveyIdleSinceMs) <
+		    RF_AMBIENT_SURVEY_IDLE_GUARD_MS)
+			return;
+	} else {
+		g_ambientSurveyIdleSinceMs = 0;
+	}
+
+	// Rate-limit autonomous retries after either a success or a failed
+	// attempt. Explicit/Builder requests set pending and bypass this freshness
+	// gate, so a user-requested retry always starts immediately.
+	const unsigned long lastAttempt =
+		g_ambientSurveyLastAttemptMs > g_ambientSurveyLastCompleteMs ?
+			g_ambientSurveyLastAttemptMs :
+			g_ambientSurveyLastCompleteMs;
+	const bool stale = !lastAttempt || (uint32_t)(now - lastAttempt) >=
+						   RF_AMBIENT_SURVEY_REFRESH_MS;
+	if (!g_ambientSurveyRunning) {
+		if (!g_ambientSurveyPending && !stale)
+			return;
+		rfAmbientSurveyBegin(now);
+	}
+	if ((uint32_t)(now - g_ambientSurveyLastStepMs) <
+	    RF_AMBIENT_SURVEY_STEP_MS)
+		return;
+	g_ambientSurveyLastStepMs = now;
+
+	const uint8_t i = g_ambientSurveyIndex;
+	g_ambientSurveyChannel = g_recoveryChannelPool[i];
+	const uint8_t sample = rfAmbientMeasureChannel(
+		g_ambientSurveyChannel, RF_AMBIENT_SURVEY_SAMPLE_US);
+	if (!sample) {
+		if (g_ambientSurveySampleRetry <
+		    RF_AMBIENT_SURVEY_SAMPLE_RETRY_MAX) {
+			g_ambientSurveySampleRetry++;
+			return;
+		}
+		const bool reportFailure = g_ambientSurveyManual;
+		g_ambientSurveyFailure =
+			reportFailure ? RF_AMBIENT_SURVEY_FAIL_SAMPLE_TIMEOUT :
+					RF_AMBIENT_SURVEY_FAIL_NONE;
+		g_ambientSurveyFailureChannel =
+			reportFailure ? g_ambientSurveyChannel : 0u;
+		g_ambientSurveyLastAttemptMs = now;
+		rfAmbientSurveyAbort();
+		g_ambientSurveyPending = false;
+		g_ambientSurveyManual = false;
+		return;
+	}
+	g_ambientSurveySampleRetry = 0;
+	if (!g_ambientWorkRssi[i] || sample < g_ambientWorkRssi[i])
+		g_ambientWorkRssi[i] = sample;
+	if (g_ambientWorkSamples[i] != 0xFFu)
+		g_ambientWorkSamples[i]++;
+	if (++g_ambientSurveyIndex >= RF_CHANNEL_HISTORY_POOL_COUNT) {
+		g_ambientSurveyIndex = 0;
+		g_ambientSurveyPass++;
+	}
+	if (g_ambientSurveyPass < RF_AMBIENT_SURVEY_PASSES)
+		return;
+
+	if (!rfAmbientSurveyComplete()) {
+		uint8_t failedChannel = 0;
+		for (uint8_t j = 0; j < RF_CHANNEL_HISTORY_POOL_COUNT; j++)
+			if (!g_ambientWorkSamples[j]) {
+				failedChannel = g_recoveryChannelPool[j];
+				break;
+			}
+		const bool reportFailure = g_ambientSurveyManual;
+		g_ambientSurveyFailure =
+			reportFailure ? RF_AMBIENT_SURVEY_FAIL_INCOMPLETE :
+					RF_AMBIENT_SURVEY_FAIL_NONE;
+		g_ambientSurveyFailureChannel = reportFailure ? failedChannel :
+								0u;
+		g_ambientSurveyLastAttemptMs = now;
+		rfAmbientSurveyAbort();
+		g_ambientSurveyPending = false;
+		g_ambientSurveyManual = false;
+		return;
+	}
+	memcpy(g_ambientStableRssi, g_ambientWorkRssi,
+	       sizeof g_ambientStableRssi);
+	g_ambientStableValid = true;
+	g_ambientSurveyGeneration++;
+	g_ambientSurveyLastCompleteMs = now;
+	g_ambientSurveyLastAttemptMs = now;
+	g_ambientSurveyFailure = RF_AMBIENT_SURVEY_FAIL_NONE;
+	g_ambientSurveyFailureChannel = 0;
+	rfAmbientSurveyAbort();
+	g_ambientSurveyPending = false;
+	g_ambientSurveyManual = false;
+}
+
+static uint8_t rfChannelHistoryDesignation(uint8_t index)
+{
+	if (index >= RF_CHANNEL_HISTORY_POOL_COUNT ||
+	    !g_channelHistoryPersistentTrials[index])
+		return RF_CHANNEL_UNEXPLORED;
+	if (g_channelHistoryPersistentWorstPct[index] >= 80u &&
+	    g_channelHistoryPersistentConfidence[index] >
+		    g_channelHistoryPersistentPenalty[index])
+		return RF_CHANNEL_GOOD;
+	if (g_channelHistoryPersistentWorstPct[index] < 55u ||
+	    g_channelHistoryPersistentPenalty[index] >
+		    g_channelHistoryPersistentConfidence[index])
+		return RF_CHANNEL_POOR;
+	return RF_CHANNEL_MIXED;
+}
+
+static uint8_t rfChannelHistorySelectGoodPrior(uint8_t current)
+{
+	uint8_t best = 0;
+	for (uint8_t i = 0; i < RF_CHANNEL_HISTORY_POOL_COUNT; i++) {
+		const uint8_t ch = g_recoveryChannelPool[i];
+		if (rfRecoveryTargetFailed(ch))
+			continue;
+		if (ch == current ||
+		    rfChannelHistoryDesignation(i) != RF_CHANNEL_GOOD)
+			continue;
+		if (!best) {
+			best = ch;
+			continue;
+		}
+		const int bi = rfChannelHistoryPoolIndex(best);
+		if (g_channelHistoryPersistentWorstPct[i] >
+			    g_channelHistoryPersistentWorstPct[bi] ||
+		    (g_channelHistoryPersistentWorstPct[i] ==
+			     g_channelHistoryPersistentWorstPct[bi] &&
+		     g_channelHistoryPersistentMeanPct[i] >
+			     g_channelHistoryPersistentMeanPct[bi]) ||
+		    (g_channelHistoryPersistentWorstPct[i] ==
+			     g_channelHistoryPersistentWorstPct[bi] &&
+		     g_channelHistoryPersistentMeanPct[i] ==
+			     g_channelHistoryPersistentMeanPct[bi] &&
+		     g_channelHistoryPersistentConfidence[i] >
+			     g_channelHistoryPersistentConfidence[bi]))
+			best = ch;
+	}
+	return best;
+}
+
+static uint8_t rfChannelHistorySelectUnexplored(uint8_t current)
+{
+	int best = -1;
+	for (uint8_t step = 0; step < RF_CHANNEL_HISTORY_POOL_COUNT; step++) {
+		const uint8_t i = (uint8_t)((g_hopIdx + step) %
+					    RF_CHANNEL_HISTORY_POOL_COUNT);
+		if (g_recoveryChannelPool[i] == current ||
+		    rfRecoveryTargetFailed(g_recoveryChannelPool[i]) ||
+		    g_channelHistoryPersistentTrials[i])
+			continue;
+		if (best < 0 ||
+		    (g_ambientStableValid && g_ambientStableRssi[i] &&
+		     (!g_ambientStableRssi[best] ||
+		      g_ambientStableRssi[i] > g_ambientStableRssi[best])))
+			best = i;
+	}
+	if (best < 0)
+		return 0;
+	g_hopIdx = (uint8_t)((best + 1) % RF_CHANNEL_HISTORY_POOL_COUNT);
+	return g_recoveryChannelPool[best];
+}
+
+static uint8_t
+rfChannelHistorySelectBestRemaining(uint8_t current,
+				    uint16_t currentWorstPermille)
+{
+	int best = -1;
+	for (uint8_t i = 0; i < RF_CHANNEL_HISTORY_POOL_COUNT; i++) {
+		if (g_recoveryChannelPool[i] == current ||
+		    rfRecoveryTargetFailed(g_recoveryChannelPool[i]) ||
+		    !g_channelHistoryPersistentTrials[i])
+			continue;
+		const uint16_t priorWorst =
+			(uint16_t)g_channelHistoryPersistentWorstPct[i] * 10u;
+		if (priorWorst <
+		    (uint16_t)(currentWorstPermille +
+			       RF_CHANNEL_RECOVERY_MIN_IMPROVEMENT_PERMILLE))
+			continue;
+		if (best < 0 ||
+		    g_channelHistoryPersistentWorstPct[i] >
+			    g_channelHistoryPersistentWorstPct[best] ||
+		    (g_channelHistoryPersistentWorstPct[i] ==
+			     g_channelHistoryPersistentWorstPct[best] &&
+		     g_channelHistoryPersistentPenalty[i] <
+			     g_channelHistoryPersistentPenalty[best]))
+			best = i;
+	}
+	return best < 0 ? 0 : g_recoveryChannelPool[best];
+}
+
+static uint8_t rfRecoveryHandoffPhase()
+{
+	if (!g_rfChGroupActive)
+		return RF_RECOVERY_HANDOFF_IDLE;
+	switch (g_rfChGroupPhase) {
+	case RF_GROUP_HOP_PENDING:
+		return g_rfChHandoffManualImmediate ?
+			       RF_RECOVERY_HANDOFF_AUTHORIZE :
+			       RF_RECOVERY_HANDOFF_WAIT_NEUTRAL;
+	case RF_GROUP_AUTHORIZED_WAIT_SWITCH:
+		return RF_RECOVERY_HANDOFF_SWITCH;
+	case RF_GROUP_TARGET_ACQUIRE:
+		return RF_RECOVERY_HANDOFF_ACQUIRE_TARGET;
+	case RF_GROUP_PARTIAL_WAIT_ROLLBACK:
+		return RF_RECOVERY_HANDOFF_RECONCILE;
+	case RF_GROUP_ROLLBACK_WAIT_SWITCH:
+		return RF_RECOVERY_HANDOFF_ROLLBACK_SWITCH;
+	case RF_GROUP_PARTIAL_ACQUIRE_OLD:
+	case RF_GROUP_ROLLBACK_ACQUIRE_OLD:
+		return RF_RECOVERY_HANDOFF_ACQUIRE_OLD;
+	default:
+		return RF_RECOVERY_HANDOFF_IDLE;
+	}
+}
+
+void rfRecoveryStatusSnapshot(RfRecoveryStatus *status)
+{
+	if (!status)
+		return;
+	memset(status, 0, sizeof *status);
+	status->version = 1;
+	if (g_ambientSurveyRunning)
+		status->flags |= 0x01u;
+	if (g_ambientSurveyPending)
+		status->flags |= 0x02u;
+	if (g_ambientStableValid)
+		status->flags |= 0x04u;
+	if (rfChannelLiveMask(millis()))
+		status->flags |= 0x08u;
+	if (g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive)
+		status->flags |= 0x10u;
+	if (g_channelHistoryPersistentLoaded)
+		status->flags |= 0x20u;
+	if (g_channelHistoryPersistentDirty)
+		status->flags |= 0x40u;
+	if (g_channelJournalLiveWriteUnsafe)
+		status->flags |= 0x80u;
+	status->currentChannel = g_sessCh;
+	status->targetChannel =
+		(g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive) ?
+			g_rfChHandoffTarget :
+			g_recoveryTargetChannel;
+	status->startupChannel =
+		g_rfStartupLastGoodChannel ? g_rfStartupLastGoodChannel : 18u;
+	status->channelCount = RF_CHANNEL_HISTORY_POOL_COUNT;
+	status->journalWrites = g_channelHistoryPersistentWrites;
+	status->ambientGeneration = g_ambientSurveyGeneration;
+	status->ambientSurveyChannel =
+		g_ambientSurveyRunning ? g_ambientSurveyChannel : 0u;
+	status->journalSequence = g_channelJournalSequence;
+	status->handoffPhase = rfRecoveryHandoffPhase();
+	status->handoffOldChannel = g_rfChHandoffOld;
+	if (status->handoffPhase != RF_RECOVERY_HANDOFF_IDLE)
+		status->handoffElapsedMs = g_rfChHandoffTelemetryElapsedMs;
+	status->journalBuilderPhase = g_rfJournalBuilderPhase;
+	status->journalBuilderIndex = g_rfJournalBuilderIndex;
+	status->journalBuilderChannel = g_rfJournalBuilderChannel;
+	status->journalBuilderProgress =
+		g_rfJournalBuilderIndex < RF_CHANNEL_HISTORY_POOL_COUNT ?
+			g_rfJournalBuilderValidWindows[g_rfJournalBuilderIndex] :
+			0u;
+	status->journalBuilderParticipantMask = g_rfJournalBuilderParticipants;
+	status->journalBuilderBestChannel = g_rfJournalBuilderBestChannel;
+	status->journalBuilderFailure = g_rfJournalBuilderFailure;
+	status->handoffWaitReason = g_rfChHandoffWaitReason;
+	status->handoffNeutralMs = g_rfChHandoffNeutralMs;
+	const unsigned long statusNow = millis();
+	if (rfChannelRecoveryCooldownActive(statusNow)) {
+		const uint32_t remaining =
+			(uint32_t)(g_recoveryCooldownUntilMs - statusNow);
+		const uint32_t seconds = (remaining + 999u) / 1000u;
+		status->recoveryCooldownSeconds =
+			seconds > 0xFFu ? 0xFFu : (uint8_t)seconds;
+	}
+	status->recoveryFailedTarget = g_recoveryLastFailedTarget;
+	status->ambientSurveyRetry = g_ambientSurveySampleRetry;
+	status->ambientSurveyFailure = g_ambientSurveyFailure;
+	status->ambientSurveyFailureChannel = g_ambientSurveyFailureChannel;
+	for (uint8_t i = 0; i < RF_CHANNEL_HISTORY_POOL_COUNT; i++) {
+		RfChannelStatusEntry &entry = status->channel[i];
+		entry.channel = g_recoveryChannelPool[i];
+		entry.ambientRssi =
+			g_ambientStableValid ? g_ambientStableRssi[i] : 0u;
+		entry.designation = rfChannelHistoryDesignation(i);
+		entry.worstPct = g_channelHistoryPersistentWorstPct[i];
+		entry.meanPct = g_channelHistoryPersistentMeanPct[i];
+		entry.confidence = g_channelHistoryPersistentConfidence[i];
+		entry.trials = g_channelHistoryPersistentTrials[i];
+		entry.penalty = g_channelHistoryPersistentPenalty[i];
+		entry.recentOrder = g_channelHistoryPersistentRecentOrder[i];
+	}
+}
+
+static uint32_t rfChannelJournalCrc32(const void *data, size_t len)
+{
+	const uint8_t *p = (const uint8_t *)data;
+	uint32_t crc = 0xFFFFFFFFu;
+	while (len--) {
+		crc ^= *p++;
+		for (uint8_t i = 0; i < 8u; i++)
+			crc = (crc >> 1) ^
+			      (0xEDB88320u & (uint32_t) - (int32_t)(crc & 1u));
+	}
+	return ~crc;
+}
+
+static uintptr_t rfChannelJournalBase()
+{
+	return (uintptr_t)&g_rfChannelJournalGuard[0];
+}
+
+static uintptr_t rfChannelJournalSlotAddress(uint16_t slot)
+{
+	const uint16_t page = slot / RF_CHANNEL_JOURNAL_RECORDS_PER_PAGE;
+	const uint16_t inPage = slot % RF_CHANNEL_JOURNAL_RECORDS_PER_PAGE;
+	return rfChannelJournalBase() +
+	       (uintptr_t)page * RF_CHANNEL_JOURNAL_PAGE_BYTES +
+	       (uintptr_t)inPage * sizeof(RfChannelJournalRecord);
+}
+
+static bool rfChannelJournalSequenceNewer(uint32_t a, uint32_t b)
+{
+	return (int32_t)(a - b) > 0;
+}
+
+static bool rfChannelJournalSlotErased(uint16_t slot)
+{
+	const volatile uint32_t *p =
+		(const volatile uint32_t *)rfChannelJournalSlotAddress(slot);
+	for (uint8_t i = 0; i < sizeof(RfChannelJournalRecord) / 4u; i++)
+		if (p[i] != 0xFFFFFFFFu)
+			return false;
+	return true;
+}
+
+static bool rfChannelJournalReadValid(uint16_t slot,
+				      RfChannelJournalRecord *out)
+{
+	if (!out)
+		return false;
+	memcpy(out, (const void *)rfChannelJournalSlotAddress(slot),
+	       sizeof *out);
+	if (out->magic != RF_CHANNEL_JOURNAL_MAGIC ||
+	    out->commit != RF_CHANNEL_JOURNAL_COMMIT ||
+	    out->format != RF_CHANNEL_JOURNAL_FORMAT ||
+	    out->poolCount != RF_CHANNEL_HISTORY_POOL_COUNT)
+		return false;
+	return out->crc32 ==
+	       rfChannelJournalCrc32(out,
+				     offsetof(RfChannelJournalRecord, crc32));
+}
+
+static void rfChannelJournalCheckSoftDevice()
+{
+	if (g_channelJournalSoftDeviceChecked)
+		return;
+	g_channelJournalSoftDeviceChecked = true;
+	uint8_t enabled = 0;
+	if (sd_softdevice_is_enabled(&enabled) != NRF_SUCCESS)
+		enabled = 1;
+	g_channelJournalSoftDeviceEnabled = enabled != 0;
+}
+
+static bool rfChannelJournalTimerReady()
+{
+	// TIMER3 is the hardware-validated 16-MHz RF timing substrate retained from
+	// Channel-history flash timing borrows only unused CC[5]; CC[0..4] and PPI13..16 remain
+	// untouched. Never initialize/reconfigure the timer here: if the retained
+	// timing substrate is unavailable, live persistence fails closed to offline.
+	return NRF_TIMER3->MODE ==
+		       (TIMER_MODE_MODE_Timer << TIMER_MODE_MODE_Pos) &&
+	       NRF_TIMER3->BITMODE == (TIMER_BITMODE_BITMODE_32Bit
+				       << TIMER_BITMODE_BITMODE_Pos) &&
+	       NRF_TIMER3->PRESCALER == 0u;
+}
+
+static bool rfChannelJournalCaptureTicks(uint32_t *ticks)
+{
+	if (!ticks || !rfChannelJournalTimerReady())
+		return false;
+	NRF_TIMER3->TASKS_CAPTURE[5] = 1;
+	*ticks = NRF_TIMER3->CC[5];
+	return true;
+}
+
+static bool rfChannelJournalProgramWord(uintptr_t address, uint32_t value,
+					uint32_t *durationUs,
+					bool *durationValid)
+{
+	rfChannelJournalCheckSoftDevice();
+	if (durationUs)
+		*durationUs = 0;
+	if (durationValid)
+		*durationValid = false;
+	if (g_channelJournalSoftDeviceEnabled || (address & 3u) != 0u ||
+	    *(const volatile uint32_t *)address != 0xFFFFFFFFu)
+		return false;
+
+	uint32_t t0Ticks = 0;
+	const bool haveHiRes = rfChannelJournalCaptureTicks(&t0Ticks);
+	const uint32_t primask = __get_PRIMASK();
+	__disable_irq();
+	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;
+	while (!NRF_NVMC->READY) {
+	}
+	*(volatile uint32_t *)address = value;
+	while (!NRF_NVMC->READY) {
+	}
+	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+	while (!NRF_NVMC->READY) {
+	}
+	uint32_t t1Ticks = 0;
+	const bool haveHiResEnd = haveHiRes &&
+				  rfChannelJournalCaptureTicks(&t1Ticks);
+	if (!primask)
+		__enable_irq();
+
+	if (haveHiResEnd) {
+		const uint32_t dtTicks = (uint32_t)(t1Ticks - t0Ticks);
+		const uint32_t dtUs =
+			(dtTicks + RF_CHANNEL_JOURNAL_TIMER3_TICKS_PER_US -
+			 1u) /
+			RF_CHANNEL_JOURNAL_TIMER3_TICKS_PER_US;
+		if (durationUs)
+			*durationUs = dtUs;
+		if (durationValid)
+			*durationValid = true;
+	}
+	return *(const volatile uint32_t *)address == value;
+}
+
+static bool rfChannelJournalErasePage(uint8_t page)
+{
+	rfChannelJournalCheckSoftDevice();
+	if (g_channelJournalSoftDeviceEnabled ||
+	    page >= RF_CHANNEL_JOURNAL_PAGE_COUNT)
+		return false;
+	const uintptr_t address =
+		rfChannelJournalBase() +
+		(uintptr_t)page * RF_CHANNEL_JOURNAL_PAGE_BYTES;
+	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Een;
+	while (!NRF_NVMC->READY) {
+	}
+	NRF_NVMC->ERASEPAGE = (uint32_t)address;
+	while (!NRF_NVMC->READY) {
+	}
+	NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+	while (!NRF_NVMC->READY) {
+	}
+	const volatile uint32_t *p = (const volatile uint32_t *)address;
+	for (uint16_t i = 0; i < RF_CHANNEL_JOURNAL_PAGE_BYTES / 4u; i++)
+		if (p[i] != 0xFFFFFFFFu)
+			return false;
+	return true;
+}
+
+static int16_t rfChannelJournalFindFreeSlot()
+{
+	for (uint16_t slot = 0; slot < RF_CHANNEL_JOURNAL_TOTAL_RECORDS; slot++)
+		if (rfChannelJournalSlotErased(slot))
+			return (int16_t)slot;
+	return -1;
+}
+
+static void rfChannelJournalLoad()
+{
+	if (g_channelHistoryPersistentLoaded)
+		return;
+	g_channelHistoryPersistentLoaded = true;
+	rfChannelJournalCheckSoftDevice();
+	const uintptr_t base = rfChannelJournalBase();
+	if (base != (uintptr_t)RF_CHANNEL_JOURNAL_BASE ||
+	    (base & (RF_CHANNEL_JOURNAL_PAGE_BYTES - 1u)) != 0u ||
+	    rfChannelJournalFlashUsedEnd() > base) {
+		g_channelJournalLiveWriteUnsafe = true;
+		return;
+	}
+	RfChannelJournalRecord latest = {};
+	bool haveLatest = false;
+	for (uint16_t slot = 0; slot < RF_CHANNEL_JOURNAL_TOTAL_RECORDS;
+	     slot++) {
+		RfChannelJournalRecord rec = {};
+		if (!rfChannelJournalReadValid(slot, &rec))
+			continue;
+		if (!haveLatest || rfChannelJournalSequenceNewer(
+					   rec.sequence, latest.sequence)) {
+			latest = rec;
+			g_channelJournalLatestSlot = (int16_t)slot;
+			haveLatest = true;
+		}
+	}
+	if (haveLatest) {
+		memcpy(g_channelHistoryPersistentWorstPct, latest.worstPct,
+		       sizeof g_channelHistoryPersistentWorstPct);
+		memcpy(g_channelHistoryPersistentMeanPct, latest.meanPct,
+		       sizeof g_channelHistoryPersistentMeanPct);
+		memcpy(g_channelHistoryPersistentConfidence, latest.confidence,
+		       sizeof g_channelHistoryPersistentConfidence);
+		memcpy(g_channelHistoryPersistentTrials, latest.trials,
+		       sizeof g_channelHistoryPersistentTrials);
+		memcpy(g_channelHistoryPersistentPenalty, latest.penalty,
+		       sizeof g_channelHistoryPersistentPenalty);
+		memcpy(g_channelHistoryPersistentRecentOrder,
+		       latest.recentOrder,
+		       sizeof g_channelHistoryPersistentRecentOrder);
+		g_channelHistoryPersistentOrderCounter = latest.orderCounter;
+		g_channelJournalSequence = latest.sequence;
+	}
+	g_channelJournalFreeSlot = rfChannelJournalFindFreeSlot();
+}
+
+static void rfChannelJournalBuildRecord(RfChannelJournalRecord *rec)
+{
+	memset(rec, 0, sizeof *rec);
+	rec->magic = RF_CHANNEL_JOURNAL_MAGIC;
+	rec->sequence = g_channelJournalSequence + 1u;
+	rec->format = RF_CHANNEL_JOURNAL_FORMAT;
+	rec->poolCount = RF_CHANNEL_HISTORY_POOL_COUNT;
+	rec->orderCounter = g_channelHistoryPersistentOrderCounter;
+	memcpy(rec->worstPct, g_channelHistoryPersistentWorstPct,
+	       sizeof rec->worstPct);
+	memcpy(rec->meanPct, g_channelHistoryPersistentMeanPct,
+	       sizeof rec->meanPct);
+	memcpy(rec->confidence, g_channelHistoryPersistentConfidence,
+	       sizeof rec->confidence);
+	memcpy(rec->trials, g_channelHistoryPersistentTrials,
+	       sizeof rec->trials);
+	memcpy(rec->penalty, g_channelHistoryPersistentPenalty,
+	       sizeof rec->penalty);
+	memcpy(rec->recentOrder, g_channelHistoryPersistentRecentOrder,
+	       sizeof rec->recentOrder);
+	rec->crc32 = rfChannelJournalCrc32(rec, offsetof(RfChannelJournalRecord,
+							 crc32));
+	rec->commit = RF_CHANNEL_JOURNAL_COMMIT;
+}
+
+static bool rfChannelJournalStartWrite()
+{
+	if (g_channelJournalJobActive || g_channelJournalFreeSlot < 0)
+		return false;
+	rfChannelJournalBuildRecord(&g_channelJournalJob);
+	g_channelJournalJobSlot = g_channelJournalFreeSlot;
+	g_channelJournalJobWord = 0;
+	g_channelJournalJobGeneration = g_channelHistoryPersistentGeneration;
+	g_channelJournalLastWordUs = 0;
+	g_channelJournalJobActive = true;
+	return true;
+}
+
+static void rfChannelJournalFinishWrite(uint32_t now)
+{
+	RfChannelJournalRecord verify = {};
+	const bool valid =
+		rfChannelJournalReadValid((uint16_t)g_channelJournalJobSlot,
+					  &verify) &&
+		verify.sequence == g_channelJournalJob.sequence;
+	if (!valid) {
+		g_channelJournalJobActive = false;
+		g_channelJournalFreeSlot = rfChannelJournalFindFreeSlot();
+		return;
+	}
+	g_channelJournalSequence = verify.sequence;
+	g_channelJournalLatestSlot = g_channelJournalJobSlot;
+	g_channelHistoryPersistentWrites++;
+	g_channelHistoryPersistentLastWriteMs = now;
+	if (g_channelHistoryPersistentGeneration ==
+	    g_channelJournalJobGeneration)
+		g_channelHistoryPersistentDirty = false;
+	g_channelJournalJobActive = false;
+	g_channelJournalFreeSlot = rfChannelJournalFindFreeSlot();
+}
+
+static void rfChannelJournalStep(uint32_t now, uint8_t liveMask)
+{
+	if (!g_channelJournalJobActive || g_rfChHandoffState != RF_CH_IDLE ||
+	    g_rfChGroupActive)
+		return;
+	const bool live = liveMask != 0u;
+	if (live && (g_channelJournalLiveWriteUnsafe ||
+		     g_channelJournalSoftDeviceEnabled))
+		return;
+	const uint32_t us = micros();
+	if (g_channelJournalLastWordUs &&
+	    (uint32_t)(us - g_channelJournalLastWordUs) <
+		    RF_CHANNEL_JOURNAL_WORD_INTERVAL_US)
+		return;
+	const uint8_t words = sizeof(RfChannelJournalRecord) / 4u;
+	if (g_channelJournalJobWord >= words)
+		return;
+	const uint8_t word = g_channelJournalJobWord;
+	// Commit is the last 32-bit word by construction. Sequential programming
+	// therefore makes every partial/power-loss record invalid at boot.
+	const uint32_t value = ((const uint32_t *)&g_channelJournalJob)[word];
+	const uintptr_t address =
+		rfChannelJournalSlotAddress((uint16_t)g_channelJournalJobSlot) +
+		(uintptr_t)word * 4u;
+	uint32_t durationUs = 0;
+	bool durationValid = false;
+	if (!rfChannelJournalProgramWord(address, value, &durationUs,
+					 &durationValid)) {
+		g_channelJournalJobActive = false;
+		g_channelJournalFreeSlot = rfChannelJournalFindFreeSlot();
+		return;
+	}
+	g_channelJournalLastWordUs = us;
+	if (live && !durationValid)
+		g_channelJournalLiveWriteUnsafe = true;
+	else if (live && durationUs > RF_CHANNEL_JOURNAL_LIVE_WORD_MAX_US)
+		g_channelJournalLiveWriteUnsafe = true;
+	g_channelJournalJobWord++;
+	if (g_channelJournalJobWord >= words)
+		rfChannelJournalFinishWrite(now);
+}
+
+// Explicit Journal Builder actions may finish an already-started, pre-erased
+// append record in one bounded gap: once at admission to clear a passive job
+// that cannot advance live, and again for Builder's own final save. The passive
+// path deliberately latches off after a slow live word; applying that latch here
+// would deadlock a user-invoked Builder. No page erase is performed here.
+static void rfChannelJournalDrainBuilderWrite(uint32_t now)
+{
+	if (!g_channelJournalJobActive || g_rfChHandoffState != RF_CH_IDLE ||
+	    g_rfChGroupActive)
+		return;
+	const uint8_t words = sizeof(RfChannelJournalRecord) / 4u;
+	while (g_channelJournalJobActive && g_channelJournalJobWord < words) {
+		const uint8_t word = g_channelJournalJobWord;
+		const uint32_t value =
+			((const uint32_t *)&g_channelJournalJob)[word];
+		const uintptr_t address =
+			rfChannelJournalSlotAddress(
+				(uint16_t)g_channelJournalJobSlot) +
+			(uintptr_t)word * 4u;
+		if (!rfChannelJournalProgramWord(address, value, nullptr,
+						 nullptr)) {
+			g_channelJournalJobActive = false;
+			g_channelJournalFreeSlot =
+				rfChannelJournalFindFreeSlot();
+			return;
+		}
+		g_channelJournalJobWord++;
+	}
+	if (g_channelJournalJobActive && g_channelJournalJobWord >= words)
+		rfChannelJournalFinishWrite(now);
+}
+
+static bool rfChannelJournalMaybeCollect(uint32_t now, uint8_t liveMask)
+{
+	if (g_channelJournalFreeSlot >= 0)
+		return true;
+	if (liveMask || g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive) {
+		g_channelJournalNoLiveSinceMs = 0;
+		return false;
+	}
+	if (!g_channelJournalNoLiveSinceMs) {
+		g_channelJournalNoLiveSinceMs = now;
+		return false;
+	}
+	if ((uint32_t)(now - g_channelJournalNoLiveSinceMs) <
+	    RF_CHANNEL_JOURNAL_OFFLINE_GUARD_MS)
+		return false;
+	uint8_t keepPage = 0xFFu;
+	if (g_channelJournalLatestSlot >= 0)
+		keepPage = (uint8_t)g_channelJournalLatestSlot /
+			   RF_CHANNEL_JOURNAL_RECORDS_PER_PAGE;
+	const uint8_t erasePage = keepPage == 0u ? 1u : 0u;
+	if (!rfChannelJournalErasePage(erasePage))
+		return false;
+	g_channelJournalFreeSlot = rfChannelJournalFindFreeSlot();
+	g_channelJournalNoLiveSinceMs = now;
+	return g_channelJournalFreeSlot >= 0;
+}
+
+static void rfChannelHistoryEnsureLoaded()
+{
+	rfChannelJournalLoad();
+}
+
+static void rfChannelHistorySyncResidence()
+{
+	if (g_channelHistoryResidenceChannel == g_sessCh)
+		return;
+	g_channelHistoryResidenceChannel = g_sessCh;
+	g_channelHistoryResidenceOutcomeRecorded = false;
+	const int idx = rfChannelHistoryPoolIndex(g_sessCh);
+	if (idx >= 0) {
+		// Good/bad streaks are consecutive-residence evidence. Never carry a
+		// partial streak across a channel excursion and count it as continuous.
+		g_channelHistoryRuntimeGoodStreak[idx] = 0;
+		g_channelHistoryRuntimeBadStreak[idx] = 0;
+	}
+}
+
+static void rfChannelHistoryRecordPersistentOutcome(uint8_t ch,
+						    uint16_t worstPermille,
+						    uint16_t meanPermille,
+						    bool good)
+{
+	rfChannelHistoryEnsureLoaded();
+	rfChannelHistorySyncResidence();
+	if (g_channelHistoryResidenceOutcomeRecorded)
+		return;
+	const int idx = rfChannelHistoryPoolIndex(ch);
+	if (idx < 0)
+		return;
+	g_channelHistoryResidenceOutcomeRecorded = true;
+	const uint8_t worstPct =
+		(uint8_t)(worstPermille > 1000u ? 100u : worstPermille / 10u);
+	const uint8_t meanPct =
+		(uint8_t)(meanPermille > 1000u ? 100u : meanPermille / 10u);
+	if (!g_channelHistoryPersistentTrials[idx]) {
+		g_channelHistoryPersistentWorstPct[idx] = worstPct;
+		g_channelHistoryPersistentMeanPct[idx] = meanPct;
+	} else if (good) {
+		g_channelHistoryPersistentWorstPct[idx] =
+			(uint8_t)(((uint16_t)g_channelHistoryPersistentWorstPct
+						   [idx] *
+					   3u +
+				   worstPct) /
+				  4u);
+		g_channelHistoryPersistentMeanPct[idx] =
+			(uint8_t)(((uint16_t)g_channelHistoryPersistentMeanPct
+						   [idx] *
+					   3u +
+				   meanPct) /
+				  4u);
+	} else {
+		// Bad current evidence must demote stale historical greatness quickly.
+		g_channelHistoryPersistentWorstPct[idx] =
+			(uint8_t)(((uint16_t)g_channelHistoryPersistentWorstPct
+					   [idx] +
+				   worstPct) /
+				  2u);
+		g_channelHistoryPersistentMeanPct[idx] =
+			(uint8_t)(((uint16_t)
+					   g_channelHistoryPersistentMeanPct[idx] +
+				   meanPct) /
+				  2u);
+	}
+	if (g_channelHistoryPersistentTrials[idx] != 0xFFu)
+		g_channelHistoryPersistentTrials[idx]++;
+	if (good) {
+		if (g_channelHistoryPersistentConfidence[idx] < 15u)
+			g_channelHistoryPersistentConfidence[idx]++;
+		if (g_channelHistoryPersistentPenalty[idx])
+			g_channelHistoryPersistentPenalty[idx]--;
+	} else {
+		if (g_channelHistoryPersistentConfidence[idx])
+			g_channelHistoryPersistentConfidence[idx]--;
+		if (g_channelHistoryPersistentPenalty[idx] < 10u)
+			g_channelHistoryPersistentPenalty[idx] += 2u;
+	}
+	g_channelHistoryPersistentOrderCounter++;
+	g_channelHistoryPersistentRecentOrder[idx] =
+		g_channelHistoryPersistentOrderCounter;
+	g_channelHistoryPersistentDirty = true;
+	g_channelHistoryPersistentGeneration++;
+}
+
+static void rfChannelHistoryObserve(uint8_t ch, uint16_t worstPermille,
+				    uint16_t meanPermille, bool valid)
+{
+	rfChannelHistoryEnsureLoaded();
+	rfChannelHistorySyncResidence();
+	const int idx = rfChannelHistoryPoolIndex(ch);
+	if (idx < 0 || !valid)
+		return;
+	if (worstPermille >= RF_CHANNEL_HISTORY_GOOD_PERMILLE) {
+		if (g_channelHistoryRuntimeGoodStreak[idx] != 0xFFu)
+			g_channelHistoryRuntimeGoodStreak[idx]++;
+		g_channelHistoryRuntimeBadStreak[idx] = 0;
+		if (g_channelHistoryRuntimeGoodStreak[idx] >=
+		    RF_CHANNEL_HISTORY_GOOD_WINDOWS) {
+			rfChannelHistoryRecordPersistentOutcome(
+				ch, worstPermille, meanPermille, true);
+		}
+	} else {
+		g_channelHistoryRuntimeGoodStreak[idx] = 0;
+		if (worstPermille < RF_CHANNEL_HISTORY_BAD_PERMILLE) {
+			if (g_channelHistoryRuntimeBadStreak[idx] != 0xFFu)
+				g_channelHistoryRuntimeBadStreak[idx]++;
+			if (g_channelHistoryRuntimeBadStreak[idx] >=
+			    RF_CHANNEL_HISTORY_BAD_WINDOWS)
+				rfChannelHistoryRecordPersistentOutcome(
+					ch, worstPermille, meanPermille, false);
+		} else {
+			g_channelHistoryRuntimeBadStreak[idx] = 0;
+		}
+	}
+}
+
+static void rfChannelHistoryMaybeCheckpoint(uint32_t now)
+{
+	rfChannelHistoryEnsureLoaded();
+	const uint8_t liveMask = rfChannelLiveMask(now);
+	if (!liveMask) {
+		if (!g_channelJournalNoLiveSinceMs)
+			g_channelJournalNoLiveSinceMs = now;
+	} else {
+		g_channelJournalNoLiveSinceMs = 0;
+	}
+	// An in-progress record is advanced in tiny, pre-erased word quanta. It is
+	// paused across any channel handoff and automatically falls back to offline
+	// completion if a live word ever exceeds the conservative stall budget.
+	rfChannelJournalStep(now, liveMask);
+	if (g_channelJournalJobActive || !g_channelHistoryPersistentDirty ||
+	    g_channelHistoryPersistentWrites >=
+		    RF_CHANNEL_HISTORY_PERSIST_MAX_WRITES_PER_BOOT ||
+	    g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive)
+		return;
+	if (g_channelHistoryPersistentLastWriteMs &&
+	    (uint32_t)(now - g_channelHistoryPersistentLastWriteMs) <
+		    RF_CHANNEL_HISTORY_PERSIST_MIN_INTERVAL_MS)
+		return;
+	// Once live word programming has failed the conservative stall budget,
+	// do not create another passive job that cannot advance until the cohort
+	// goes offline. Leaving such a job active would block the explicit Journal
+	// Builder, which itself requires a live controller.
+	if (liveMask && (g_channelJournalLiveWriteUnsafe ||
+			 g_channelJournalSoftDeviceEnabled))
+		return;
+	if (g_channelJournalFreeSlot < 0 &&
+	    !rfChannelJournalMaybeCollect(now, liveMask))
+		return;
+	if (!rfChannelJournalStartWrite())
+		return;
+	// Allow the first word immediately; later words are rate-shaped.
+	rfChannelJournalStep(now, liveMask);
+}
+
+static void rfJournalBuilderResetChannel(uint8_t index)
+{
+	if (index >= RF_CHANNEL_HISTORY_POOL_COUNT)
+		return;
+	g_rfJournalBuilderWorstPermille[index] = 1000u;
+	g_rfJournalBuilderMeanSumPermille[index] = 0;
+	g_rfJournalBuilderValidWindows[index] = 0;
+	g_rfJournalBuilderBadWindows[index] = 0;
+}
+
+static void rfJournalBuilderResetAll()
+{
+	for (uint8_t i = 0; i < RF_CHANNEL_HISTORY_POOL_COUNT; i++)
+		rfJournalBuilderResetChannel(i);
+	g_rfJournalBuilderIndex = 0;
+	g_rfJournalBuilderChannel = 0;
+	g_rfJournalBuilderBestChannel = 0;
+	g_rfJournalBuilderFailure = RF_JOURNAL_BUILDER_FAIL_NONE;
+	g_rfJournalBuilderHopAttempts = 0;
+	g_rfJournalBuilderPromoted = false;
+	g_rfJournalBuilderCancelRequested = false;
+	g_rfJournalBuilderIdleValueValidMask = 0;
+	memset(g_rfJournalBuilderIdleValueSeconds, 0,
+	       sizeof g_rfJournalBuilderIdleValueSeconds);
+	g_rfJournalBuilderIdleQueryStartedMs = 0;
+	memset(g_rfJournalBuilderIdleLastQueryMs, 0,
+	       sizeof g_rfJournalBuilderIdleLastQueryMs);
+	g_rfJournalBuilderIdleLastPulseMs = 0;
+	g_rfJournalBuilderSurveyStarted = false;
+}
+
+static void rfJournalBuilderSetPhase(uint8_t phase, unsigned long now)
+{
+	g_rfJournalBuilderPhase = phase;
+	g_rfJournalBuilderPhaseMs = now;
+}
+
+static void rfJournalBuilderObserveWindow(uint8_t ch, uint16_t worstPermille,
+					  uint16_t meanPermille, bool valid)
+{
+	if (g_rfJournalBuilderPhase != RF_JOURNAL_BUILDER_MEASURING ||
+	    g_rfJournalBuilderIndex >= RF_CHANNEL_HISTORY_POOL_COUNT ||
+	    ch != g_rfJournalBuilderChannel || !valid)
+		return;
+	const uint8_t i = g_rfJournalBuilderIndex;
+	if (g_rfJournalBuilderValidWindows[i] >= RF_JOURNAL_BUILDER_WINDOWS)
+		return;
+	if (worstPermille < g_rfJournalBuilderWorstPermille[i])
+		g_rfJournalBuilderWorstPermille[i] = worstPermille;
+	g_rfJournalBuilderMeanSumPermille[i] += meanPermille;
+	g_rfJournalBuilderValidWindows[i]++;
+	if (worstPermille < RF_CHANNEL_HISTORY_BAD_PERMILLE &&
+	    g_rfJournalBuilderBadWindows[i] != 0xFFu)
+		g_rfJournalBuilderBadWindows[i]++;
+}
+
+static void rfJournalBuilderMarkHopFailure(uint8_t index)
+{
+	if (index >= RF_CHANNEL_HISTORY_POOL_COUNT)
+		return;
+	g_rfJournalBuilderWorstPermille[index] = 0;
+	g_rfJournalBuilderMeanSumPermille[index] = 0;
+	g_rfJournalBuilderValidWindows[index] = 1;
+	g_rfJournalBuilderBadWindows[index] = 10;
+}
+
+static uint8_t rfJournalBuilderSelectBest()
+{
+	int best = -1;
+	for (uint8_t i = 0; i < RF_CHANNEL_HISTORY_POOL_COUNT; i++) {
+		if (g_rfJournalBuilderValidWindows[i] <
+		    RF_JOURNAL_BUILDER_WINDOWS)
+			continue;
+		const uint16_t worst = g_rfJournalBuilderWorstPermille[i];
+		const uint16_t mean =
+			(uint16_t)(g_rfJournalBuilderMeanSumPermille[i] /
+				   g_rfJournalBuilderValidWindows[i]);
+		if (best < 0) {
+			best = i;
+			continue;
+		}
+		const uint16_t bestWorst =
+			g_rfJournalBuilderWorstPermille[best];
+		const uint16_t bestMean =
+			(uint16_t)(g_rfJournalBuilderMeanSumPermille[best] /
+				   g_rfJournalBuilderValidWindows[best]);
+		if (worst > bestWorst ||
+		    (worst == bestWorst && mean > bestMean) ||
+		    (worst == bestWorst && mean == bestMean &&
+		     g_rfJournalBuilderBadWindows[i] <
+			     g_rfJournalBuilderBadWindows[best]) ||
+		    (worst == bestWorst && mean == bestMean &&
+		     g_rfJournalBuilderBadWindows[i] ==
+			     g_rfJournalBuilderBadWindows[best] &&
+		     g_ambientStableValid &&
+		     g_ambientStableRssi[i] > g_ambientStableRssi[best]))
+			best = i;
+	}
+	return best < 0 ? 0u : g_recoveryChannelPool[best];
+}
+
+static bool rfJournalBuilderPromoteAndStartWrite(unsigned long now)
+{
+	if (g_rfJournalBuilderPromoted)
+		return true;
+	if (g_channelJournalJobActive || g_channelJournalFreeSlot < 0)
+		return false;
+
+	uint8_t order = g_channelHistoryPersistentOrderCounter;
+	for (uint8_t i = 0; i < RF_CHANNEL_HISTORY_POOL_COUNT; i++) {
+		const uint8_t windows = g_rfJournalBuilderValidWindows[i];
+		if (!windows)
+			return false;
+		const uint16_t worst = g_rfJournalBuilderWorstPermille[i];
+		const uint16_t mean =
+			(uint16_t)(g_rfJournalBuilderMeanSumPermille[i] /
+				   windows);
+		g_channelHistoryPersistentWorstPct[i] =
+			(uint8_t)(worst > 1000u ? 100u : worst / 10u);
+		g_channelHistoryPersistentMeanPct[i] =
+			(uint8_t)(mean > 1000u ? 100u : mean / 10u);
+		g_channelHistoryPersistentTrials[i] = windows;
+		g_channelHistoryPersistentConfidence[i] =
+			(uint8_t)((windows / 4u) > 15u ? 15u : windows / 4u);
+		g_channelHistoryPersistentPenalty[i] =
+			g_rfJournalBuilderBadWindows[i] > 10u ?
+				10u :
+				g_rfJournalBuilderBadWindows[i];
+		order++;
+		g_channelHistoryPersistentRecentOrder[i] = order;
+	}
+	g_channelHistoryPersistentOrderCounter = order;
+	g_channelHistoryPersistentDirty = true;
+	g_channelHistoryPersistentGeneration++;
+	g_rfJournalBuilderPromoted = true;
+	g_channelHistoryResidenceChannel = 0xFFu;
+	g_channelHistoryResidenceOutcomeRecorded = false;
+	if (!rfChannelJournalStartWrite())
+		return false;
+	return true;
+}
+
+static bool rfChannelRetuneNoControllers(uint8_t channel, unsigned long now)
+{
+	if (rfChannelHistoryPoolIndex(channel) < 0 || rfChannelLiveMask(now) ||
+	    g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive)
+		return false;
+	if (channel == g_sessCh)
+		return true;
+	g_sessCh = channel;
+	g_rfCh = channel;
+	g_lastSessBeacon = 0;
+	g_lastDisc = 0;
+	g_lastChannelHopMs = now;
+	g_qosLastHopMs = now;
+	g_linkQualityCheckMs = now;
+	g_qosCheckMs = now;
+	for (int s = 0; s < NSLOT; s++) {
+		rfLinkQualityResetWindow(s);
+		g_linkQualityBadStreak[s] = 0;
+	}
+	rfChannelRecoverySyncResidence();
+	(void)rfChannelRecoverySetTarget(0u);
+	rfChannelEvidenceSyncResidence();
+	rfChannelHistorySyncResidence();
+	rfConfig(channel);
+	return true;
+}
+
+static bool rfJournalBuilderImmediateHop(uint8_t channel)
+{
+	if (rfChannelHistoryPoolIndex(channel) < 0)
+		return false;
+	if (channel == g_sessCh || g_rfChHandoffState != RF_CH_IDLE ||
+	    g_rfChGroupActive)
+		return channel == g_sessCh;
+	const unsigned long now = millis();
+	const uint8_t mask = rfChannelLiveMask(now);
+	if (!mask)
+		return rfChannelRetuneNoControllers(channel, now);
+	return rfChannelGroupBegin(g_sessCh, channel, mask, now, true);
+}
+
+static bool rfJournalBuilderIdleQueryComplete()
+{
+	return (g_rfJournalBuilderIdleValueValidMask &
+		g_rfJournalBuilderParticipants) ==
+	       g_rfJournalBuilderParticipants;
+}
+
+static bool rfJournalBuilderIdleQueueRead(uint8_t slot)
+{
+	const uint8_t setting = RF_JOURNAL_BUILDER_IDLE_SETTING;
+	return relayEnqueue(IBEX_CMD_GET_SETTINGS_VALUES, &setting, 1u, false,
+			    slot, true);
+}
+
+static bool rfJournalBuilderIdleQueueWrite(uint8_t slot, uint16_t value)
+{
+	const uint8_t payload[3] = {
+		RF_JOURNAL_BUILDER_IDLE_SETTING,
+		(uint8_t)value,
+		(uint8_t)(value >> 8),
+	};
+	return relayEnqueue(IBEX_CMD_SET_SETTINGS_VALUES, payload,
+			    sizeof payload, false, slot);
+}
+
+static void rfJournalBuilderIdlePulse(uint8_t mask, unsigned long now)
+{
+	for (uint8_t slot = 0; slot < NSLOT; slot++) {
+		const uint8_t bit = (uint8_t)(1u << slot);
+		if (!(mask & bit) ||
+		    !(g_rfJournalBuilderIdleValueValidMask & bit))
+			continue;
+		const uint16_t original =
+			g_rfJournalBuilderIdleValueSeconds[slot];
+		// Zero disables inactivity sleep, so that controller needs no pulse.
+		if (!original)
+			continue;
+		// Hardware validation showed that a same-value write does not reset
+		// inactivity. Force a one-second transition, then immediately restore
+		// the captured timeout; decrement only for unusually large values.
+		const uint16_t pulse = original < 32767u ?
+					       (uint16_t)(original + 1u) :
+					       (uint16_t)(original - 1u);
+		for (uint8_t i = 0; i < RF_JOURNAL_BUILDER_IDLE_WRITE_REPS; i++)
+			(void)rfJournalBuilderIdleQueueWrite(slot, pulse);
+		for (uint8_t i = 0; i < RF_JOURNAL_BUILDER_IDLE_WRITE_REPS; i++)
+			(void)rfJournalBuilderIdleQueueWrite(slot, original);
+	}
+	g_rfJournalBuilderIdleLastPulseMs = now ? now : 1u;
+}
+
+static void rfJournalBuilderIdleCapture(uint8_t slot, const uint8_t *response,
+					uint8_t responseLen)
+{
+	if (!rfJournalBuilderActive() || slot >= NSLOT || responseLen < 5u ||
+	    !(g_rfJournalBuilderParticipants & (uint8_t)(1u << slot)) ||
+	    !g_rfJournalBuilderIdleLastQueryMs[slot] ||
+	    response[0] != IBEX_CMD_GET_SETTINGS_VALUES || response[1] < 3u ||
+	    response[2] != RF_JOURNAL_BUILDER_IDLE_SETTING)
+		return;
+	const uint8_t bit = (uint8_t)(1u << slot);
+	if (g_rfJournalBuilderIdleValueValidMask & bit)
+		return;
+	g_rfJournalBuilderIdleValueSeconds[slot] = (uint16_t)response[3] |
+						   ((uint16_t)response[4] << 8);
+	g_rfJournalBuilderIdleValueValidMask |= bit;
+}
+
+static bool rfJournalBuilderIdlePrepare(unsigned long now)
+{
+	if (rfJournalBuilderIdleQueryComplete())
+		return true;
+	if (!g_rfJournalBuilderIdleQueryStartedMs)
+		g_rfJournalBuilderIdleQueryStartedMs = now ? now : 1u;
+	if ((uint32_t)(now - g_rfJournalBuilderIdleQueryStartedMs) >=
+	    RF_JOURNAL_BUILDER_IDLE_QUERY_TIMEOUT_MS) {
+		g_rfJournalBuilderFailure =
+			RF_JOURNAL_BUILDER_FAIL_IDLE_TIMEOUT_QUERY;
+		rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_FAILED, now);
+		return false;
+	}
+	for (uint8_t slot = 0; slot < NSLOT; slot++) {
+		const uint8_t bit = (uint8_t)(1u << slot);
+		if (!(g_rfJournalBuilderParticipants & bit) ||
+		    (g_rfJournalBuilderIdleValueValidMask & bit))
+			continue;
+		if (!g_rfJournalBuilderIdleLastQueryMs[slot] ||
+		    (uint32_t)(now - g_rfJournalBuilderIdleLastQueryMs[slot]) >=
+			    RF_JOURNAL_BUILDER_IDLE_QUERY_RETRY_MS) {
+			if (rfJournalBuilderIdleQueueRead(slot))
+				g_rfJournalBuilderIdleLastQueryMs[slot] =
+					now ? now : 1u;
+		}
+	}
+	return false;
+}
+
+bool rfRecoveryRequestJournalBuilder()
+{
+	const unsigned long now = millis();
+	rfChannelHistoryEnsureLoaded();
+	// WebUSB status can lag a successful start request. Treat a duplicate Start
+	// while this Builder already owns the workflow as an idempotent success
+	// instead of converting the in-progress run into a false BUSY failure.
+	if (rfJournalBuilderActive())
+		return true;
+
+	// An explicit Builder request may supersede only an automatic recovery
+	// that is still waiting for its activity/neutral admission proof. No E4
+	// authorization has been sent and the session channel has not changed in
+	// RF_GROUP_HOP_PENDING, so aborting that automatic request is safe. Never
+	// preempt a manual hop or any handoff that has advanced past authorization.
+	if (g_rfChGroupActive && g_rfChGroupPhase == RF_GROUP_HOP_PENDING &&
+	    !g_rfChHandoffManualImmediate)
+		rfChannelGroupAbort();
+
+	if (g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive) {
+		g_rfJournalBuilderPhase = RF_JOURNAL_BUILDER_FAILED;
+		g_rfJournalBuilderFailure = RF_JOURNAL_BUILDER_FAIL_BUSY;
+		return false;
+	}
+	// Builder requires a live cohort, while an unsafe passive journal job only
+	// resumes after that cohort disappears. Resolve that otherwise-impossible
+	// admission state by finishing the already-started append record here.
+	if (g_channelJournalJobActive)
+		rfChannelJournalDrainBuilderWrite(now);
+	if (g_channelJournalJobActive) {
+		g_rfJournalBuilderPhase = RF_JOURNAL_BUILDER_FAILED;
+		g_rfJournalBuilderFailure =
+			RF_JOURNAL_BUILDER_FAIL_JOURNAL_WRITE_BUSY;
+		return false;
+	}
+	const uint8_t liveMask = rfChannelLiveMask(now);
+	if (!liveMask) {
+		g_rfJournalBuilderPhase = RF_JOURNAL_BUILDER_FAILED;
+		g_rfJournalBuilderFailure =
+			RF_JOURNAL_BUILDER_FAIL_NO_CONTROLLERS;
+		return false;
+	}
+	if (g_channelJournalFreeSlot < 0) {
+		g_rfJournalBuilderPhase = RF_JOURNAL_BUILDER_FAILED;
+		g_rfJournalBuilderFailure =
+			RF_JOURNAL_BUILDER_FAIL_JOURNAL_FULL;
+		return false;
+	}
+
+	if (g_ambientSurveyRunning)
+		rfAmbientSurveyAbort();
+	g_ambientSurveyPending = false;
+	g_ambientSurveyManual = false;
+	g_ambientSurveyFailure = RF_AMBIENT_SURVEY_FAIL_NONE;
+	g_ambientSurveyFailureChannel = 0;
+	rfJournalBuilderResetAll();
+	g_rfJournalBuilderParticipants = liveMask;
+	g_rfJournalBuilderOriginChannel = g_sessCh;
+	g_rfJournalBuilderSurveyGeneration = g_ambientSurveyGeneration;
+	g_rfJournalBuilderCohortStableMs = now;
+	g_rfJournalBuilderIdleQueryStartedMs = now ? now : 1u;
+	rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_SURVEY, now);
+	// Capture every participant's own setting 50 before the survey starts.
+	// The first +1 -> original pulse then refreshes inactivity immediately.
+	(void)rfChannelRecoverySetTarget(0u);
+	rfJournalBuilderResetQualityWindows();
+	return true;
+}
+
+void rfRecoveryCancelJournalBuilder()
+{
+	if (!rfJournalBuilderActive() ||
+	    g_rfJournalBuilderPhase == RF_JOURNAL_BUILDER_SAVING)
+		return;
+	g_rfJournalBuilderCancelRequested = true;
+}
+
+static void rfJournalBuilderFinishCanceled(unsigned long now)
+{
+	if (g_sessCh != g_rfJournalBuilderOriginChannel) {
+		if (g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive)
+			return;
+		if (!rfJournalBuilderImmediateHop(
+			    g_rfJournalBuilderOriginChannel))
+			return;
+		if (g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive)
+			return;
+		if (g_sessCh != g_rfJournalBuilderOriginChannel)
+			return;
+	}
+	g_rfJournalBuilderCancelRequested = false;
+	g_rfJournalBuilderParticipants = 0;
+	g_rfJournalBuilderChannel = 0;
+	rfJournalBuilderResetQualityWindows();
+	rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_CANCELED, now);
+}
+
+static void rfJournalBuilderTask()
+{
+	const unsigned long now = millis();
+	if (!rfJournalBuilderActive())
+		return;
+
+	if (g_rfJournalBuilderCancelRequested) {
+		rfJournalBuilderFinishCanceled(now);
+		return;
+	}
+
+	const uint8_t liveMask = rfChannelLiveMask(now);
+	if (g_rfJournalBuilderPhase != RF_JOURNAL_BUILDER_SAVING &&
+	    liveMask != g_rfJournalBuilderParticipants) {
+		if (g_rfJournalBuilderPhase != RF_JOURNAL_BUILDER_PAUSED) {
+			g_rfJournalBuilderResumePhase =
+				g_rfJournalBuilderPhase ==
+						RF_JOURNAL_BUILDER_SURVEY ?
+					RF_JOURNAL_BUILDER_SURVEY :
+					RF_JOURNAL_BUILDER_HOPPING;
+			if (g_rfJournalBuilderIndex <
+			    RF_CHANNEL_HISTORY_POOL_COUNT)
+				rfJournalBuilderResetChannel(
+					g_rfJournalBuilderIndex);
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_PAUSED,
+						 now);
+			g_rfJournalBuilderCohortStableMs = 0;
+			rfJournalBuilderResetQualityWindows();
+		}
+		if (g_rfJournalBuilderIdleValueValidMask &&
+		    (!g_rfJournalBuilderIdleLastPulseMs ||
+		     (uint32_t)(now - g_rfJournalBuilderIdleLastPulseMs) >=
+			     RF_JOURNAL_BUILDER_IDLE_PULSE_INTERVAL_MS))
+			rfJournalBuilderIdlePulse(
+				(uint8_t)(liveMask &
+					  g_rfJournalBuilderParticipants),
+				now);
+		return;
+	}
+	if (g_rfJournalBuilderPhase == RF_JOURNAL_BUILDER_PAUSED) {
+		if (!g_rfJournalBuilderCohortStableMs)
+			g_rfJournalBuilderCohortStableMs = now;
+		if ((uint32_t)(now - g_rfJournalBuilderCohortStableMs) <
+		    RF_JOURNAL_BUILDER_RECONNECT_STABLE_MS)
+			return;
+		if (g_rfJournalBuilderResumePhase ==
+			    RF_JOURNAL_BUILDER_SURVEY &&
+		    !rfJournalBuilderIdleQueryComplete())
+			g_rfJournalBuilderIdleQueryStartedMs = now ? now : 1u;
+		if (g_rfJournalBuilderIdleValueValidMask)
+			rfJournalBuilderIdlePulse(
+				g_rfJournalBuilderParticipants, now);
+		rfJournalBuilderSetPhase(g_rfJournalBuilderResumePhase, now);
+		g_rfJournalBuilderHopAttempts = 0;
+		rfJournalBuilderResetQualityWindows();
+		return;
+	}
+
+	switch (g_rfJournalBuilderPhase) {
+	case RF_JOURNAL_BUILDER_SURVEY:
+		if (g_rfJournalBuilderSurveyStarted &&
+		    g_ambientSurveyFailure != RF_AMBIENT_SURVEY_FAIL_NONE) {
+			g_rfJournalBuilderFailure =
+				RF_JOURNAL_BUILDER_FAIL_AMBIENT_SURVEY;
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_FAILED,
+						 now);
+			return;
+		}
+		if (!rfJournalBuilderIdleQueryComplete()) {
+			(void)rfJournalBuilderIdlePrepare(now);
+			return;
+		}
+		if (!g_rfJournalBuilderSurveyStarted) {
+			rfJournalBuilderIdlePulse(
+				g_rfJournalBuilderParticipants, now);
+			g_rfJournalBuilderSurveyGeneration =
+				g_ambientSurveyGeneration;
+			g_rfJournalBuilderSurveyStarted = true;
+			rfJournalBuilderRequestAmbientSurvey();
+			return;
+		}
+		if (g_ambientSurveyGeneration !=
+			    g_rfJournalBuilderSurveyGeneration &&
+		    !g_ambientSurveyRunning && !g_ambientSurveyPending &&
+		    !g_ambientSurveyManual) {
+			g_rfJournalBuilderIndex = 0;
+			g_rfJournalBuilderChannel = g_recoveryChannelPool[0];
+			g_rfJournalBuilderHopAttempts = 0;
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_HOPPING,
+						 now);
+			return;
+		}
+		if (!g_ambientSurveyRunning && !g_ambientSurveyPending &&
+		    !g_ambientSurveyManual)
+			rfJournalBuilderRequestAmbientSurvey();
+		return;
+
+	case RF_JOURNAL_BUILDER_HOPPING: {
+		if (g_rfJournalBuilderIndex >= RF_CHANNEL_HISTORY_POOL_COUNT) {
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_SELECTING,
+						 now);
+			return;
+		}
+		const uint8_t target =
+			g_recoveryChannelPool[g_rfJournalBuilderIndex];
+		g_rfJournalBuilderChannel = target;
+		if (g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive)
+			return;
+		if (g_sessCh == target) {
+			rfJournalBuilderResetChannel(g_rfJournalBuilderIndex);
+			rfJournalBuilderResetQualityWindows();
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_SETTLING,
+						 now);
+			return;
+		}
+		if (g_rfJournalBuilderHopAttempts >=
+		    RF_JOURNAL_BUILDER_HOP_ATTEMPTS) {
+			rfJournalBuilderMarkHopFailure(g_rfJournalBuilderIndex);
+			rfJournalBuilderIdlePulse(
+				g_rfJournalBuilderParticipants, now);
+			hapticRfJournalBuilderTick(
+				g_rfJournalBuilderParticipants);
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_BETWEEN,
+						 now);
+			return;
+		}
+		g_rfJournalBuilderHopAttempts++;
+		(void)rfJournalBuilderImmediateHop(target);
+		return;
+	}
+
+	case RF_JOURNAL_BUILDER_SETTLING:
+		if ((uint32_t)(now - g_rfJournalBuilderPhaseMs) <
+		    RF_JOURNAL_BUILDER_SETTLE_MS)
+			return;
+		rfJournalBuilderResetQualityWindows();
+		rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_MEASURING, now);
+		return;
+
+	case RF_JOURNAL_BUILDER_MEASURING:
+		if (g_rfJournalBuilderValidWindows[g_rfJournalBuilderIndex] <
+		    RF_JOURNAL_BUILDER_WINDOWS)
+			return;
+		rfJournalBuilderIdlePulse(g_rfJournalBuilderParticipants, now);
+		hapticRfJournalBuilderTick(g_rfJournalBuilderParticipants);
+		rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_BETWEEN, now);
+		return;
+
+	case RF_JOURNAL_BUILDER_BETWEEN:
+		rfJournalBuilderResetQualityWindows();
+		if ((uint32_t)(now - g_rfJournalBuilderPhaseMs) <
+		    RF_JOURNAL_BUILDER_BETWEEN_MS)
+			return;
+		g_rfJournalBuilderIndex++;
+		g_rfJournalBuilderHopAttempts = 0;
+		if (g_rfJournalBuilderIndex >= RF_CHANNEL_HISTORY_POOL_COUNT)
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_SELECTING,
+						 now);
+		else {
+			g_rfJournalBuilderChannel =
+				g_recoveryChannelPool[g_rfJournalBuilderIndex];
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_HOPPING,
+						 now);
+		}
+		return;
+
+	case RF_JOURNAL_BUILDER_SELECTING:
+		g_rfJournalBuilderBestChannel = rfJournalBuilderSelectBest();
+		if (!g_rfJournalBuilderBestChannel) {
+			g_rfJournalBuilderFailure =
+				RF_JOURNAL_BUILDER_FAIL_NO_VALID_CHANNEL;
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_FAILED,
+						 now);
+			return;
+		}
+		g_rfJournalBuilderChannel = g_rfJournalBuilderBestChannel;
+		g_rfJournalBuilderHopAttempts = 0;
+		rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_FINAL_HOP, now);
+		return;
+
+	case RF_JOURNAL_BUILDER_FINAL_HOP:
+		if (g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive)
+			return;
+		if (g_sessCh == g_rfJournalBuilderBestChannel) {
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_SAVING,
+						 now);
+			return;
+		}
+		if (g_rfJournalBuilderHopAttempts >=
+		    RF_JOURNAL_BUILDER_HOP_ATTEMPTS) {
+			g_rfJournalBuilderFailure =
+				RF_JOURNAL_BUILDER_FAIL_FINAL_HOP;
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_FAILED,
+						 now);
+			return;
+		}
+		g_rfJournalBuilderHopAttempts++;
+		(void)rfJournalBuilderImmediateHop(
+			g_rfJournalBuilderBestChannel);
+		return;
+
+	case RF_JOURNAL_BUILDER_SAVING:
+		if (!g_rfJournalBuilderPromoted &&
+		    !rfJournalBuilderPromoteAndStartWrite(now)) {
+			g_rfJournalBuilderFailure =
+				RF_JOURNAL_BUILDER_FAIL_SAVE;
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_FAILED,
+						 now);
+			return;
+		}
+		rfChannelJournalDrainBuilderWrite(now);
+		if (g_rfJournalBuilderPromoted && !g_channelJournalJobActive &&
+		    g_channelHistoryPersistentDirty) {
+			g_rfJournalBuilderFailure =
+				RF_JOURNAL_BUILDER_FAIL_SAVE;
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_FAILED,
+						 now);
+			return;
+		}
+		if (!g_channelJournalJobActive &&
+		    !g_channelHistoryPersistentDirty) {
+			if (!saveRfStartupLastGoodChannel(
+				    g_rfJournalBuilderBestChannel)) {
+				g_rfJournalBuilderFailure =
+					RF_JOURNAL_BUILDER_FAIL_STARTUP_SAVE;
+				rfJournalBuilderSetPhase(
+					RF_JOURNAL_BUILDER_FAILED, now);
+				return;
+			}
+			g_rfJournalBuilderParticipants = 0;
+			g_rfJournalBuilderChannel =
+				g_rfJournalBuilderBestChannel;
+			rfJournalBuilderResetQualityWindows();
+			rfJournalBuilderSetPhase(RF_JOURNAL_BUILDER_COMPLETE,
+						 now);
+		}
+		return;
+
+	default:
+		return;
+	}
+}
+
+static void rfChannelEvidenceClearParticipant(uint8_t slot)
+{
+	if (slot >= NSLOT)
+		return;
+	for (unsigned i = 0; i < RF_RECOVERY_CHANNEL_COUNT; i++) {
+		g_channelEvidenceGoodCount[slot][i] = 0;
+		g_channelEvidenceGoodSum[slot][i] = 0;
+		g_channelEvidenceMean[slot][i] = 0;
+		g_channelEvidenceLastGoodMs[slot][i] = 0;
+	}
+}
+
+static void rfChannelRecoveryResetForParticipantChange()
+{
+	g_channelEvidenceResidenceChannel = g_sessCh;
+	g_channelRecoveryDecidedThisResidence = false;
+	g_recoveryCooldownUntilMs = 0;
+	g_recoveryFailedTargetMask = 0;
+	g_recoveryLastFailedTarget = 0;
+	g_recoveryRequestedThisResidence = false;
+	if (g_rfChHandoffState == RF_CH_IDLE)
+		rfChannelRecoverySetTarget(0u);
+}
+
+static void rfChannelEvidenceSyncParticipants(uint8_t liveMask)
+{
+	if (liveMask == g_channelEvidenceParticipantMask)
+		return;
+	const uint8_t oldMask = g_channelEvidenceParticipantMask;
+	const uint8_t changed = (uint8_t)(liveMask ^ oldMask);
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		const uint8_t bit = (uint8_t)(1u << s);
+		if (changed & bit)
+			rfChannelEvidenceClearParticipant(s);
+	}
+	g_channelEvidenceParticipantMask = liveMask;
+	rfChannelRecoveryResetForParticipantChange();
+}
+
+static void rfChannelEvidenceSyncResidence()
+{
+	if (g_channelEvidenceResidenceChannel == g_sessCh)
+		return;
+	g_channelEvidenceResidenceChannel = g_sessCh;
+	g_channelRecoveryDecidedThisResidence = false;
+	// QoS bad-window streaks are residence-local evidence. Never let a prior
+	// channel contribute bad windows toward recovery on the newly selected one.
+	for (int s = 0; s < NSLOT; s++)
+		g_linkQualityBadStreak[s] = 0;
+}
+
+static void rfChannelEvidenceObserve(uint8_t slot, uint8_t ch,
+				     uint16_t successPermille, bool valid,
+				     uint32_t now)
+{
+	if (slot >= NSLOT || !valid)
+		return;
+	const int idx = rfRecoveryChannelIndex(ch);
+	if (idx < 0)
+		return;
+	if (successPermille < RF_CHANNEL_EVIDENCE_MIN_SUCCESS_PERMILLE) {
+		g_channelEvidenceGoodCount[slot][idx] = 0;
+		g_channelEvidenceGoodSum[slot][idx] = 0;
+		g_channelEvidenceMean[slot][idx] = 0;
+		g_channelEvidenceLastGoodMs[slot][idx] = 0;
+		return;
+	}
+	if (g_channelEvidenceGoodCount[slot][idx] <
+	    RF_CHANNEL_EVIDENCE_WINDOWS) {
+		g_channelEvidenceGoodCount[slot][idx]++;
+		g_channelEvidenceGoodSum[slot][idx] += successPermille;
+		g_channelEvidenceMean[slot][idx] =
+			(uint16_t)(g_channelEvidenceGoodSum[slot][idx] /
+				   g_channelEvidenceGoodCount[slot][idx]);
+	} else {
+		g_channelEvidenceMean[slot][idx] =
+			(uint16_t)(((uint32_t)g_channelEvidenceMean[slot][idx] *
+					    4u +
+				    successPermille) /
+				   5u);
+	}
+	g_channelEvidenceLastGoodMs[slot][idx] = now;
+}
+
+static uint8_t rfCohortSelectRecoveryChannel(uint8_t liveMask,
+					     uint16_t currentWorstPermille,
+					     uint32_t now)
+{
+	uint8_t bestCh = 0;
+	uint16_t bestWorst = 0;
+	uint16_t bestCohortMean = 0;
+	uint32_t bestWorstAge = 0xFFFFFFFFu;
+	for (uint8_t ch = RF_RECOVERY_CHANNEL_MIN;
+	     ch <= RF_RECOVERY_CHANNEL_MAX; ch += 2u) {
+		if (ch == g_sessCh || rfRecoveryTargetFailed(ch))
+			continue;
+		const int idx = rfRecoveryChannelIndex(ch);
+		if (idx < 0)
+			continue;
+		bool eligible = true;
+		uint16_t worst = 1000u;
+		uint32_t sum = 0;
+		uint32_t oldestAge = 0;
+		uint8_t count = 0;
+		for (uint8_t s = 0; s < NSLOT; s++) {
+			const uint8_t bit = (uint8_t)(1u << s);
+			if (!(liveMask & bit))
+				continue;
+			if (g_channelEvidenceGoodCount[s][idx] <
+				    RF_CHANNEL_EVIDENCE_WINDOWS ||
+			    g_channelEvidenceMean[s][idx] <
+				    RF_CHANNEL_EVIDENCE_MIN_SUCCESS_PERMILLE) {
+				eligible = false;
+				break;
+			}
+			const uint32_t age =
+				(uint32_t)(now -
+					   g_channelEvidenceLastGoodMs[s][idx]);
+			if (age > RF_CHANNEL_EVIDENCE_MAX_AGE_MS) {
+				eligible = false;
+				break;
+			}
+			const uint16_t mean = g_channelEvidenceMean[s][idx];
+			if (mean < worst)
+				worst = mean;
+			if (age > oldestAge)
+				oldestAge = age;
+			sum += mean;
+			count++;
+		}
+		if (!eligible || !count)
+			continue;
+		if (worst <
+		    (uint16_t)(currentWorstPermille +
+			       RF_CHANNEL_RECOVERY_MIN_IMPROVEMENT_PERMILLE))
+			continue;
+		const uint16_t cohortMean = (uint16_t)(sum / count);
+		if (bestCh == 0u || worst > bestWorst ||
+		    (worst == bestWorst && cohortMean > bestCohortMean) ||
+		    (worst == bestWorst && cohortMean == bestCohortMean &&
+		     oldestAge < bestWorstAge)) {
+			bestCh = ch;
+			bestWorst = worst;
+			bestCohortMean = cohortMean;
+			bestWorstAge = oldestAge;
+		}
+	}
+	if (bestCh)
+		return bestCh;
+
+	// Current packet evidence is authoritative. When no alternate channel has
+	// fresh proof yet, consult learned history; if history also has no proven
+	// option, explore exactly one never-tried pool member. Cached idle RSSI may
+	// rank only that unexplored set and never overrides an explored channel.
+	rfChannelHistoryEnsureLoaded();
+	bestCh = rfChannelHistorySelectGoodPrior(g_sessCh);
+	if (bestCh)
+		return bestCh;
+	bestCh = rfChannelHistorySelectUnexplored(g_sessCh);
+	if (bestCh)
+		return bestCh;
+	return rfChannelHistorySelectBestRemaining(g_sessCh,
+						   currentWorstPermille);
+}
+
+static void rfCohortQualityWindow(uint8_t liveMask, uint32_t now)
+{
+	rfChannelEvidenceSyncResidence();
+	const bool recoveryCooldown = rfChannelRecoveryCooldownActive(now);
+	bool allValid = true;
+	bool wouldPending = false;
+	uint16_t currentWorst = 1000u;
+
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		const uint8_t bit = (uint8_t)(1u << s);
+		if (!(liveMask & bit))
+			continue;
+		const uint32_t polls = g_linkQualityPolls[s];
+		const uint32_t replies = g_linkQualityReplies[s];
+		const uint16_t successPermille =
+			polls ? (uint16_t)((replies * 1000u) / polls) : 0u;
+		const bool valid = polls >= RF_LINK_QUALITY_MIN_POLLS;
+		const bool bad = valid &&
+				 successPermille <
+					 RF_LINK_QUALITY_BAD_SUCCESS_PERMILLE;
+		if (!rfJournalBuilderActive()) {
+			if (recoveryCooldown) {
+				g_linkQualityBadStreak[s] = 0;
+			} else if (bad) {
+				if (g_linkQualityBadStreak[s] != 0xFF)
+					g_linkQualityBadStreak[s]++;
+			} else {
+				g_linkQualityBadStreak[s] = 0;
+			}
+			rfChannelEvidenceObserve(s, g_sessCh, successPermille,
+						 valid, now);
+			rfStartupChannelObserveWindow(s, successPermille,
+						      valid);
+		}
+		if (!valid)
+			allValid = false;
+		else if (successPermille < currentWorst)
+			currentWorst = successPermille;
+		const bool residency = (uint32_t)(now - g_qosLastHopMs) >=
+				       RF_LINK_QUALITY_MIN_RESIDENCY_MS;
+		if (!recoveryCooldown && valid && residency &&
+		    g_linkQualityBadStreak[s] >=
+			    RF_LINK_QUALITY_BAD_STREAK_WINDOWS)
+			wouldPending = true;
+	}
+
+	uint32_t historySum = 0;
+	uint8_t historyCount = 0;
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		const uint8_t bit = (uint8_t)(1u << s);
+		if (!(liveMask & bit))
+			continue;
+		const uint32_t polls = g_linkQualityPolls[s];
+		const uint32_t replies = g_linkQualityReplies[s];
+		if (polls >= RF_LINK_QUALITY_MIN_POLLS) {
+			historySum += (uint16_t)((replies * 1000u) / polls);
+			historyCount++;
+		}
+	}
+	const uint16_t historyMean =
+		historyCount ? (uint16_t)(historySum / historyCount) : 0u;
+	if (rfJournalBuilderActive()) {
+		rfJournalBuilderObserveWindow(g_sessCh, currentWorst,
+					      historyMean,
+					      allValid && historyCount != 0u);
+	} else {
+		rfChannelHistoryObserve(g_sessCh, currentWorst, historyMean,
+					allValid && historyCount != 0u);
+	}
+	for (int s = 0; s < NSLOT; s++)
+		rfLinkQualityResetWindow(s);
+	if (rfJournalBuilderActive())
+		return;
+	if (!allValid || !wouldPending)
+		return;
+	if (g_channelRecoveryDecidedThisResidence)
+		return;
+
+	g_channelRecoveryDecidedThisResidence = true;
+	const uint8_t target =
+		rfCohortSelectRecoveryChannel(liveMask, currentWorst, now);
+	rfChannelRecoverySetTarget(target);
+	rfChannelRecoveryRequest(wouldPending);
+}
+
+static void rfLinkQualityTask()
+{
+	const unsigned long now = millis();
+	rfChannelHistoryEnsureLoaded();
+	if (!rfJournalBuilderActive())
+		rfChannelHistoryMaybeCheckpoint(now);
+	if (g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive) {
+		// Handoff acquisition and rollback are transition traffic, not a stable
+		// channel residence. Discard those windows instead of learning from them.
+		for (int s = 0; s < NSLOT; s++)
+			rfLinkQualityResetWindow(s);
+		g_linkQualityCheckMs = now;
+		g_qosCheckMs = now;
+		return;
+	}
+	if (g_ambientSurveyManual) {
+		for (int s = 0; s < NSLOT; s++)
+			rfLinkQualityResetWindow(s);
+		g_linkQualityCheckMs = now;
+		g_qosCheckMs = now;
+		return;
+	}
+	if (!g_qos && !rfJournalBuilderActive())
+		return;
+	if (rfJournalBuilderActive() &&
+	    g_rfJournalBuilderPhase != RF_JOURNAL_BUILDER_MEASURING) {
+		for (int s = 0; s < NSLOT; s++)
+			rfLinkQualityResetWindow(s);
+		g_linkQualityCheckMs = now;
+		g_qosCheckMs = now;
+		return;
+	}
+	if ((uint32_t)(now - g_qosCheckMs) < RF_LINK_QUALITY_WINDOW_MS)
+		return;
+	g_linkQualityCheckMs = now;
+	g_qosCheckMs = now;
+
+	const uint8_t liveMask = rfChannelLiveMask(now);
+	rfChannelEvidenceSyncParticipants(liveMask);
+	if (!liveMask) {
+		for (int s = 0; s < NSLOT; s++)
+			rfLinkQualityResetWindow(s);
+		return;
+	}
+	rfCohortQualityWindow(liveMask, now);
+}
+
+#define RF_HOP_ACT_DIGITAL 0x01u
+#define RF_HOP_ACT_LSTICK 0x02u
+#define RF_HOP_ACT_RSTICK 0x04u
+#define RF_HOP_ACT_LT 0x08u
+#define RF_HOP_ACT_RT 0x10u
+#define RF_HOP_ACT_LPAD 0x20u
+#define RF_HOP_ACT_RPAD 0x40u
+
+static int32_t rfHopAbs16(int16_t v)
+{
+	return v == (int16_t)0x8000 ? 32768 :
+				      (v < 0 ? -(int32_t)v : (int32_t)v);
+}
+
+static uint8_t rfChannelDecodedActivity(int slot, uint32_t buttons)
+{
+	if (slot < 0 || slot >= NSLOT)
+		return 0;
+	const PuckInput &in = g_in[slot];
+	const uint32_t digitalMask =
+		TB_A | TB_B | TB_X | TB_Y | TB_QAM | TB_R3 | TB_VIEW | TB_R4 |
+		TB_R5 | TB_RB | TB_DDN | TB_DRT | TB_DLF | TB_DUP | TB_MENU |
+		TB_L3 | TB_STEAM | TB_L4 | TB_L5 | TB_LB | TB_RPADC | TB_LPADC |
+		TB_R2 | TB_L2 | TB_TOUCH | TB_MUTE;
+	uint8_t activity = 0;
+	if (buttons & digitalMask)
+		activity |= RF_HOP_ACT_DIGITAL;
+	if (rfHopAbs16(in.lx) > RF_CHANNEL_HANDOFF_STICK_DEADZONE ||
+	    rfHopAbs16(in.ly) > RF_CHANNEL_HANDOFF_STICK_DEADZONE)
+		activity |= RF_HOP_ACT_LSTICK;
+	if (rfHopAbs16(in.rx) > RF_CHANNEL_HANDOFF_STICK_DEADZONE ||
+	    rfHopAbs16(in.ry) > RF_CHANNEL_HANDOFF_STICK_DEADZONE)
+		activity |= RF_HOP_ACT_RSTICK;
+	if (in.lt > RF_CHANNEL_HANDOFF_TRIGGER_THRESHOLD)
+		activity |= RF_HOP_ACT_LT;
+	if (in.rt > RF_CHANNEL_HANDOFF_TRIGGER_THRESHOLD)
+		activity |= RF_HOP_ACT_RT;
+
+	// Only decoded touch bits are authoritative pad activity. Coordinates and
+	// pressure may remain noisy or undefined at idle and are not handoff evidence.
+	if (buttons & TB_LPADT)
+		activity |= RF_HOP_ACT_LPAD;
+	if (buttons & TB_RPADT)
+		activity |= RF_HOP_ACT_RPAD;
+	return activity;
+}
+
+static void rfChannelNoteDecodedInput(int slot, uint32_t buttons)
+{
+	if (slot < 0 || slot >= NSLOT)
+		return;
+	const uint8_t activity = rfChannelDecodedActivity(slot, buttons);
+	const unsigned long reportNow = millis();
+	const bool priorFresh =
+		g_rfHopInputLastReportMs[slot] &&
+		(uint32_t)(reportNow - g_rfHopInputLastReportMs[slot]) <=
+			RF_CHANNEL_HANDOFF_INPUT_REPORT_FRESH_MS;
+	if (activity) {
+		g_rfHopInputNeutralSinceMs[slot] = 0;
+	} else if (!priorFresh || g_rfHopInputLastMask[slot] != 0u ||
+		   !g_rfHopInputNeutralSinceMs[slot]) {
+		// A stale gap is never credited as neutral time. Start (or restart)
+		// the continuous neutral interval only on a fresh decoded report.
+		g_rfHopInputNeutralSinceMs[slot] = reportNow ? reportNow : 1u;
+	}
+	g_rfHopInputLastMask[slot] = activity;
+	g_rfHopInputLastReportMs[slot] = reportNow;
+	g_rfHopInputReportSeq[slot]++;
+	if (activity)
+		g_rfHopInputSeq[slot]++;
+}
+
+bool rfChannelHandoffHostGrace(int slot)
+{
+	if (g_rfChHandoffState == RF_CH_IDLE ||
+	    g_rfChHandoffState == RF_CH_HOP_PENDING || slot < 0 ||
+	    slot >= NSLOT)
+		return false;
+	if (!(g_rfChHandoffMask & (uint8_t)(1u << slot)))
+		return false;
+	return (uint32_t)(millis() - g_rfChHandoffStartedMs) <
+	       RF_CHANNEL_HANDOFF_HOST_GRACE_MS;
+}
+
+static bool rfChannelHandoffOwnsRadio()
+{
+	return g_rfChHandoffState == RF_CH_QUIET_DWELL ||
+	       g_rfChHandoffState == RF_CH_ROLLBACK_QUIET_DWELL;
+}
+
+static void rfChannelSnapshotReplies(uint8_t mask)
+{
+	for (uint8_t s = 0; s < NSLOT; s++)
+		if (mask & (uint8_t)(1u << s))
+			g_rfChHandoffReplyBaseline[s] = g_connReplyMs[s];
+}
+
+static bool rfChannelFreshReply(uint8_t mask, unsigned long now)
+{
+	if (!mask)
+		return false;
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		if (!(mask & (uint8_t)(1u << s)))
+			continue;
+		if (!g_connReplyMs[s] ||
+		    g_connReplyMs[s] == g_rfChHandoffReplyBaseline[s] ||
+		    (uint32_t)(now - g_connReplyMs[s]) >= 80u)
+			return false;
+	}
+	return true;
+}
+
+static uint8_t rfE4FastResponseTxn(uint8_t fromCh, uint8_t toCh, uint8_t mask)
+{
+	int slot = rfChannelMaskSlot(mask);
+	if (slot < 0)
+		return RF_E4_RESP_NONE;
+
+	const uint8_t txS1 = (uint8_t)(((g_pollPid[slot]++ & 3u) << 1) | 1u);
+
+	// Use the validated EasyDMA TX-to-RX response-turn sequence.
+	memset(rftx, 0, sizeof rftx);
+	rftx[0] = 4;
+	rftx[1] = txS1;
+	rftx[2] = 0xE4;
+	rftx[3] = toCh;
+	rftx[4] = 0x02;
+	rftx[5] = RF_E4_TIMING_CONTROL;
+
+	rfConfig(fromCh);
+	rfSetAddr(g_sessBase[slot], g_sessPrefix[slot]);
+	NRF_RADIO->PACKETPTR = (uint32_t)rftx;
+	NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk |
+			    RADIO_SHORTS_END_DISABLE_Msk |
+			    RADIO_SHORTS_DISABLED_RXEN_Msk;
+
+	NRF_RADIO->EVENTS_READY = 0;
+	NRF_RADIO->EVENTS_ADDRESS = 0;
+	NRF_RADIO->EVENTS_PAYLOAD = 0;
+	NRF_RADIO->EVENTS_END = 0;
+	NRF_RADIO->EVENTS_DISABLED = 0;
+#if defined(RADIO_EVENTS_CRCOK_EVENTS_CRCOK_Msk)
+	NRF_RADIO->EVENTS_CRCOK = 0;
+#endif
+#if defined(RADIO_EVENTS_CRCERROR_EVENTS_CRCERROR_Msk)
+	NRF_RADIO->EVENTS_CRCERROR = 0;
+#endif
+
+	const uint32_t txStartUs = micros();
+	NRF_RADIO->TASKS_TXEN = 1;
+
+	// Synchronize on TX END and clear TX-owned latches before RX observation.
+	while (!NRF_RADIO->EVENTS_END &&
+	       (uint32_t)(micros() - txStartUs) < 2500u) {
+	}
+
+	if (!NRF_RADIO->EVENTS_END) {
+		NRF_RADIO->SHORTS = 0;
+		NRF_RADIO->EVENTS_DISABLED = 0;
+		NRF_RADIO->TASKS_DISABLE = 1;
+		const uint32_t stopUs = micros();
+		while (!NRF_RADIO->EVENTS_DISABLED &&
+		       (uint32_t)(micros() - stopUs) < 500u) {
+		}
+		NRF_RADIO->EVENTS_DISABLED = 0;
+		NRF_RADIO->PACKETPTR = (uint32_t)rfrx;
+		return RF_E4_RESP_NONE;
+	}
+
+	const uint32_t e4Primask = __get_PRIMASK();
+	__disable_irq();
+	NRF_RADIO->EVENTS_READY = 0;
+	NRF_RADIO->EVENTS_ADDRESS = 0;
+	NRF_RADIO->EVENTS_PAYLOAD = 0;
+	NRF_RADIO->EVENTS_END = 0;
+#if defined(RADIO_EVENTS_CRCOK_EVENTS_CRCOK_Msk)
+	NRF_RADIO->EVENTS_CRCOK = 0;
+#endif
+#if defined(RADIO_EVENTS_CRCERROR_EVENTS_CRCERROR_Msk)
+	NRF_RADIO->EVENTS_CRCERROR = 0;
+#endif
+	__set_PRIMASK(e4Primask);
+
+	bool sawEnd = false;
+	const uint32_t rxWaitStartUs = micros();
+	while ((uint32_t)(micros() - rxWaitStartUs) < RF_E4_RESPONSE_WAIT_US) {
+		if (NRF_RADIO->EVENTS_END) {
+			sawEnd = true;
+			break;
+		}
+	}
+
+	uint8_t kind = RF_E4_RESP_NONE;
+	if (sawEnd && (NRF_RADIO->CRCSTATUS & 1u) != 0) {
+		const uint8_t rxLen = rftx[0];
+		const uint8_t rxS1 = rftx[1];
+		if ((rxS1 & 0x07u) == (txS1 & 0x07u)) {
+			if (rxLen == 0u)
+				kind = RF_E4_RESP_ZERO;
+			else if (rxLen <= 96u && rftx[2] == 0xF1u)
+				kind = RF_E4_RESP_F1;
+			else
+				kind = RF_E4_RESP_OTHER;
+		}
+	}
+
+	NRF_RADIO->SHORTS = 0;
+	NRF_RADIO->EVENTS_DISABLED = 0;
+	NRF_RADIO->TASKS_DISABLE = 1;
+	const uint32_t stopUs = micros();
+	while (!NRF_RADIO->EVENTS_DISABLED &&
+	       (uint32_t)(micros() - stopUs) < 500u) {
+	}
+	NRF_RADIO->EVENTS_DISABLED = 0;
+	NRF_RADIO->PACKETPTR = (uint32_t)rfrx;
+
+	return kind;
+}
+
+static void rfChannelGroupReset()
+{
+	g_rfChGroupActive = false;
+	g_rfChGroupPhase = RF_GROUP_IDLE;
+	g_rfChGroupParticipants = 0;
+	g_rfChGroupNeutralSeenMask = 0;
+	g_rfChGroupSawActivitySincePending = false;
+	g_rfChGroupNeutralStartValid = false;
+	g_rfChGroupNeutralStartMs = 0;
+	g_rfChHandoffManualImmediate = false;
+	g_rfChHandoffTelemetryElapsedMs = 0;
+	g_rfChHandoffTelemetryLastMs = 0;
+	g_rfChHandoffWaitReason = RF_RECOVERY_WAIT_NONE;
+	g_rfChHandoffNeutralMs = 0;
+	memset(g_rfChGroupActivitySeqSeen, 0,
+	       sizeof g_rfChGroupActivitySeqSeen);
+	memset(g_rfChGroupReportSeqSeen, 0, sizeof g_rfChGroupReportSeqSeen);
+}
+
+static void rfChannelGroupSnapshotInputSeqs(uint8_t mask)
+{
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		const uint8_t bit = (uint8_t)(1u << s);
+		if (!(mask & bit))
+			continue;
+		g_rfChGroupActivitySeqSeen[s] = g_rfHopInputSeq[s];
+		g_rfChGroupReportSeqSeen[s] = g_rfHopInputReportSeq[s];
+	}
+}
+
+static void rfChannelGroupResetNeutralProof()
+{
+	g_rfChGroupNeutralSeenMask = 0;
+	g_rfChGroupNeutralStartValid = false;
+	g_rfChGroupNeutralStartMs = 0;
+}
+
+static void rfChannelGroupAbort()
+{
+	g_rfChHandoffState = RF_CH_IDLE;
+	rfChannelGroupReset();
+}
+
+static bool rfChannelGroupBegin(uint8_t oldCh, uint8_t newCh, uint8_t mask,
+				unsigned long now, bool manualImmediate)
+{
+	if (!mask)
+		return false;
+
+	// Drop any partially accumulated old-channel QoS window before the
+	// transition can retune the session and accidentally attribute it elsewhere.
+	for (int s = 0; s < NSLOT; s++)
+		rfLinkQualityResetWindow(s);
+	g_linkQualityCheckMs = now;
+	g_qosCheckMs = now;
+
+	g_rfChHandoffOld = oldCh;
+	g_rfChHandoffTarget = newCh;
+	g_rfChHandoffMask = mask;
+	g_rfChHandoffStartedMs = now;
+	g_rfChHandoffTelemetryElapsedMs = 0;
+	g_rfChHandoffTelemetryLastMs = (uint32_t)now;
+	g_rfChHandoffPhaseMs = now;
+	g_rfChHandoffRequireActivityCycle = true;
+	g_rfChHandoffManualImmediate = manualImmediate;
+	g_rfChHandoffWaitReason = manualImmediate ?
+					  RF_RECOVERY_WAIT_NONE :
+					  RF_RECOVERY_WAIT_FRESH_REPORT;
+	g_rfChHandoffNeutralMs = 0;
+
+	g_rfChGroupActive = true;
+	g_rfChGroupPhase = RF_GROUP_HOP_PENDING;
+	g_rfChGroupParticipants = mask;
+	g_rfChGroupSawActivitySincePending = false;
+	rfChannelGroupResetNeutralProof();
+	rfChannelGroupSnapshotInputSeqs(mask);
+	g_rfChHandoffState = RF_CH_HOP_PENDING;
+	return true;
+}
+
+static bool rfChannelGroupFreshNeutral(unsigned long now)
+{
+	// The participant set is frozen. A join/leave before E4 means this
+	// degradation episode could not migrate safely; abandon it and require a
+	// cooldown plus fresh QoS proof rather than carrying a stale target.
+	const uint8_t liveMask = rfChannelLiveMask(now);
+	if (liveMask != g_rfChGroupParticipants) {
+		const uint8_t failedTarget = g_rfChHandoffTarget;
+		rfChannelGroupAbort();
+		rfChannelRecoveryAbandonAutomaticAttempt(failedTarget, now);
+		return false;
+	}
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		const uint8_t bit = (uint8_t)(1u << s);
+		if (!(g_rfChGroupParticipants & bit))
+			continue;
+		if (g_rfHopInputReportSeq[s] != g_rfChGroupReportSeqSeen[s]) {
+			g_rfChGroupReportSeqSeen[s] = g_rfHopInputReportSeq[s];
+			g_rfChGroupNeutralSeenMask |= bit;
+		}
+	}
+	if (g_rfChGroupNeutralSeenMask != g_rfChGroupParticipants) {
+		g_rfChHandoffWaitReason = RF_RECOVERY_WAIT_FRESH_REPORT;
+		g_rfChHandoffNeutralMs = 0;
+		return false;
+	}
+	uint32_t cohortNeutralMs = 0xFFFFFFFFu;
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		const uint8_t bit = (uint8_t)(1u << s);
+		if (!(g_rfChGroupParticipants & bit))
+			continue;
+		if (g_rfHopInputLastMask[s] != 0u) {
+			g_rfChHandoffWaitReason = RF_RECOVERY_WAIT_INPUT_ACTIVE;
+			g_rfChHandoffNeutralMs = 0;
+			return false;
+		}
+		if (!g_rfHopInputLastReportMs[s] ||
+		    (uint32_t)(now - g_rfHopInputLastReportMs[s]) >
+			    RF_CHANNEL_HANDOFF_INPUT_REPORT_FRESH_MS ||
+		    !g_rfHopInputNeutralSinceMs[s]) {
+			g_rfChHandoffWaitReason = RF_RECOVERY_WAIT_FRESH_REPORT;
+			g_rfChHandoffNeutralMs = 0;
+			return false;
+		}
+		const uint32_t neutralMs =
+			(uint32_t)(now - g_rfHopInputNeutralSinceMs[s]);
+		if (neutralMs < cohortNeutralMs)
+			cohortNeutralMs = neutralMs;
+	}
+	if (cohortNeutralMs < RF_CHANNEL_HANDOFF_QUIESCENT_MS) {
+		g_rfChHandoffWaitReason = RF_RECOVERY_WAIT_NEUTRAL_DWELL;
+		g_rfChHandoffNeutralMs = cohortNeutralMs > 0xFFFFu ?
+						 0xFFFFu :
+						 (uint16_t)cohortNeutralMs;
+		return false;
+	}
+	g_rfChHandoffWaitReason = RF_RECOVERY_WAIT_NONE;
+	g_rfChHandoffNeutralMs = RF_CHANNEL_HANDOFF_QUIESCENT_MS;
+	return true;
+}
+
+static bool rfChannelGroupAuthorizeAll()
+{
+	g_rfChHandoffStartedMs = millis();
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		const uint8_t bit = (uint8_t)(1u << s);
+		if (!(g_rfChGroupParticipants & bit))
+			continue;
+
+		const uint8_t kind = rfE4FastResponseTxn(
+			g_rfChHandoffOld, g_rfChHandoffTarget, bit);
+		if (kind != RF_E4_RESP_ZERO && kind != RF_E4_RESP_F1)
+			return false;
+	}
+	return true;
+}
+
+static void rfChannelGroupRollback(uint8_t mask)
+{
+	for (uint8_t s = 0; s < NSLOT; s++) {
+		const uint8_t bit = (uint8_t)(1u << s);
+		if (!(mask & bit))
+			continue;
+		(void)rfE4FastResponseTxn(g_rfChHandoffTarget, g_rfChHandoffOld,
+					  bit);
+	}
+}
+
+static void rfChannelGroupHandoffTask(unsigned long now)
+{
+	if (!g_rfChGroupActive)
+		return;
+
+	g_rfChHandoffTelemetryElapsedMs +=
+		(uint32_t)((uint32_t)now - g_rfChHandoffTelemetryLastMs);
+	g_rfChHandoffTelemetryLastMs = (uint32_t)now;
+
+	if (g_rfChGroupPhase == RF_GROUP_HOP_PENDING) {
+		if (g_rfChHandoffManualImmediate) {
+			// The manual cohort is frozen when the request is accepted. A
+			// participant aging out after that point is adjudicated by its E4
+			// response instead of aborting before authorization starts. A new
+			// recently-heard controller outside the frozen cohort is different:
+			// do not strand it on the old channel.
+			if (rfChannelLiveMask(now) &
+			    (uint8_t)~g_rfChGroupParticipants) {
+				rfChannelGroupAbort();
+				return;
+			}
+		} else {
+			if (!rfChannelGroupFreshNeutral(now))
+				return;
+			g_rfChHandoffRequireActivityCycle = false;
+		}
+		g_rfChGroupSawActivitySincePending = false;
+		rfChannelGroupResetNeutralProof();
+
+		if (!rfChannelGroupAuthorizeAll()) {
+			// A missing/invalid E4 response never proves that a participant
+			// stayed on the old channel.  Treat the whole frozen cohort as
+			// potentially moved, allow the 5-ms switch interval, then issue
+			// target->old reconciliation attempts to every participant.
+			g_rfChGroupPhase = RF_GROUP_PARTIAL_WAIT_ROLLBACK;
+			g_rfChHandoffState = RF_CH_ROLLBACK_QUIET_DWELL;
+			g_rfChHandoffPhaseMs = millis();
+			return;
+		}
+
+		g_rfChGroupPhase = RF_GROUP_AUTHORIZED_WAIT_SWITCH;
+		g_rfChHandoffState = RF_CH_QUIET_DWELL;
+		g_rfChHandoffPhaseMs = millis();
+		return;
+	}
+
+	if (g_rfChGroupPhase == RF_GROUP_AUTHORIZED_WAIT_SWITCH) {
+		if ((uint32_t)(now - g_rfChHandoffPhaseMs) <
+		    RF_CHANNEL_HANDOFF_EARLY_SWITCH_MS)
+			return;
+		rfChannelSnapshotReplies(g_rfChGroupParticipants);
+		g_sessCh = g_rfChHandoffTarget;
+		for (int s = 0; s < NSLOT; s++)
+			rfLinkQualityResetWindow(s);
+		g_linkQualityCheckMs = now;
+		g_qosCheckMs = now;
+		rfChannelHistorySyncResidence();
+		g_rfChHandoffPhaseMs = now;
+		g_rfChHandoffState = RF_CH_ACQUIRE;
+		g_rfChGroupPhase = RF_GROUP_TARGET_ACQUIRE;
+		return;
+	}
+
+	if (g_rfChGroupPhase == RF_GROUP_TARGET_ACQUIRE) {
+		if (rfChannelFreshReply(g_rfChGroupParticipants, now)) {
+			const bool automatic = !g_rfChHandoffManualImmediate;
+			g_rfChHandoffState = RF_CH_IDLE;
+			g_lastChannelHopMs = now;
+			g_qosLastHopMs = now;
+			if (automatic) {
+				g_recoveryTargetChannel = 0;
+				rfChannelRecoverySyncResidence();
+			}
+			rfChannelGroupReset();
+			return;
+		}
+		if ((uint32_t)(now - g_rfChHandoffPhaseMs) <
+		    RF_CHANNEL_HANDOFF_TARGET_OBSERVE_MS)
+			return;
+		rfChannelGroupRollback(g_rfChGroupParticipants);
+		g_rfChGroupPhase = RF_GROUP_ROLLBACK_WAIT_SWITCH;
+		g_rfChHandoffState = RF_CH_ROLLBACK_QUIET_DWELL;
+		g_rfChHandoffPhaseMs = millis();
+		return;
+	}
+
+	if (g_rfChGroupPhase == RF_GROUP_PARTIAL_WAIT_ROLLBACK) {
+		if ((uint32_t)(now - g_rfChHandoffPhaseMs) <
+		    RF_CHANNEL_HANDOFF_EARLY_SWITCH_MS)
+			return;
+		rfChannelSnapshotReplies(g_rfChGroupParticipants);
+		rfChannelGroupRollback(g_rfChGroupParticipants);
+		g_rfChGroupPhase = RF_GROUP_PARTIAL_ACQUIRE_OLD;
+		g_rfChHandoffState = RF_CH_ROLLBACK_ACQUIRE;
+		g_rfChHandoffPhaseMs = millis();
+		return;
+	}
+
+	if (g_rfChGroupPhase == RF_GROUP_PARTIAL_ACQUIRE_OLD) {
+		if (rfChannelFreshReply(g_rfChGroupParticipants, now)) {
+			const bool automatic = !g_rfChHandoffManualImmediate;
+			const uint8_t failedTarget = g_rfChHandoffTarget;
+			rfChannelGroupAbort();
+			if (automatic)
+				rfChannelRecoveryAbandonAutomaticAttempt(
+					failedTarget, now);
+			return;
+		}
+		if ((uint32_t)(now - g_rfChHandoffPhaseMs) <
+		    RF_CHANNEL_HANDOFF_ROLLBACK_ACQUIRE_MS)
+			return;
+		g_lastDisc = 0;
+		g_lastSessBeacon = 0;
+		const bool automatic = !g_rfChHandoffManualImmediate;
+		const uint8_t failedTarget = g_rfChHandoffTarget;
+		rfChannelGroupAbort();
+		if (automatic)
+			rfChannelRecoveryAbandonAutomaticAttempt(failedTarget,
+								 now);
+		return;
+	}
+
+	if (g_rfChGroupPhase == RF_GROUP_ROLLBACK_WAIT_SWITCH) {
+		if ((uint32_t)(now - g_rfChHandoffPhaseMs) <
+		    RF_CHANNEL_HANDOFF_ROLLBACK_QUIET_MS)
+			return;
+		rfChannelSnapshotReplies(g_rfChGroupParticipants);
+		g_sessCh = g_rfChHandoffOld;
+		for (int s = 0; s < NSLOT; s++)
+			rfLinkQualityResetWindow(s);
+		g_linkQualityCheckMs = now;
+		g_qosCheckMs = now;
+		rfChannelHistorySyncResidence();
+		g_rfChHandoffState = RF_CH_ROLLBACK_ACQUIRE;
+		g_rfChGroupPhase = RF_GROUP_ROLLBACK_ACQUIRE_OLD;
+		g_rfChHandoffPhaseMs = now;
+		return;
+	}
+
+	if (g_rfChGroupPhase == RF_GROUP_ROLLBACK_ACQUIRE_OLD) {
+		if (rfChannelFreshReply(g_rfChGroupParticipants, now)) {
+			const bool automatic = !g_rfChHandoffManualImmediate;
+			const uint8_t failedTarget = g_rfChHandoffTarget;
+			g_rfChHandoffState = RF_CH_IDLE;
+			rfChannelGroupReset();
+			if (automatic)
+				rfChannelRecoveryAbandonAutomaticAttempt(
+					failedTarget, now);
+			return;
+		}
+		if ((uint32_t)(now - g_rfChHandoffPhaseMs) <
+		    RF_CHANNEL_HANDOFF_ROLLBACK_ACQUIRE_MS)
+			return;
+		g_lastDisc = 0;
+		g_lastSessBeacon = 0;
+		const bool automatic = !g_rfChHandoffManualImmediate;
+		const uint8_t failedTarget = g_rfChHandoffTarget;
+		rfChannelGroupAbort();
+		if (automatic)
+			rfChannelRecoveryAbandonAutomaticAttempt(failedTarget,
+								 now);
+	}
+}
+
+static void rfChannelHandoffTask()
+{
+	if (!g_rfChGroupActive)
+		return;
+	rfChannelGroupHandoffTask(millis());
+}
+
+// QoS hop is shared across all slots -- we run all connected sessions on the same channel for simplicity.
+// The per-slot session ADDRESS is what isolates the controllers from each other; the channel is global.
 void rfHopTo(uint8_t newCh)
 {
-	// QoS hop is shared across all slots -- we run all connected sessions on the same channel for simplicity.
-	// The per-slot session ADDRESS is what isolates the controllers from each other; the channel is global.
-	if (g_curSlot < 0 || newCh == g_sessCh)
+	if (newCh == g_sessCh || g_rfChHandoffState != RF_CH_IDLE)
 		return;
-	uint8_t cur = g_sessCh, savedRfCh = g_rfCh;
-	g_sessCh = newCh;
-	// host frame now advertises newCh but is TXed on cur (per-slot session addr)
-	g_rfCh = cur;
-	for (int s = 0; s < NSLOT; s++)
-		for (int k = 0; k < 6; k++) {
-			rfHostFrameOnce(s, false);
-			delayMicroseconds(700);
-		}
-	g_rfCh = savedRfCh; // poll + session beacon now run on g_sessCh=newCh
+	if (newCh < 4u || newCh > 80u || (newCh & 1u))
+		return;
+
+	unsigned long now = millis();
+	uint8_t mask = rfChannelLiveMask(now);
+	if (!mask)
+		return;
+
+	(void)rfChannelGroupBegin(g_sessCh, newCh, mask, now, false);
+}
+
+bool rfRecoveryRequestHop(uint8_t channel)
+{
+	if (rfJournalBuilderActive() || rfChannelHistoryPoolIndex(channel) < 0)
+		return false;
+	if (channel == g_sessCh)
+		return true;
+	if (g_rfChHandoffState != RF_CH_IDLE || g_rfChGroupActive)
+		return false;
+	const unsigned long now = millis();
+	const uint8_t liveMask = rfChannelLiveMask(now);
+	// Explicit user intent owns the radio over a standalone ambient scan.
+	if (g_ambientSurveyRunning)
+		rfAmbientSurveyAbort();
+	g_ambientSurveyPending = false;
+	g_ambientSurveyManual = false;
+	g_recoveryCooldownUntilMs = 0;
+	g_recoveryFailedTargetMask &= ~rfRecoveryTargetBit(channel);
+	if (g_recoveryLastFailedTarget == channel)
+		g_recoveryLastFailedTarget = 0;
+	g_recoveryRequestedThisResidence = false;
+	g_channelRecoveryDecidedThisResidence = true;
+	// With no live controller there is nobody to coordinate via E4. Retune
+	// the puck/session directly so the next controller is advertised the
+	// newly selected channel. Live cohorts keep the neutral-gated path.
+	if (!liveMask)
+		return rfChannelRetuneNoControllers(channel, now);
+	if (!rfChannelRecoverySetTarget(channel))
+		return false;
+	rfChannelRecoveryRequest(true);
+	return g_rfChGroupActive && g_rfChHandoffTarget == channel &&
+	       !g_rfChHandoffManualImmediate;
 }
 
 // TX one connected packet [LEN][S1][payload] on channel ch, then RX the reply into rfrx; decodes 0xF1.
@@ -704,6 +3762,9 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 								fresh, tlen);
 						lastRep = rep;
 						lastTlen = tlen;
+						if (fresh)
+							rfChannelNoteDecodedInput(
+								g_curSlot, bb);
 					} else if (ttype == 6 &&
 						   (size_t)(idx + 2) + tlen <=
 							   sizeof(rfrx) &&
@@ -776,6 +3837,14 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 						// clobber a slot that has moved on to a different query.
 						const uint8_t *rec =
 							&rfrx[idx + 2];
+						if (ttype == 4 &&
+						    g_curSlot >= 0 &&
+						    g_curSlot < NSLOT) {
+							rfJournalBuilderIdleCapture(
+								(uint8_t)
+									g_curSlot,
+								rec, tlen);
+						}
 						if (ttype == 4 && tlen >= 2 &&
 						    rec[0] != 0 &&
 						    (uint16_t)(2 + rec[1]) <=
@@ -906,6 +3975,8 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 	NRF_RADIO->TASKS_DISABLE = 1;
 	RWAIT_DISABLED();
 	NRF_RADIO->EVENTS_DISABLED = 0;
+	if (plen && payload[0] == 0xE3 && g_curSlot >= 0 && g_curSlot < NSLOT)
+		rfLinkQualityNotePoll(g_curSlot, rxlen != 0);
 	return rxlen;
 }
 
@@ -1076,6 +4147,11 @@ static void rfConnStep()
 
 void rfLinkTask()
 {
+	rfChannelHandoffTask();
+	rfJournalBuilderTask();
+	if (rfChannelHandoffOwnsRadio())
+		return;
+	rfStartupChannelTask();
 	// Poll before beacons: the cycle gate must fire as close to its
 	// 4 ms deadline as possible; beacon TX (up to 3.6 ms for 4 slots)
 	// runs after so it never delays the current poll.
@@ -1214,25 +4290,9 @@ void rfLinkTask()
 		}
 		wasRfConn = nowRfConn;
 	}
-	// QoS: if the current channel is degrading (crcfail+noRx), hop to the next clean candidate (conservative).
-	if (g_qos && g_curSlot >= 0 && millis() - g_qosCheckMs >= 600) {
-		uint16_t bad = g_qosBad;
-		g_qosBad = 0;
-		g_qosCheckMs = millis();
-		if (bad > 20 && millis() - g_qosLastHopMs > 2000) {
-			for (int k = 0; k < (int)sizeof g_hopCand; k++) {
-				g_hopIdx = (g_hopIdx + 1) % (sizeof g_hopCand);
-				if (g_hopCand[g_hopIdx] != g_sessCh)
-					break;
-			}
-			if (Serial.availableForWrite() > 60)
-				Serial.printf(
-					"# QoS: ch%u bad=%u -> hop ch%u\n",
-					g_sessCh, bad, g_hopCand[g_hopIdx]);
-			rfHopTo(g_hopCand[g_hopIdx]);
-			g_qosLastHopMs = millis();
-		}
-	}
+	// Evaluate the completed link-quality window and request recovery only through the policy gate.
+	rfLinkQualityTask();
+	rfAmbientSurveyTask();
 	if (g_connOn && millis() - g_stMs >= 1000) {
 		// Per-slot snapshots first (blob v13 / per-controller panel stats), then the legacy aggregates as
 		// their sums (serial stat line + pre-v13 blob fields).

--- a/OpenPuck/rf_link.h
+++ b/OpenPuck/rf_link.h
@@ -115,6 +115,104 @@ extern volatile uint8_t g_battery[NSLOT];
 // charge state from report 0x43 body[0] (EChargeState: 1=discharging, 2=charging, 4=charging-done; 0=unknown)
 extern volatile uint8_t g_batteryState[NSLOT];
 
+#define RF_RECOVERY_STATUS_CHANNELS 14u
+
+enum RfChannelDesignation : uint8_t {
+	RF_CHANNEL_UNEXPLORED = 0,
+	RF_CHANNEL_GOOD = 1,
+	RF_CHANNEL_POOR = 2,
+	RF_CHANNEL_MIXED = 3,
+};
+
+struct RfChannelStatusEntry {
+	uint8_t channel;
+	uint8_t ambientRssi;
+	uint8_t designation;
+	uint8_t worstPct;
+	uint8_t meanPct;
+	uint8_t confidence;
+	uint8_t trials;
+	uint8_t penalty;
+	uint8_t recentOrder;
+};
+
+enum RfRecoveryHandoffPhase : uint8_t {
+	RF_RECOVERY_HANDOFF_IDLE = 0,
+	RF_RECOVERY_HANDOFF_WAIT_NEUTRAL = 1,
+	RF_RECOVERY_HANDOFF_AUTHORIZE = 2,
+	RF_RECOVERY_HANDOFF_SWITCH = 3,
+	RF_RECOVERY_HANDOFF_ACQUIRE_TARGET = 4,
+	RF_RECOVERY_HANDOFF_RECONCILE = 5,
+	RF_RECOVERY_HANDOFF_ROLLBACK_SWITCH = 6,
+	RF_RECOVERY_HANDOFF_ACQUIRE_OLD = 7,
+};
+
+enum RfRecoveryWaitReason : uint8_t {
+	RF_RECOVERY_WAIT_NONE = 0,
+	RF_RECOVERY_WAIT_FRESH_REPORT = 1,
+	RF_RECOVERY_WAIT_INPUT_ACTIVE = 2,
+	RF_RECOVERY_WAIT_NEUTRAL_DWELL = 3,
+};
+
+enum RfAmbientSurveyFailure : uint8_t {
+	RF_AMBIENT_SURVEY_FAIL_NONE = 0,
+	RF_AMBIENT_SURVEY_FAIL_SAMPLE_TIMEOUT = 1,
+	RF_AMBIENT_SURVEY_FAIL_INCOMPLETE = 2,
+};
+
+enum RfJournalBuilderPhase : uint8_t {
+	RF_JOURNAL_BUILDER_IDLE = 0,
+	RF_JOURNAL_BUILDER_SURVEY = 1,
+	RF_JOURNAL_BUILDER_HOPPING = 2,
+	RF_JOURNAL_BUILDER_SETTLING = 3,
+	RF_JOURNAL_BUILDER_MEASURING = 4,
+	RF_JOURNAL_BUILDER_BETWEEN = 5,
+	RF_JOURNAL_BUILDER_SELECTING = 6,
+	RF_JOURNAL_BUILDER_FINAL_HOP = 7,
+	RF_JOURNAL_BUILDER_SAVING = 8,
+	RF_JOURNAL_BUILDER_PAUSED = 9,
+	RF_JOURNAL_BUILDER_COMPLETE = 10,
+	RF_JOURNAL_BUILDER_CANCELED = 11,
+	RF_JOURNAL_BUILDER_FAILED = 12,
+};
+
+struct RfRecoveryStatus {
+	uint8_t version;
+	uint8_t flags;
+	uint8_t currentChannel;
+	uint8_t targetChannel;
+	uint8_t startupChannel;
+	uint8_t channelCount;
+	uint8_t journalWrites;
+	uint16_t ambientGeneration;
+	uint8_t ambientSurveyChannel;
+	uint32_t journalSequence;
+	RfChannelStatusEntry channel[RF_RECOVERY_STATUS_CHANNELS];
+	uint8_t handoffPhase;
+	uint64_t handoffElapsedMs;
+	uint8_t handoffOldChannel;
+	uint8_t journalBuilderPhase;
+	uint8_t journalBuilderIndex;
+	uint8_t journalBuilderChannel;
+	uint8_t journalBuilderProgress;
+	uint8_t journalBuilderParticipantMask;
+	uint8_t journalBuilderBestChannel;
+	uint8_t journalBuilderFailure;
+	uint8_t handoffWaitReason;
+	uint16_t handoffNeutralMs;
+	uint8_t recoveryCooldownSeconds;
+	uint8_t recoveryFailedTarget;
+	uint8_t ambientSurveyRetry;
+	uint8_t ambientSurveyFailure;
+	uint8_t ambientSurveyFailureChannel;
+};
+
+bool rfRecoveryRequestAmbientSurvey();
+bool rfRecoveryRequestHop(uint8_t channel);
+bool rfRecoveryRequestJournalBuilder();
+void rfRecoveryCancelJournalBuilder();
+void rfRecoveryStatusSnapshot(RfRecoveryStatus *status);
+
 // TX one connected packet [LEN][S1][payload] on channel ch, then RX the reply into rfrx; decodes 0xF1.
 // rxWinUs overrides the reply-wait window (0 = use g_rxWin). Pass a tiny value for NO-ACK relays that expect
 // no reply, so they don't burn a full ~1.2ms window of dead air per haptic.
@@ -122,5 +220,6 @@ uint8_t rfConnTx(uint8_t ch, uint8_t s1, const uint8_t *payload, uint8_t plen,
 		 uint16_t rxWinUs = 0);
 // Mid-session channel hop: advertise newCh on the current channel a few times, then move the poll to newCh.
 void rfHopTo(uint8_t newCh);
+bool rfChannelHandoffHostGrace(int slot);
 // Per-loop: host-frame beacons + connected-mode poll + remote-wakeup + QoS hop + per-second stats.
 void rfLinkTask();

--- a/OpenPuck/serial_console.cpp
+++ b/OpenPuck/serial_console.cpp
@@ -426,9 +426,8 @@ void serialConsolePoll()
 				g_hopIdx = 0;
 				g_qosBad = 0;
 				g_qosCheckMs = millis();
-				Serial.printf(
-					"# QoS adaptive channel hopping %s (candidates 18,46,76,22,68)\n",
-					g_qos ? "ON" : "off");
+				Serial.printf("# adaptive RF recovery %s\n",
+					      g_qos ? "ON" : "off");
 			} else if (line[0] == 'U') {
 				// Per-slot debug dump: which controllers are connected, their RSSI, haptic-block
 				// state, and session address. Quick at-a-glance view for multi-controller testing.

--- a/OpenPuck/webusb_config.cpp
+++ b/OpenPuck/webusb_config.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "bonds.h"
 #include "rf_link.h"
+#include "radio.h"
 #include "haptics.h"
 #include "puck_hid.h"
 #include "triton.h" // g_in raw IMU (diagnostic readout)
@@ -94,13 +95,14 @@ static bool boardCommand(uint8_t op)
 //                [v12: relayps(lo,hi)][clkLfSrc][clkHfSrc][usPerMs(lo,hi)][hangStage][curStage][stallMs/40][ringFault(lo,hi)][hangPC u32][hangLR u32][usbdStackFree(lo,hi)][loopStackFree(lo,hi)]
 //                [v13: per-slot link stats, 4x9B from p[145]: {pollsps u16, f1ps u16, newps u16, crc/s u8,
 //                 noRx/s u8, relay/s u8} -- each controller's own rates (the v4 aggregates are their sums)]
-//                [v14/v17: p[181] landAll87 (verbatim-0x87-relay experiment toggle)]
+//                [v14/v17: p[181] legacy relay field, now Steam Machine emulation toggle (0xEE=on)]
 //                [v18: p[182..185] chordDpad left/up/right/down (back4+D-pad mode assignments)]
 //                [v19: p[186] swGyroLegacy (Switch Pro gyro mapping: 0 = corrected, 1 = legacy/pre-#189)]
 //                [v20: p[187..194] per-type trackpad->stick map, 4x2B {left pad, right pad} (PS_OFF/LEFT/RIGHT)]
 //                [v21: p[53] rumble strength as PERCENT/2 (field 22, revived); p[195] rumble style
 //                 (field 39, RUMBLE_STYLE_* in haptics.h)]
-#define WB_PAYLEN 194
+//                [v22: p[196] RF recovery status/journal transport capability marker (0x52)]
+#define WB_PAYLEN 195
 // The blob send is drop-on-full (never blocks loop), so the vendor TX FIFO MUST be able to hold a whole blob
 // -- otherwise tud_vendor_write_available() never reaches the frame size and EVERY frame is dropped (blank
 // panel / stale mappings). The Makefile sets -DCFG_TUD_VENDOR_TX_BUFSIZE=256; guard it here so a build without
@@ -129,6 +131,7 @@ static void webusbSendBlob()
 	// protocol version
 	// (21 = +rumble style (field 39, blob p[195]) and the REVIVED rumble-strength field 22 at blob p[53], 
 	// now carrying percent/2; 
+	// 22 = +RF recovery capability marker at blob p[196];
 	// 20 = +per-type trackpad->stick mapping (fields 80..87, blob p[187..194]); 
 	// 19 = +Switch Pro legacy-gyro select (field 38, blob p[186]); the Switch report-rate and
 	// gyro-scale settings (fields 23/24, blob p[54..55]) are GONE -- those bytes read 0; 
@@ -148,7 +151,7 @@ static void webusbSendBlob()
 	// 7 = +raw accel; 
 	// 6 = +swPro120/gyroScale)
 	// clang-format on
-	p[2] = 21;
+	p[2] = 22;
 	p[3] = g_usbMode;
 	p[4] = (uint8_t)g_mDiv;
 	p[5] = (uint8_t)g_mFric;
@@ -314,7 +317,8 @@ static void webusbSendBlob()
 		q[7] = g_slotNoRxps[s];
 		q[8] = g_slotRelayps[s];
 	}
-	// v14/v17: verbatim-0x87-relay (g_landAll87), later repurposed for Machine toggle
+	// v14/v17: verbatim-0x87-relay field, later repurposed for the Steam Machine toggle.
+	// Keep the current upstream meaning here; RF capability is append-only at p[196].
 	p[181] = (uint8_t)(g_isMachineInternal ? 0xEE : 0);
 	// v18: back4+D-pad mode assignments (panel renders these as selects next to the B/X/Y ones)
 	p[182] = g_chordDpad[CHD_LEFT];
@@ -330,6 +334,9 @@ static void webusbSendBlob()
 	}
 	// v21: host-rumble style (RUMBLE_STYLE_* -- see haptics.h)
 	p[195] = g_rumbleStyle;
+	// v22: append-only RF recovery transport capability. p[181] remains the
+	// upstream Steam Machine toggle; older RF builds used that byte for 0x52.
+	p[196] = 0x52;
 	// CRITICAL: usb_web.write() SPINS (`while (remain && _connected) yield();`) until the IN FIFO drains or the
 	// panel disconnects. If the panel holds the WebUSB interface open but stops reading its IN endpoint -- a
 	// backgrounded tab, or the host briefly not servicing transferIn under load -- the FIFO never empties and
@@ -484,6 +491,82 @@ static void webusbDrainFlight(bool restart)
 
 // Runs on the usbd task (registered via usbTxRegisterDrain -> tud_sof_cb). Sends the blob if loop() asked for
 // one. Keeps every usb_web write/flush off the loop task so it can't block on the device event queue.
+static volatile bool g_rfStatusRequest = false;
+
+static bool webusbSendRfStatus()
+{
+	if (!usb_web.connected())
+		return false;
+	static RfRecoveryStatus status;
+	rfRecoveryStatusSnapshot(&status);
+	// Append-only trailers after the counted channel rows preserve the v1
+	// header/row offsets: 4 bytes legacy handoff telemetry + 7 bytes journal-
+	// builder status + 1 byte ambient-survey progress + 5 bytes automatic-
+	// handoff admission/retry diagnostics + 3 bytes ambient-survey retry/failure
+	// diagnostics + 8 bytes full-width handoff elapsed time.
+	static uint8_t f[2 + 13 + RF_RECOVERY_STATUS_CHANNELS * 9 + 4 + 7 + 1 +
+			 5 + 3 + 8];
+	uint8_t *q = f + 2;
+	f[0] = 0xAD;
+	f[1] = (uint8_t)(sizeof f - 2u);
+	*q++ = status.version;
+	*q++ = status.flags;
+	*q++ = status.currentChannel;
+	*q++ = status.targetChannel;
+	*q++ = status.startupChannel;
+	*q++ = status.channelCount;
+	*q++ = status.journalWrites;
+	*q++ = (uint8_t)status.ambientGeneration;
+	*q++ = (uint8_t)(status.ambientGeneration >> 8);
+	*q++ = (uint8_t)status.journalSequence;
+	*q++ = (uint8_t)(status.journalSequence >> 8);
+	*q++ = (uint8_t)(status.journalSequence >> 16);
+	*q++ = (uint8_t)(status.journalSequence >> 24);
+	for (uint8_t i = 0; i < status.channelCount; i++) {
+		const RfChannelStatusEntry &entry = status.channel[i];
+		*q++ = entry.channel;
+		*q++ = entry.ambientRssi;
+		*q++ = entry.designation;
+		*q++ = entry.worstPct;
+		*q++ = entry.meanPct;
+		*q++ = entry.confidence;
+		*q++ = entry.trials;
+		*q++ = entry.penalty;
+		*q++ = entry.recentOrder;
+	}
+	*q++ = status.handoffPhase;
+	const uint16_t legacyHandoffElapsedMs =
+		status.handoffElapsedMs > 0xFFFFu ?
+			0xFFFFu :
+			(uint16_t)status.handoffElapsedMs;
+	*q++ = (uint8_t)legacyHandoffElapsedMs;
+	*q++ = (uint8_t)(legacyHandoffElapsedMs >> 8);
+	*q++ = status.handoffOldChannel;
+	*q++ = status.journalBuilderPhase;
+	*q++ = status.journalBuilderIndex;
+	*q++ = status.journalBuilderChannel;
+	*q++ = status.journalBuilderProgress;
+	*q++ = status.journalBuilderParticipantMask;
+	*q++ = status.journalBuilderBestChannel;
+	*q++ = status.journalBuilderFailure;
+	*q++ = status.ambientSurveyChannel;
+	*q++ = status.handoffWaitReason;
+	*q++ = (uint8_t)status.handoffNeutralMs;
+	*q++ = (uint8_t)(status.handoffNeutralMs >> 8);
+	*q++ = status.recoveryCooldownSeconds;
+	*q++ = status.recoveryFailedTarget;
+	*q++ = status.ambientSurveyRetry;
+	*q++ = status.ambientSurveyFailure;
+	*q++ = status.ambientSurveyFailureChannel;
+	for (uint8_t shift = 0; shift < 64u; shift += 8u)
+		*q++ = (uint8_t)(status.handoffElapsedMs >> shift);
+	if (tud_vendor_write_available() < sizeof f)
+		return false;
+	usb_web.write(f, sizeof f);
+	usb_web.flush();
+	return true;
+}
+
 static void webusbSofDrain(void)
 {
 	// If loop() has stopped beating, it's wedged -- keep pushing the blob (which carries the live stuck stage)
@@ -513,6 +596,8 @@ static void webusbSofDrain(void)
 		g_bondExportRequest = false;
 		webusbSendBondExport();
 	}
+	if (g_rfStatusRequest && webusbSendRfStatus())
+		g_rfStatusRequest = false;
 }
 // ---- live wedge reporter (0xA9) --------------------------------------------------------------------------
 // THE one channel that survives a loop() wedge on boards that wipe .noinit/GPREGRET across the watchdog reset
@@ -916,6 +1001,10 @@ void webusbPoll()
 
 				// every settable field persists (poll rate is no longer settable)
 				bool persist = true;
+				// RF controls (97..101) use the dedicated 0xAD reply only. Scheduling
+				// the generic 0xA5 blob as well lets the SOF drain expose either frame
+				// first and phase-shifts the browser's shared bulk-IN stream.
+				const bool rfStatusOnly = f >= 97u && f <= 101u;
 				// per-type cfg writes (protocol v10/v17): field = 40 + et*9 + k, k: 0..3 back, 4 qam, 5 abSwap,
 				// 6 padHaptics, 7 ledBright, 8 rumble. Edits g_type[et]; refresh the live mirrors if it's the active type.
 				if (f >= 40 && f < 40 + ET_COUNT * 9) {
@@ -1099,6 +1188,47 @@ void webusbPoll()
 					// (field 25, poll RX window, removed -- g_rxWin is now FIXED/not configurable)
 					// (fields 27/28, post-connect haptic block, removed -- permanently disabled)
 
+				// RF recovery controls reuse the field setter without its generic
+				// persistence path. Field 100 persists only the selected startup channel.
+				case 97:
+					g_rfStatusRequest = true;
+					persist = false;
+					break;
+				case 98:
+					(void)rfRecoveryRequestAmbientSurvey();
+					g_rfStatusRequest = true;
+					persist = false;
+					break;
+				case 99:
+					(void)rfRecoveryRequestHop(v);
+					g_rfStatusRequest = true;
+					persist = false;
+					break;
+				case 101:
+					if (v)
+						(void)rfRecoveryRequestJournalBuilder();
+					else
+						rfRecoveryCancelJournalBuilder();
+					g_rfStatusRequest = true;
+					persist = false;
+					break;
+				case 100: {
+					static RfRecoveryStatus status;
+					rfRecoveryStatusSnapshot(&status);
+					for (uint8_t i = 0;
+					     i < status.channelCount; i++) {
+						if (status.channel[i].channel !=
+						    v)
+							continue;
+						(void)saveRfStartupLastGoodChannel(
+							v);
+						break;
+					}
+					g_rfStatusRequest = true;
+					persist = false;
+					break;
+				}
+
 				// Used to be g_landAll87, now g_isMachineInternal. Persisted to blob p[181].
 				case 29:
 					g_isMachineInternal = v ? 0xEE : 0;
@@ -1106,7 +1236,8 @@ void webusbPoll()
 				}
 				if (persist)
 					saveCfg();
-				g_blobRequest = true;
+				if (!rfStatusOnly)
+					g_blobRequest = true;
 			} else if (op == 0x03) {
 				uint8_t m = buf[1];
 				if (modeValid(m) && !USBDevice.suspended()) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -263,8 +263,34 @@
       </div>
       <div class="row debugonly" style="margin:10px 0 0;border-top:1px solid #272d3d;padding-top:14px"><button id="stabBtn">Test stability</button>
         <span class="v" id="stabStatus" style="flex:0 0 auto;min-width:120px">—</span>
-        <span class="note" style="flex:1">Buzzes the controllers every 10 s (keeps them awake) and times how long the puck stays up. On a reset it records the uptime and shows it by <em>Last reset</em>; it auto-resumes after the puck reconnects. The count is kept in this tab (a page refresh clears it).</span>
+        <span class="note" style="flex:1">Buzzes the controllers every 10 s and times how long the puck stays up. On a reset it records the uptime and shows it by <em>Last reset</em>; it auto-resumes after the puck reconnects. The count is kept in this tab (a page refresh clears it).</span>
       </div>
+    </div>
+
+    <div class="card wide hide" id="rfRecoveryCard">
+      <h2>RF recovery &amp; channel journal</h2>
+      <div class="statgrid">
+        <div class="stat"><div class="k">Active channel</div><div class="v" id="rfActiveCh">—</div></div>
+        <div class="stat"><div class="k">Recovery target</div><div class="v" id="rfTargetCh">—</div></div>
+        <div class="stat"><div class="k">Startup channel</div><div class="v" id="rfStartupCh">—</div></div>
+        <div class="stat"><div class="k">Ambient survey</div><div class="v" id="rfSurveyState">—</div></div>
+        <div class="stat"><div class="k">Journal sequence</div><div class="v" id="rfJournalSeq">—</div></div>
+        <div class="stat"><div class="k">Journal writes this boot</div><div class="v" id="rfJournalWrites">—</div></div>
+        <div class="stat"><div class="k">Handoff status</div><div class="v" id="rfHandoffStatus" style="font-size:14px">Idle</div></div>
+        <div class="stat"><div class="k">Journal builder</div><div class="v" id="rfBuilderStatus" style="font-size:14px">Idle</div></div>
+      </div>
+      <div class="row" style="margin-top:10px">
+        <button id="rfSurvey">Survey Ambient RF</button>
+        <button id="rfBuilder" style="margin-left:8px">Build RF Journal</button>
+      </div>
+      <p class="note" style="margin-top:10px"><strong>Survey Ambient RF</strong> samples background RF interference across all 14 recovery channels and updates the Ambient measurements shown below.<br><strong>Build RF Journal</strong> will initiate a comprehensive 14-channel scan to build the RF Journal ahead of time and save the winning channel as Startup.<br><strong>Hop</strong> uses the same neutral-gated coordinated channel migration as automatic RF recovery.<br><strong>Startup</strong> manually saves that channel as the starting channel for subsequent boots, but automatic RF learning may replace it later.</p>
+      <div style="overflow-x:auto;margin-top:12px">
+        <table style="width:100%;border-collapse:collapse;font-size:0.88em">
+          <thead><tr style="text-align:left"><th>Channel</th><th>MHz</th><th>Journal</th><th>Worst</th><th>Mean</th><th>Confidence</th><th>Trials</th><th>Penalty</th><th>Ambient</th><th>Recent</th><th>Actions</th></tr></thead>
+          <tbody id="rfJournalBody"></tbody>
+        </table>
+      </div>
+      <div id="rfAmbientBars" style="display:flex;gap:4px;align-items:flex-end;height:76px;margin-top:12px;padding:8px;background:#151821;border:1px solid #272d3d;border-radius:6px"></div>
     </div>
 
     <div class="card" id="mouseCard">
@@ -738,6 +764,386 @@ const RUMBLE_SCALES=[50,75,100,150,200,250,300,400,500];
     const o=document.createElement("option"); o.value=v; o.textContent=v+"%"+(v===200?" (default)":""); sel.appendChild(o); }
 }
 
+// ---- RF recovery / journal status ----
+let rfCapable=false, rfBusy=false, rfLastRefresh=0, rfHopPending=false, rfHandoffActive=false, rfHandoffPhase=0, rfBuilderActive=false, rfBuilderSaving=false, rfBuilderStartPending=false, rfSurveyRunning=false, rfSurveyPending=false, rfSurveyGeneration=0, rfSurveyWatchActive=false, rfSurveyLockActive=false, rfSurveyLockGeneration=0, rfSurveyRetry=0, rfSurveyFailure=0, rfSurveyFailureChannel=0;
+let rfHopRequestedCh=0, rfHopSawHandoff=false;
+let rfPoolChannels=new Set();
+const RF_DESIG=["unexplored","good","poor","mixed"];
+function rfChLabel(ch){ return ch ? `Ch ${ch} · ${2400+ch} MHz` : "—"; }
+function rfElapsedLabel(ms){
+  if(ms<1000) return `${ms} ms`;
+  const s=Math.floor(ms/1000);
+  if(s<60) return `${(ms/1000).toFixed(1)} s`;
+  const m=Math.floor(s/60);
+  if(m<60) return `${m}m ${String(s%60).padStart(2,"0")}s`;
+  const h=Math.floor(m/60);
+  if(h<24) return `${h}h ${String(m%60).padStart(2,"0")}m`;
+  const d=Math.floor(h/24);
+  return `${d}d ${String(h%24).padStart(2,"0")}h`;
+}
+function applyRfStatus(p){
+  if(!p || p.length<13 || p[0]!==1) return;
+  const flags=p[1], current=p[2], target=p[3], startup=p[4], count=p[5];
+  const writes=p[6], generation=p[7]|(p[8]<<8);
+  const seq=((p[9]|(p[10]<<8)|(p[11]<<16)|(p[12]<<24))>>>0);
+  $("#rfActiveCh").textContent=rfChLabel(current);
+  $("#rfTargetCh").textContent=target?rfChLabel(target):"none";
+  $("#rfStartupCh").textContent=rfChLabel(startup || 18);
+  $("#rfJournalSeq").textContent=String(seq);
+  $("#rfJournalWrites").textContent=String(writes);
+  const running=!!(flags&1), pending=!!(flags&2), ambient=!!(flags&4), live=!!(flags&8), handoff=!!(flags&16);
+  const tail=13+count*9;
+  const hopPhase=p.length>=tail+4?p[tail]:0;
+  const hopElapsed16=p.length>=tail+4?(p[tail+1]|(p[tail+2]<<8)):0;
+  const hopOld=p.length>=tail+4?p[tail+3]:0;
+  // The automatic-handoff trailer follows 4 handoff bytes, 7 Builder bytes,
+  // and the ambient-survey channel byte. Parse it before rendering handoff state.
+  const autoBase=tail+12;
+  const waitReason=p.length>=autoBase+5?p[autoBase]:0;
+  const neutralMs=p.length>=autoBase+5?(p[autoBase+1]|(p[autoBase+2]<<8)):0;
+  const recoveryCooldown=p.length>=autoBase+5?p[autoBase+3]:0;
+  const recoveryFailedTarget=p.length>=autoBase+5?p[autoBase+4]:0;
+  const surveyDiagBase=autoBase+5;
+  const surveyRetry=p.length>=surveyDiagBase+3?p[surveyDiagBase]:0;
+  const surveyFailure=p.length>=surveyDiagBase+3?p[surveyDiagBase+1]:0;
+  const surveyFailureChannel=p.length>=surveyDiagBase+3?p[surveyDiagBase+2]:0;
+  const handoffElapsedBase=surveyDiagBase+3;
+  let hopElapsed=hopElapsed16;
+  if(p.length>=handoffElapsedBase+8){
+    const lo=((p[handoffElapsedBase]|(p[handoffElapsedBase+1]<<8)|(p[handoffElapsedBase+2]<<16)|(p[handoffElapsedBase+3]<<24))>>>0);
+    const hi=((p[handoffElapsedBase+4]|(p[handoffElapsedBase+5]<<8)|(p[handoffElapsedBase+6]<<16)|(p[handoffElapsedBase+7]<<24))>>>0);
+    hopElapsed=hi*4294967296+lo;
+  }
+  const hopPhaseText=["Idle","Waiting for neutral","Authorizing","Switching","Acquiring","Reconciling","Rolling back","Reacquiring"];
+  let hopText=hopPhaseText[hopPhase]||("Phase "+hopPhase);
+  if(hopPhase===1){
+    if(waitReason===1) hopText="Starting hop · awaiting fresh controller reports";
+    else if(waitReason===2) hopText="Input detected · waiting for neutral";
+    else if(waitReason===3) hopText=`Neutral · ${Math.min(neutralMs,250)}/250 ms`;
+  }
+  if(hopPhase===2||hopPhase===3||hopPhase===4) hopText+=(target?` Ch ${target}`:"");
+  else if(hopPhase>=5) hopText+=(hopOld?` Ch ${hopOld}`:"");
+  if(hopPhase) hopText+=` · ${rfElapsedLabel(hopElapsed)}`;
+  else if(recoveryCooldown) hopText=`Recovery cooldown · ${recoveryCooldown}s${recoveryFailedTarget?` · Ch ${recoveryFailedTarget} excluded`:""}`;
+  if(hopPhase||!rfHopPending) $("#rfHandoffStatus").textContent=hopText;
+  const builderBase=tail+4;
+  const builderPhase=p.length>=builderBase+7?p[builderBase]:0;
+  const builderIndex=p.length>=builderBase+7?p[builderBase+1]:0;
+  const builderChannel=p.length>=builderBase+7?p[builderBase+2]:0;
+  const builderProgress=p.length>=builderBase+7?p[builderBase+3]:0;
+  const builderMask=p.length>=builderBase+7?p[builderBase+4]:0;
+  const builderBest=p.length>=builderBase+7?p[builderBase+5]:0;
+  const builderFailure=p.length>=builderBase+7?p[builderBase+6]:0;
+  const surveyChannel=p.length>=builderBase+8?p[builderBase+7]:0;
+  const builderFailureText=["","no live controller","RF workflow busy","journal storage full","no valid channel","final hop failed","journal save failed","journal write could not be completed","could not read controller idle timeout","startup save failed","ambient survey failed"];
+  let builderText="Idle";
+  if(builderPhase===1) builderText="Preparing controllers / ambient survey";
+  else if(builderPhase===2) builderText=`Testing ${Math.min(builderIndex+1,count)}/${count} · hopping to Ch ${builderChannel}`;
+  else if(builderPhase===3) builderText=`Testing ${Math.min(builderIndex+1,count)}/${count} · settling Ch ${builderChannel}`;
+  else if(builderPhase===4) builderText=`Testing ${Math.min(builderIndex+1,count)}/${count} · Ch ${builderChannel} · ${builderProgress}/60 s`;
+  else if(builderPhase===5) builderText=`Testing ${Math.min(builderIndex+1,count)}/${count} · between channels`;
+  else if(builderPhase===6) builderText="Selecting best channel";
+  else if(builderPhase===7) builderText=`Final hop · Ch ${builderBest||builderChannel}`;
+  else if(builderPhase===8) builderText=`Saving journal${builderBest?` · Ch ${builderBest}`:""}`;
+  else if(builderPhase===9) builderText=`Paused · waiting for controller cohort 0x${builderMask.toString(16).toUpperCase()}`;
+  else if(builderPhase===10) builderText=`Complete${builderBest?` · Ch ${builderBest} selected`:""}`;
+  else if(builderPhase===11) builderText="Canceled";
+  else if(builderPhase===12) builderText=`Failed · ${builderFailureText[builderFailure]||("code "+builderFailure)}`;
+  $("#rfBuilderStatus").textContent=builderText;
+  rfBuilderActive=builderPhase>=1&&builderPhase<=9;
+  rfBuilderSaving=builderPhase===8;
+  rfHandoffActive=handoff;
+  rfHandoffPhase=hopPhase;
+  if(rfBuilderStartPending&&builderPhase!==0) rfBuilderStartPending=false;
+  $("#rfBuilder").textContent=rfBuilderActive?"Cancel Journal Build":rfBuilderStartPending?"Starting…":"Build RF Journal";
+  syncRfBuilderDisabled();
+  rfSurveyRunning=running;
+  rfSurveyPending=pending;
+  rfSurveyGeneration=generation;
+  rfSurveyRetry=surveyRetry;
+  rfSurveyFailure=surveyFailure;
+  rfSurveyFailureChannel=surveyFailureChannel;
+  if(rfSurveyLockActive&&(surveyFailure||(!running&&!pending&&generation!==rfSurveyLockGeneration)))
+    rfSurveyLockActive=false;
+  if(rfHopPending&&handoff) rfHopSawHandoff=true;
+  if(rfHopPending&&!rfHopRequestedCh&&!handoff) rfHopPending=false;
+  const surveyFailureText=["","sample timeout","incomplete scan"];
+  $("#rfSurveyState").textContent=running?(surveyRetry&&surveyChannel?`retrying Ch ${surveyChannel} · ${surveyRetry}/5`:surveyChannel?`surveying Ch ${surveyChannel}`:"surveying"):pending?(handoff?"queued for handoff":"starting survey"):surveyFailure?`failed${surveyFailureChannel?` · Ch ${surveyFailureChannel}`:""} · ${surveyFailureText[surveyFailure]||(`code ${surveyFailure}`)}`:ambient?`cached #${generation}`:"not sampled";
+  const body=$("#rfJournalBody"), bars=$("#rfAmbientBars"); body.innerHTML=""; bars.innerHTML=""; rfPoolChannels=new Set();
+  for(let i=0;i<count;i++){
+    const q=13+i*9; if(q+9>p.length) break;
+    const ch=p[q], noise=p[q+1], d=p[q+2], worst=p[q+3], mean=p[q+4], conf=p[q+5], trials=p[q+6], penalty=p[q+7], recent=p[q+8];
+    rfPoolChannels.add(ch);
+    const tr=document.createElement("tr"); tr.dataset.rfCh=String(ch);
+    const desig=RF_DESIG[d]||("state "+d);
+    tr.innerHTML=`<td>${ch}${ch===current?' <span class="pill up">active</span>':''}${ch===target?' <span class="pill rf-target">target</span>':''}</td><td>${2400+ch}</td><td>${desig}</td><td>${trials?worst+'%':'—'}</td><td>${trials?mean+'%':'—'}</td><td>${trials?conf:'—'}</td><td>${trials}</td><td>${trials?penalty:'—'}</td><td>${noise?'-'+noise+' dBm':'—'}</td><td>${recent||'—'}</td>`;
+    const hopCell=document.createElement("td");
+    const hopBtn=document.createElement("button");
+    hopBtn.textContent=ch===current?"Active":"Hop";
+    hopBtn.dataset.rfHop="1";
+    hopBtn.disabled=ch===current||rfSurveyLockActive||rfHopWorkflowBlocked()||rfHopPending||rfBuilderActive;
+    hopBtn.style.padding="4px 8px";
+    hopBtn.dataset.rfCurrent=ch===current?"1":"0";
+    hopBtn.addEventListener("click",()=>hopRf(ch));
+    hopCell.appendChild(hopBtn);
+    const startupBtn=document.createElement("button");
+    startupBtn.textContent=ch===startup?"Startup ✓":"Startup";
+    startupBtn.dataset.rfStartup="1";
+    startupBtn.dataset.rfStartupSelected=ch===startup?"1":"0";
+    startupBtn.disabled=rfSurveyLockActive||ch===startup;
+    startupBtn.style.cssText="padding:4px 8px;margin-left:6px";
+    startupBtn.title="Use this channel on the next boot. This does not mark the channel good.";
+    startupBtn.addEventListener("click",()=>manualStartupRf(ch));
+    hopCell.appendChild(startupBtn);
+    tr.appendChild(hopCell);
+    body.appendChild(tr);
+    const col=document.createElement("div"); col.style.cssText="flex:1;min-width:18px;height:100%;display:flex;flex-direction:column;justify-content:flex-end;align-items:center";
+    const h=noise?Math.max(6,Math.min(58,(noise-35)*1.15)):4;
+    col.title=noise?`Ch ${ch}: ambient peak -${noise} dBm`:`Ch ${ch}: no ambient sample`;
+    col.innerHTML=`<div style="font-size:9px;color:#8ba2c4">${noise?'-'+noise:''}</div><div style="width:100%;height:${h}px;background:currentColor;opacity:${noise?'.72':'.18'};border-radius:2px 2px 0 0"></div><div style="font-size:9px;margin-top:2px">${ch}</div>`;
+    bars.appendChild(col);
+  }
+  syncRfSurveyControls();
+}
+function syncRfSurveyControls(){
+  const locked=rfSurveyLockActive;
+  $("#rfSurvey").disabled=locked||rfBuilderActive;
+  for(const tr of $("#rfJournalBody").querySelectorAll("tr")){
+    for(const btn of tr.querySelectorAll("button[data-rf-hop]"))
+      btn.disabled=locked||rfHopPending||rfBuilderActive||btn.dataset.rfCurrent==="1"||rfHopWorkflowBlocked();
+    for(const btn of tr.querySelectorAll("button[data-rf-startup]"))
+      btn.disabled=locked||btn.dataset.rfStartupSelected==="1";
+  }
+  syncRfBuilderDisabled();
+}
+function rfBuilderWorkflowBlocked(){
+  // Waiting-for-neutral is the automatic, pre-E4 admission phase. Firmware can
+  // safely yield that phase to an explicit Builder request; every other live
+  // handoff phase remains non-preemptible.
+  return (rfHandoffActive||rfHopPending) && !(rfHandoffActive&&rfHandoffPhase===1);
+}
+function rfHopWorkflowBlocked(){
+  // Hop itself now uses the production automatic neutral-gated path, so an
+  // existing handoff remains authoritative until it reaches a terminal state.
+  return rfHandoffActive;
+}
+function syncRfBuilderDisabled(){
+  $("#rfBuilder").disabled=rfSurveyLockActive||rfBuilderSaving||rfBuilderStartPending||(!rfBuilderActive&&rfBuilderWorkflowBlocked());
+}
+function setRfHopButtonsDisabled(disabled){
+  rfHopPending=!!disabled;
+  for(const tr of $("#rfJournalBody").querySelectorAll("tr")){
+    for(const btn of tr.querySelectorAll("button[data-rf-hop]"))
+      btn.disabled=rfSurveyLockActive||rfHopPending||rfBuilderActive||btn.dataset.rfCurrent==="1"||rfHopWorkflowBlocked();
+  }
+  // Keep the Builder interlock synchronized with the local Hop latch as well
+  // as firmware handoff state. The terminal status frame arrives before the
+  // Hop finally block releases rfHopPending, so applyRfStatus() may have
+  // left this DOM button disabled using the old latch value.
+  syncRfBuilderDisabled();
+}
+function showRfHopTarget(ch){
+  $("#rfTargetCh").textContent=rfChLabel(ch);
+  for(const tr of $("#rfJournalBody").querySelectorAll("tr")){
+    const cell=tr.cells[0]; if(!cell) continue;
+    for(const badge of cell.querySelectorAll(".rf-target")) badge.remove();
+    if(+tr.dataset.rfCh===ch){
+      const badge=document.createElement("span"); badge.className="pill rf-target"; badge.textContent="target";
+      cell.append(" ",badge);
+    }
+  }
+}
+async function waitRfUiIdle(){
+  for(let i=0;i<100&&rfBusy&&dev;i++) await new Promise(resolve=>setTimeout(resolve,50));
+  return !!dev&&!rfBusy;
+}
+async function hopRf(ch){
+  if(!dev||isDongle||!rfCapable||!rfPoolChannels.has(ch)||rfSurveyLockActive||rfHopPending||rfBuilderActive||rfHopWorkflowBlocked()) return;
+  setRfHopButtonsDisabled(true);
+  rfHopRequestedCh=ch;
+  rfHopSawHandoff=false;
+  showRfHopTarget(ch);
+  $("#rfHandoffStatus").textContent=`Requesting Ch ${ch}`;
+  if(!(await waitRfUiIdle())){
+    $("#rfHandoffStatus").textContent=`Hop not started · Ch ${ch}`;
+    rfHopRequestedCh=0;
+    setRfHopButtonsDisabled(false);
+    return;
+  }
+  rfBusy=true;
+  let terminal=false, sawStatus=false;
+  try{
+    await waitIdle(); if(!dev) return;
+    await send([0x02,99,ch]);
+    let p=await readFrame(0xAD,13,256);
+    for(let i=0;i<1200&&dev;i++){
+      if(p){
+        sawStatus=true;
+        applyRfStatus(p);
+        const active=!!(p[1]&16), current=p[2];
+        if(active) rfHopSawHandoff=true;
+        if(!active&&current===ch){ $("#rfHandoffStatus").textContent=`Complete · Ch ${ch}`; terminal=true; break; }
+        if(!active&&rfHopSawHandoff){ $("#rfHandoffStatus").textContent=`Rolled back · Ch ${current}`; terminal=true; break; }
+        if(!active&&!rfHopSawHandoff&&i>=6){ $("#rfHandoffStatus").textContent=`Hop not started · stayed Ch ${current}`; terminal=true; break; }
+      }
+      await new Promise(resolve=>setTimeout(resolve,100));
+      await send([0x02,97,1]);
+      p=await readFrame(0xAD,13,256);
+    }
+    if(!terminal&&dev) $("#rfHandoffStatus").textContent=sawStatus?`Handoff still pending · Ch ${ch}`:"Hop status unavailable";
+    if(sawStatus) rfLastRefresh=Date.now();
+  }catch(e){
+    $("#rfHandoffStatus").textContent=`Hop error · Ch ${ch}`;
+    log("RF hop err: "+e.message);
+  }finally{
+    rfBusy=false;
+    rfHopRequestedCh=0;
+    setRfHopButtonsDisabled(rfHandoffActive);
+  }
+}
+
+async function manualStartupRf(ch){
+  if(!dev||isDongle||!rfCapable||!rfPoolChannels.has(ch)||rfSurveyLockActive) return;
+  if(!(await waitRfUiIdle())) return;
+  rfBusy=true;
+  try{
+    await waitIdle(); if(!dev) return;
+    await send([0x02,100,ch]);
+    const p=await readFrame(0xAD,13,256); if(p) applyRfStatus(p);
+    rfLastRefresh=Date.now();
+  }catch(e){ log("RF startup err: "+e.message); }
+  finally{ rfBusy=false; }
+}
+async function manualJournalBuilderRf(){
+  if(!dev||isDongle||!rfCapable||rfSurveyLockActive||rfBuilderSaving||rfBuilderStartPending) return;
+  if(rfBuilderActive){
+    if(!confirm("Cancel the RF Journal Builder? The current safe RF operation will finish, the puck will return to the channel that was active before the build, and the existing saved journal will be preserved.")) return;
+    if(!(await waitRfUiIdle())) return;
+    rfBusy=true;
+    try{
+      await waitIdle(); if(!dev) return;
+      await send([0x02,101,0]);
+      const p=await readFrame(0xAD,13,256); if(p) applyRfStatus(p);
+      rfLastRefresh=Date.now();
+    }catch(e){ log("RF journal builder cancel err: "+e.message); }
+    finally{ rfBusy=false; }
+    return;
+  }
+  const ok=confirm("RF Journal Builder\n\nPlace all connected controllers at approximately the farthest distance from the puck at which you normally use them, and leave them in their normal operating location during the test.\n\nThe puck will survey ambient RF, test all 14 recovery channels for about 60 seconds each, select the best channel, and save one completed RF journal record. The test takes roughly 15 minutes.\n\nStart the journal build?");
+  if(!ok) return;
+  rfBuilderStartPending=true;
+  $("#rfBuilderStatus").textContent="Starting…";
+  $("#rfBuilder").textContent="Starting…";
+  $("#rfBuilder").disabled=true;
+  if(!(await waitRfUiIdle())){
+    rfBuilderStartPending=false;
+    $("#rfBuilder").textContent="Build RF Journal";
+    syncRfBuilderDisabled();
+    return;
+  }
+  rfBusy=true;
+  let sawStatus=false;
+  try{
+    await waitIdle(); if(!dev) return;
+    await send([0x02,101,1]);
+    // Latch the Start button until firmware positively reports either an
+    // active Builder phase or a terminal failure. This closes the duplicate
+    // Start window while the first RF-status response is still propagating.
+    for(let i=0;i<20&&dev&&rfBuilderStartPending;i++){
+      const p=await readFrame(0xAD,13,256);
+      if(p){ sawStatus=true; applyRfStatus(p); }
+      if(!rfBuilderStartPending) break;
+      await new Promise(resolve=>setTimeout(resolve,100));
+      await send([0x02,97,1]);
+    }
+    if(rfBuilderStartPending){
+      rfBuilderStartPending=false;
+      $("#rfBuilderStatus").textContent=sawStatus?"Start outcome unknown · waiting for RF status":"Start status unavailable";
+      $("#rfBuilder").textContent="Build RF Journal";
+      syncRfBuilderDisabled();
+    }
+    if(sawStatus) rfLastRefresh=Date.now();
+  }catch(e){
+    rfBuilderStartPending=false;
+    $("#rfBuilder").textContent="Build RF Journal";
+    syncRfBuilderDisabled();
+    log("RF journal builder err: "+e.message);
+  }
+  finally{ rfBusy=false; }
+}
+async function manualSurveyRf(){
+  if(!dev||isDongle||!rfCapable||rfSurveyWatchActive||rfSurveyLockActive) return;
+  rfSurveyLockGeneration=rfSurveyGeneration;
+  rfSurveyLockActive=true;
+  rfSurveyWatchActive=true;
+  syncRfSurveyControls();
+  $("#rfSurveyState").textContent="requesting…";
+  if(!(await waitRfUiIdle())){
+    rfSurveyWatchActive=false;
+    rfSurveyLockActive=false;
+    syncRfSurveyControls();
+    return;
+  }
+  rfBusy=true;
+  const startGeneration=rfSurveyLockGeneration;
+  let sawSurvey=false, sawStatus=false, terminal=false;
+  try{
+    await waitIdle(); if(!dev) return;
+    await send([0x02,98,1]);
+    // A successful request is reflected immediately as pending/running in the
+    // dedicated RF-status frame. Poll faster than the 100-ms scanner step so
+    // per-channel progress and retries remain visible.
+    for(let i=0;i<400&&dev;i++){
+      const p=await readFrame(0xAD,13,256);
+      if(p){
+        sawStatus=true;
+        const flags=p[1], running=!!(flags&1), pending=!!(flags&2);
+        const generation=p[7]|(p[8]<<8);
+        applyRfStatus(p);
+        if(running||pending) sawSurvey=true;
+        if(rfSurveyFailure){ terminal=true; break; }
+        if(!running&&!pending&&generation!==startGeneration){ terminal=true; break; }
+        if(!running&&!pending&&!sawSurvey&&i>=2){
+          rfSurveyLockActive=false;
+          $("#rfSurveyState").textContent="Survey not started · RF workflow busy";
+          terminal=true;
+          break;
+        }
+      }
+      await new Promise(resolve=>setTimeout(resolve,50));
+      await send([0x02,97,1]);
+    }
+    if(!terminal){
+      if(rfSurveyRunning||rfSurveyPending) $("#rfSurveyState").textContent=rfSurveyRunning?"Survey still active":"Survey queued";
+      else if(!sawStatus){
+        rfSurveyLockActive=false;
+        $("#rfSurveyState").textContent="Survey status unavailable";
+      }
+    }
+    if(sawStatus) rfLastRefresh=Date.now();
+  }catch(e){
+    rfSurveyLockActive=false;
+    $("#rfSurveyState").textContent="Survey error";
+    log("RF survey err: "+e.message);
+  }
+  finally{
+    rfBusy=false;
+    rfSurveyWatchActive=false;
+    syncRfSurveyControls();
+  }
+}
+async function refreshRfStatus(survey=false){
+  if(!dev||isDongle||!rfCapable||rfBusy) return;
+  rfBusy=true;
+  try{
+    await waitIdle(); if(!dev) return;
+    await send([0x02,survey?98:97,1]);
+    const p=await readFrame(0xAD,13,256); if(p) applyRfStatus(p);
+    rfLastRefresh=Date.now();
+  }catch(e){ log("RF status err: "+e.message); }
+  finally{ rfBusy=false; }
+}
+
 // ---- per-slot tab state ----
 let g_activeSlot = 0;
 let g_slotData = []; // [{up, battery, rssi}] indexed by slot 0..3, only set for bonded slots
@@ -939,6 +1345,12 @@ function applyBlob(p){
   const rumbleCap=(p[0]>=21 && p.length>193);
   const rumbleScale=rumbleCap?p[51]*2:200, rumbleStyle=rumbleCap?p[193]:0;
   const rssi=(p.length>37?p[37]:0);
+  // Reconciled firmware advertises RF recovery in the append-only v22 byte (firmware p[196] -> JS p[194]).
+  // Keep the old p[179] check so the same panel can still talk to the hardware-validated pre-reconcile RF build.
+  rfCapable=(p.length>194 && p[194]===0x52) || (p.length>179 && p[179]===0x52);
+  const rfCard=$("#rfRecoveryCard"); if(rfCard) rfCard.classList.toggle("hide", !rfCapable);
+  if(rfCapable&&Date.now()-rfLastRefresh>(rfHandoffActive||rfHopPending||rfSurveyRunning||rfSurveyPending?100:rfBuilderActive?500:2000)) refreshRfStatus(false);
+
 
   // per-slot link status (protocol v8, p.length >= 73)
   const hasSlotsData = p.length >= 73;
@@ -1173,7 +1585,7 @@ function setSlider(id,v){ const el=$("#"+id); if(document.activeElement!==el){ e
 
 let inflight=false;
 async function refresh(){
-  if(!dev||inflight||capturing||backupBusy||flightBusy||lizardBusy) return; inflight=true;
+  if(!dev||inflight||capturing||backupBusy||flightBusy||lizardBusy||rfBusy) return; inflight=true;
   // try/finally: an exception anywhere in here (applyBlob included) must never leave inflight latched true --
   // that would silently kill all future polls and read as a fake "heartbeat lost".
   try{
@@ -2316,6 +2728,8 @@ $("#rumbleTest").onclick=async()=>{ if(dev){ await send([0x16]); log("test rumbl
 $("#rumbleStyle").addEventListener("change", ()=>setField(39, +$("#rumbleStyle").value));
 $("#rumbleScale").addEventListener("change", ()=>setField(22, (+$("#rumbleScale").value)/2));
 $("#swGyroMap").addEventListener("change", ()=>setField(38, +$("#swGyroMap").value));
+$("#rfSurvey").onclick=()=>manualSurveyRf();
+$("#rfBuilder").onclick=()=>manualJournalBuilderRf();
 for(const sel of document.querySelectorAll("select.chord")){
   sel.addEventListener("change", ()=>setField(CHORD_FIELD[+sel.dataset.i], +sel.value));
 }


### PR DESCRIPTION
Adds adaptive RF channel recovery and coordinated channel handoff for degraded controller links, together with startup-channel persistence, persistent channel history, idle RF surveying, and WebUSB diagnostics.

The goal is that the puck will learn your RF environment and keep a journal of it.
You can see the Journal via WebUSB, and can choose to migrate channels whenever, along with setting your preference of startup channel.
It will continuously update your startup channel to the best one over time.
It will only switch channels when your controller(s) is/are idle or in between inputs in a similar fashion as the official puck.
It's meant to be autonomous and hands-off, and will keep you on only the good channels.

**Changes:**

- A **Build RF Journal** option is available via WebUSB to do a comprehensive assessment/journal build ahead of time. It takes ~15 minutes, and prevents the controller(s) from shutting down from idling during the test, so no need to change the timeout on your end, if you have a 5 or 15 minute timeout.
- Tracks per-channel link quality and use it to identify degraded RF conditions.
- Coordinates controller handoff to a better recovery channel instead of switching the radio unilaterally.
- Preserves rollback and recovery safeguards when a handoff does not establish a better link.
- Persists the independently qualified startup/last-good channel for future boots and reconnects.
- Maintains a power-loss-safe channel journal with learned good, poor, mixed, and unexplored state.
- Progressively explores the recovery-channel pool rather than repeatedly retrying only previously known channels.
- Adds an idle-only ambient RF survey.
- Uses ambient RSSI only as a weak ranking prior for channels that do not yet have real link history.
- Exposes RF status, channel history, survey state, and journal information through the WebUSB configuration panel.
- Adds a guarded Hop action for each recovery-pool channel. Manual hops use the same coordinated handoff path as automatic recovery.
- Adds a Startup action for each recovery-pool channel allowing you to choose what channel to start in.